### PR TITLE
Add SplitMapping

### DIFF
--- a/include/llama/Types.hpp
+++ b/include/llama/Types.hpp
@@ -99,5 +99,20 @@ namespace llama
     {
         std::size_t nr;
         std::size_t offset;
+
+        friend auto operator==(const NrAndOffset& a, const NrAndOffset& b) -> bool
+        {
+            return a.nr == b.nr && a.offset == b.offset;
+        }
+
+        friend auto operator!=(const NrAndOffset& a, const NrAndOffset& b) -> bool
+        {
+            return !(a == b);
+        }
+
+        friend auto operator<<(std::ostream& os, const NrAndOffset& value) -> std::ostream&
+        {
+            return os << "NrAndOffset{" << value.nr << ", " << value.offset << "}";
+        }
     };
 } // namespace llama

--- a/include/llama/llama.hpp
+++ b/include/llama/llama.hpp
@@ -41,5 +41,6 @@
 #include "mapping/AoSoA.hpp"
 #include "mapping/One.hpp"
 #include "mapping/SoA.hpp"
+#include "mapping/SplitMapping.hpp"
 #include "mapping/Trace.hpp"
 #include "mapping/tree/Mapping.hpp"

--- a/include/llama/mapping/SplitMapping.hpp
+++ b/include/llama/mapping/SplitMapping.hpp
@@ -1,0 +1,91 @@
+#pragma once
+
+#include "../Types.hpp"
+#include "Common.hpp"
+
+namespace llama::mapping
+{
+    namespace internal
+    {
+        template <typename... DatumElements, std::size_t FirstCoord, std::size_t... Coords>
+        auto partitionDatumDomain(DatumStruct<DatumElements...>, DatumCoord<FirstCoord, Coords...>)
+        {
+            if constexpr (sizeof...(Coords) == 0)
+            {
+                using With = DatumStruct<boost::mp11::mp_at_c<DatumStruct<DatumElements...>, FirstCoord>>;
+                using Without
+                    = DatumStruct<boost::mp11::mp_erase_c<DatumStruct<DatumElements...>, FirstCoord, FirstCoord>>;
+                return boost::mp11::mp_list<With, Without> {};
+            }
+            else
+            {
+                using Result = decltype(partitionDatumDomain(
+                    DatumStruct<boost::mp11::mp_at_c<DatumStruct<DatumElements...>, FirstCoord>> {},
+                    DatumCoord<Coords...> {}));
+                using With = boost::mp11::
+                    mp_replace_at_c<DatumStruct<DatumElements...>, FirstCoord, boost::mp11::mp_first<Result>>;
+                using Without = boost::mp11::
+                    mp_replace_at_c<DatumStruct<DatumElements...>, FirstCoord, boost::mp11::mp_second<Result>>;
+                return boost::mp11::mp_list<With, Without> {};
+            }
+        }
+    } // namespace internal
+
+    template <
+        typename T_ArrayDomain,
+        typename T_DatumDomain,
+        typename DatumCoordForMapping1,
+        template <typename, typename>
+        typename Mapping1,
+        template <typename, typename>
+        typename Mapping2>
+    struct SplitMapping
+    {
+        using ArrayDomain = T_ArrayDomain;
+        using DatumDomain = T_DatumDomain;
+
+        using DatumDomainPartitions
+            = decltype(internal::partitionDatumDomain(DatumDomain {}, DatumCoordForMapping1 {}));
+        using DatumDomain1 = boost::mp11::mp_first<DatumDomainPartitions>;
+        using DatumDomain2 = boost::mp11::mp_second<DatumDomainPartitions>;
+
+        static constexpr std::size_t blobCount = 1;
+        // = Mapping1<ArrayDomain, DatumDomain1>::blobCount + Mapping2<ArrayDomain, DatumDomain2>::blobCount;
+        static_assert(Mapping1<ArrayDomain, DatumDomain>::blobCount == 1);
+        static_assert(Mapping2<ArrayDomain, DatumDomain>::blobCount == 1);
+
+        SplitMapping() = default;
+
+        LLAMA_FN_HOST_ACC_INLINE
+        SplitMapping(ArrayDomain size)
+            : userDomainSize(size)
+            , mapping1(size)
+            , mapping2(size)
+            , mapping1BlobSize(mapping1.getBlobSize(0))
+        {
+        }
+
+        LLAMA_FN_HOST_ACC_INLINE auto getBlobSize(std::size_t) const -> std::size_t
+        {
+            return mapping1BlobSize + mapping2.getBlobSize();
+        }
+
+        template <std::size_t... DatumDomainCoord>
+        LLAMA_FN_HOST_ACC_INLINE auto getBlobNrAndOffset(ArrayDomain coord) const -> NrAndOffset
+        {
+            if constexpr (DatumCoordCommonPrefixIsSame<DatumCoordForMapping1, DatumCoord<DatumDomainCoord...>>)
+                return mapping1.template getBlobNrAndOffset<DatumDomainCoord...>(coord);
+            else
+            {
+                auto blobNrAndOffset = mapping2.template getBlobNrAndOffset<DatumDomainCoord...>(coord);
+                blobNrAndOffset.offset += mapping1BlobSize;
+                return blobNrAndOffset;
+            }
+        }
+
+        ArrayDomain userDomainSize = {};
+        Mapping1<ArrayDomain, DatumDomain> mapping1;
+        Mapping2<ArrayDomain, DatumDomain> mapping2;
+        std::size_t mapping1BlobSize;
+    };
+} // namespace llama::mapping

--- a/tests/dump.cpp
+++ b/tests/dump.cpp
@@ -47,4 +47,9 @@ TEST_CASE("dump")
     dump(llama::mapping::SoA<ArrayDomain, Particle> {arrayDomain}, "SoAMapping");
     dump(llama::mapping::AoSoA<ArrayDomain, Particle, 8> {arrayDomain}, "AoSoAMapping8");
     dump(llama::mapping::AoSoA<ArrayDomain, Particle, 32> {arrayDomain}, "AoSoAMapping32");
+    dump(
+        llama::mapping::
+            SplitMapping<ArrayDomain, Particle, llama::DatumCoord<0>, llama::mapping::SoA, llama::mapping::AoS> {
+                arrayDomain},
+        "SplitMapping");
 }

--- a/tests/splitmapping.cpp
+++ b/tests/splitmapping.cpp
@@ -1,0 +1,57 @@
+#include "common.h"
+
+#include <catch2/catch.hpp>
+#include <llama/llama.hpp>
+
+// clang-format off
+namespace tag {
+    struct Pos {};
+    struct X {};
+    struct Y {};
+    struct Z {};
+    struct Momentum {};
+    struct Weight {};
+    struct Flags {};
+}
+
+// clang-format off
+using Particle = llama::DS<
+    llama::DE<tag::Pos, llama::DS<
+        llama::DE<tag::X, double>,
+        llama::DE<tag::Y, double>,
+        llama::DE<tag::Z, double>
+    >>,
+    llama::DE<tag::Weight, float>,
+    llama::DE<tag::Momentum, llama::DS<
+        llama::DE<tag::X, double>,
+        llama::DE<tag::Y, double>,
+        llama::DE<tag::Z, double>
+    >>,
+    llama::DE<tag::Flags, llama::DA<bool, 4>>
+>;
+// clang-format on
+
+TEST_CASE("splitmapping")
+{
+    using ArrayDomain = llama::ArrayDomain<2>;
+    auto arrayDomain = ArrayDomain {16, 16};
+
+    // we layout Pos as SoA, the rest as AoS
+    auto mapping = llama::mapping::
+        SplitMapping<ArrayDomain, Particle, llama::DatumCoord<0>, llama::mapping::SoA, llama::mapping::AoS> {
+            arrayDomain};
+
+    constexpr auto mapping1Size = 14336;
+    const auto coord = ArrayDomain {0, 0};
+    CHECK(mapping.getBlobNrAndOffset<0, 0>(coord) == llama::NrAndOffset {0, 0});
+    CHECK(mapping.getBlobNrAndOffset<0, 1>(coord) == llama::NrAndOffset {0, 2048});
+    CHECK(mapping.getBlobNrAndOffset<0, 2>(coord) == llama::NrAndOffset {0, 4096});
+    CHECK(mapping.getBlobNrAndOffset<1>(coord) == llama::NrAndOffset {0, mapping1Size + 24});
+    CHECK(mapping.getBlobNrAndOffset<2, 0>(coord) == llama::NrAndOffset {0, mapping1Size + 28});
+    CHECK(mapping.getBlobNrAndOffset<2, 1>(coord) == llama::NrAndOffset {0, mapping1Size + 36});
+    CHECK(mapping.getBlobNrAndOffset<2, 2>(coord) == llama::NrAndOffset {0, mapping1Size + 44});
+    CHECK(mapping.getBlobNrAndOffset<3, 0>(coord) == llama::NrAndOffset {0, mapping1Size + 52});
+    CHECK(mapping.getBlobNrAndOffset<3, 1>(coord) == llama::NrAndOffset {0, mapping1Size + 53});
+    CHECK(mapping.getBlobNrAndOffset<3, 2>(coord) == llama::NrAndOffset {0, mapping1Size + 54});
+    CHECK(mapping.getBlobNrAndOffset<3, 3>(coord) == llama::NrAndOffset {0, mapping1Size + 55});
+}


### PR DESCRIPTION
Allows to apply two mappings on two parts of a datum domain.

* add equality comparison and put operator to NrAndOffset
* dumping SplitMapping in test dump
* add a test for splitmapping