### PR TITLE
Enable multiple blobs for SoA mapping

### DIFF
--- a/examples/alpaka/nbody/nbody.cpp
+++ b/examples/alpaka/nbody/nbody.cpp
@@ -16,7 +16,7 @@
 #include <random>
 #include <utility>
 
-constexpr auto MAPPING = 0; /// 0 native AoS, 1 native SoA, 2 tree AoS, 3 tree SoA
+constexpr auto MAPPING = 0; ///< 0 native AoS, 1 native SoA, 2 native SoA (separate blobs), 3 tree AoS, 4 tree SoA
 constexpr auto USE_SHARED = true; ///< defines whether shared memory shall be used
 constexpr auto USE_SHARED_TREE = true; ///< defines whether the shared memory shall use tree mapping or
                                        ///< native mapping
@@ -187,8 +187,10 @@ int main(int argc, char** argv)
         if constexpr (MAPPING == 1)
             return llama::mapping::SoA{arrayDomain, Particle{}};
         if constexpr (MAPPING == 2)
-            return llama::mapping::tree::Mapping{arrayDomain, llama::Tuple{}, Particle{}};
+            return llama::mapping::SoA{arrayDomain, Particle{}, std::true_type{}};
         if constexpr (MAPPING == 3)
+            return llama::mapping::tree::Mapping{arrayDomain, llama::Tuple{}, Particle{}};
+        if constexpr (MAPPING == 4)
             return llama::mapping::tree::Mapping{
                 arrayDomain,
                 llama::Tuple{llama::mapping::tree::functor::LeafOnlyRT()},

--- a/examples/alpaka/vectoradd/vectoradd.cpp
+++ b/examples/alpaka/vectoradd/vectoradd.cpp
@@ -16,7 +16,8 @@
 #include <random>
 #include <utility>
 
-constexpr auto MAPPING = 0; /// 0 native AoS, 1 native SoA, 2 tree AoS, 3 tree SoA
+constexpr auto MAPPING
+    = 1; ///< 0 native AoS, 1 native SoA, 2 native SoA (separate blobs, does not work yet), 3 tree AoS, 4 tree SoA
 constexpr auto PROBLEM_SIZE = 64 * 1024 * 1024;
 constexpr auto BLOCK_SIZE = 256;
 constexpr auto STEPS = 10;
@@ -86,8 +87,10 @@ int main(int argc, char** argv)
         if constexpr (MAPPING == 1)
             return llama::mapping::SoA{arrayDomain, Vector{}};
         if constexpr (MAPPING == 2)
-            return llama::mapping::tree::Mapping{arrayDomain, llama::Tuple{}, Vector{}};
+            return llama::mapping::SoA{arrayDomain, Vector{}, std::true_type{}};
         if constexpr (MAPPING == 3)
+            return llama::mapping::tree::Mapping{arrayDomain, llama::Tuple{}, Vector{}};
+        if constexpr (MAPPING == 4)
             return llama::mapping::tree::Mapping{
                 arrayDomain,
                 llama::Tuple{llama::mapping::tree::functor::LeafOnlyRT()},

--- a/examples/nbody/CMakeLists.txt
+++ b/examples/nbody/CMakeLists.txt
@@ -10,8 +10,8 @@ target_link_libraries(${PROJECT_NAME} PRIVATE llama::llama)
 if (CMAKE_CXX_COMPILER_ID STREQUAL "GNU" OR CMAKE_CXX_COMPILER_ID STREQUAL "Clang")
 	target_compile_options(${PROJECT_NAME} PRIVATE
 		-fno-math-errno # sqrt prevents vectorization otherwise
-#		-march=native
-#		-ffast-math
+		-march=native
+		-ffast-math
 	)
 endif()
 

--- a/examples/nbody/nbody.cpp
+++ b/examples/nbody/nbody.cpp
@@ -7,7 +7,7 @@
 
 // needs -fno-math-errno, so std::sqrt() can be vectorized
 
-constexpr auto MAPPING = 1; ///< 0 native AoS, 1 native SoA, 2 tree AoS, 3 tree SoA
+constexpr auto MAPPING = 2; ///< 0 native AoS, 1 native SoA, 2 native SoA (separate blos), 3 tree AoS, 4 tree SoA
 constexpr auto PROBLEM_SIZE = 16 * 1024; ///< total number of particles
 constexpr auto STEPS = 5; ///< number of steps to calculate
 constexpr auto TRACE = false;
@@ -86,8 +86,10 @@ namespace usellama
             if constexpr (MAPPING == 1)
                 return llama::mapping::SoA{arrayDomain, Particle{}};
             if constexpr (MAPPING == 2)
-                return llama::mapping::tree::Mapping{arrayDomain, llama::Tuple{}, Particle{}};
+                return llama::mapping::SoA{arrayDomain, Particle{}, std::true_type{}};
             if constexpr (MAPPING == 3)
+                return llama::mapping::tree::Mapping{arrayDomain, llama::Tuple{}, Particle{}};
+            if constexpr (MAPPING == 4)
                 return llama::mapping::tree::Mapping{
                     arrayDomain,
                     llama::Tuple{llama::mapping::tree::functor::LeafOnlyRT()},

--- a/examples/vectoradd/vectoradd.cpp
+++ b/examples/vectoradd/vectoradd.cpp
@@ -3,7 +3,7 @@
 #include <llama/llama.hpp>
 #include <utility>
 
-constexpr auto MAPPING = 3; /// 0 native AoS, 1 native SoA, 2 tree AoS, 3 tree SoA
+constexpr auto MAPPING = 2; ///< 0 native AoS, 1 native SoA, 2 native SoA (separate blobs), 3 tree AoS, 4 tree SoA
 constexpr auto PROBLEM_SIZE = 64 * 1024 * 1024; ///< problem size
 constexpr auto STEPS = 10; ///< number of vector adds to perform
 
@@ -48,8 +48,10 @@ namespace usellama
             if constexpr (MAPPING == 1)
                 return llama::mapping::SoA{arrayDomain, Vector{}};
             if constexpr (MAPPING == 2)
-                return llama::mapping::tree::Mapping{arrayDomain, llama::Tuple{}, Vector{}};
+                return llama::mapping::SoA{arrayDomain, Vector{}, std::true_type{}};
             if constexpr (MAPPING == 3)
+                return llama::mapping::tree::Mapping{arrayDomain, llama::Tuple{}, Vector{}};
+            if constexpr (MAPPING == 4)
                 return llama::mapping::tree::Mapping{
                     arrayDomain,
                     llama::Tuple{llama::mapping::tree::functor::LeafOnlyRT()},

--- a/include/llama/Array.hpp
+++ b/include/llama/Array.hpp
@@ -19,28 +19,28 @@ namespace llama
         static constexpr std::size_t rank = N;
         T element[N > 0 ? N : 1];
 
-        LLAMA_FN_HOST_ACC_INLINE T* begin()
+        LLAMA_FN_HOST_ACC_INLINE constexpr T* begin()
         {
             return &element[0];
         }
 
-        LLAMA_FN_HOST_ACC_INLINE const T* begin() const
+        LLAMA_FN_HOST_ACC_INLINE constexpr const T* begin() const
         {
             return &element[0];
         }
 
-        LLAMA_FN_HOST_ACC_INLINE T* end()
+        LLAMA_FN_HOST_ACC_INLINE constexpr T* end()
         {
             return &element[N];
         };
 
-        LLAMA_FN_HOST_ACC_INLINE const T* end() const
+        LLAMA_FN_HOST_ACC_INLINE constexpr const T* end() const
         {
             return &element[N];
         };
 
         template <typename IndexType>
-        LLAMA_FN_HOST_ACC_INLINE auto operator[](IndexType&& idx) -> T&
+        LLAMA_FN_HOST_ACC_INLINE constexpr auto operator[](IndexType&& idx) -> T&
         {
             return element[idx];
         }
@@ -51,7 +51,7 @@ namespace llama
             return element[idx];
         }
 
-        LLAMA_FN_HOST_ACC_INLINE friend auto operator==(const Array<T, N>& a, const Array<T, N>& b) -> bool
+        LLAMA_FN_HOST_ACC_INLINE constexpr friend auto operator==(const Array<T, N>& a, const Array<T, N>& b) -> bool
         {
             for (std::size_t i = 0; i < N; ++i)
                 if (a.element[i] != b.element[i])
@@ -59,7 +59,7 @@ namespace llama
             return true;
         }
 
-        LLAMA_FN_HOST_ACC_INLINE friend auto operator+(const Array<T, N>& a, const Array<T, N>& b) -> Array
+        LLAMA_FN_HOST_ACC_INLINE constexpr friend auto operator+(const Array<T, N>& a, const Array<T, N>& b) -> Array
         {
             Array temp;
             for (std::size_t i = 0; i < N; ++i)
@@ -68,13 +68,13 @@ namespace llama
         }
 
         template <std::size_t I>
-        auto get() -> T&
+        constexpr auto get() -> T&
         {
             return element[I];
         }
 
         template <std::size_t I>
-        auto get() const -> const T&
+        constexpr auto get() const -> const T&
         {
             return element[I];
         }

--- a/include/llama/mapping/SoA.hpp
+++ b/include/llama/mapping/SoA.hpp
@@ -68,16 +68,19 @@ namespace llama::mapping
         {
             if constexpr (SeparateBuffers::value)
             {
+                using TargetDatumCoord = DatumCoord<DatumDomainCoord...>;
                 constexpr auto blob = [&]() constexpr
                 {
                     std::size_t index = 0;
                     bool found = false;
-                    forEach<DatumDomain>([&](auto coord) constexpr {
-                        if constexpr (std::is_same_v<decltype(coord), DatumCoord<DatumDomainCoord...>>)
+                    forEach<DatumDomain>([&](auto c) constexpr {
+                        if constexpr (std::is_same_v<decltype(c), TargetDatumCoord>)
                             found = true;
                         else if (!found)
                             index++;
                     });
+                    if (!found)
+                        throw "Passed TargetDatumCoord must be in datum domain";
                     return index;
                 }
                 ();

--- a/include/llama/mapping/SoA.hpp
+++ b/include/llama/mapping/SoA.hpp
@@ -47,17 +47,17 @@ namespace llama::mapping
         {
             if constexpr (SeparateBuffers::value)
             {
-                auto typeSize = [&]() {
-                    std::size_t index = 0;
-                    std::size_t size = 0;
-                    forEach<DatumDomain>([&](auto coord) {
-                        if (index == blobIndex)
-                            size = sizeof(GetType<DatumDomain, decltype(coord)>);
-                        index++;
+                static constexpr llama::Array<std::size_t, blobCount> typeSizes = []() constexpr
+                {
+                    llama::Array<std::size_t, blobCount> r{};
+                    std::size_t i = 0;
+                    forEach<DatumDomain>([&](auto coord) constexpr {
+                        r[i++] = sizeof(GetType<DatumDomain, decltype(coord)>);
                     });
-                    return size;
-                }();
-                return LinearizeArrayDomainFunctor{}.size(arrayDomainSize) * typeSize;
+                    return r;
+                }
+                ();
+                return LinearizeArrayDomainFunctor{}.size(arrayDomainSize) * typeSizes[blobIndex];
             }
             else
                 return LinearizeArrayDomainFunctor{}.size(arrayDomainSize) * sizeOf<DatumDomain>;

--- a/include/llama/mapping/SoA.hpp
+++ b/include/llama/mapping/SoA.hpp
@@ -16,34 +16,85 @@ namespace llama::mapping
     template <
         typename T_ArrayDomain,
         typename T_DatumDomain,
+        typename SeparateBuffers = std::false_type, // TODO: make this a bool. Needs work in SplitMapping
         typename LinearizeArrayDomainFunctor = LinearizeArrayDomainCpp>
     struct SoA
     {
         using ArrayDomain = T_ArrayDomain;
         using DatumDomain = T_DatumDomain;
-        static constexpr std::size_t blobCount = 1;
+        static constexpr std::size_t blobCount = []() constexpr
+        {
+            if constexpr (SeparateBuffers::value)
+            {
+                std::size_t count = 0;
+                forEach<DatumDomain>([&](auto) constexpr { count++; });
+                return count;
+            }
+            else
+                return 1;
+        }
+        ();
 
         SoA() = default;
 
         LLAMA_FN_HOST_ACC_INLINE
-        SoA(ArrayDomain size, DatumDomain = {}) : arrayDomainSize(size)
+        SoA(ArrayDomain size, DatumDomain = {}, SeparateBuffers = {}) : arrayDomainSize(size)
         {
         }
 
         LLAMA_FN_HOST_ACC_INLINE
-        auto getBlobSize(std::size_t) const -> std::size_t
+        auto getBlobSize(std::size_t blobIndex) const -> std::size_t
         {
-            return LinearizeArrayDomainFunctor{}.size(arrayDomainSize) * sizeOf<DatumDomain>;
+            if constexpr (SeparateBuffers::value)
+            {
+                auto typeSize = [&]() {
+                    std::size_t index = 0;
+                    std::size_t size = 0;
+                    forEach<DatumDomain>([&](auto coord) {
+                        if (index == blobIndex)
+                            size = sizeof(GetType<DatumDomain, decltype(coord)>);
+                        index++;
+                    });
+                    return size;
+                }();
+                return LinearizeArrayDomainFunctor{}.size(arrayDomainSize) * typeSize;
+            }
+            else
+                return LinearizeArrayDomainFunctor{}.size(arrayDomainSize) * sizeOf<DatumDomain>;
         }
 
         template <std::size_t... DatumDomainCoord>
         LLAMA_FN_HOST_ACC_INLINE auto getBlobNrAndOffset(ArrayDomain coord) const -> NrAndOffset
         {
-            LLAMA_FORCE_INLINE_RECURSIVE
-            const auto offset = LinearizeArrayDomainFunctor{}(coord, arrayDomainSize)
-                    * sizeof(GetType<DatumDomain, DatumCoord<DatumDomainCoord...>>)
-                + offsetOf<DatumDomain, DatumDomainCoord...> * LinearizeArrayDomainFunctor{}.size(arrayDomainSize);
-            return {0, offset};
+            if constexpr (SeparateBuffers::value)
+            {
+                constexpr auto blob = [&]() constexpr
+                {
+                    std::size_t index = 0;
+                    bool found = false;
+                    forEach<DatumDomain>([&](auto coord) constexpr {
+                        if constexpr (std::is_same_v<decltype(coord), DatumCoord<DatumDomainCoord...>>)
+                            found = true;
+                        else if (!found)
+                            index++;
+                    });
+                    return index;
+                }
+                ();
+
+                LLAMA_FORCE_INLINE_RECURSIVE
+                const auto offset = LinearizeArrayDomainFunctor{}(coord, arrayDomainSize)
+                    * sizeof(GetType<DatumDomain, DatumCoord<DatumDomainCoord...>>);
+                return {blob, offset};
+            }
+            else
+            {
+                LLAMA_FORCE_INLINE_RECURSIVE
+                const auto offset = LinearizeArrayDomainFunctor{}(coord, arrayDomainSize)
+                        * sizeof(GetType<DatumDomain, DatumCoord<DatumDomainCoord...>>)
+                    + offsetOf<DatumDomain, DatumDomainCoord...> * LinearizeArrayDomainFunctor{}.size(arrayDomainSize);
+                return {0, offset};
+            }
         }
 
         ArrayDomain arrayDomainSize;

--- a/include/llama/mapping/SplitMapping.hpp
+++ b/include/llama/mapping/SplitMapping.hpp
@@ -77,7 +77,7 @@ namespace llama::mapping
 
         LLAMA_FN_HOST_ACC_INLINE auto getBlobSize(std::size_t) const -> std::size_t
         {
-            return mapping1BlobSize + mapping2.getBlobSize();
+            return mapping1BlobSize + mapping2.getBlobSize(0);
         }
 
         template <std::size_t... DatumDomainCoord>

--- a/tests/dump.cpp
+++ b/tests/dump.cpp
@@ -81,6 +81,11 @@ TEST_CASE("dump.SoA")
     dump(llama::mapping::SoA{arrayDomain, Particle{}}, "SoAMapping");
 }
 
+TEST_CASE("dump.SoA.MultiBlob")
+{
+    dump(llama::mapping::SoA{arrayDomain, Particle{}, std::true_type{}}, "SoAMappingMultiBlob");
+}
+
 TEST_CASE("dump.AoSoA.8")
 {
     dump(llama::mapping::AoSoA<ArrayDomain, Particle, 8>{arrayDomain}, "AoSoAMapping8");
@@ -90,7 +95,6 @@ TEST_CASE("dump.AoSoA.32")
 {
     dump(llama::mapping::AoSoA<ArrayDomain, Particle, 32>{arrayDomain}, "AoSoAMapping32");
 }
-
 
 TEST_CASE("dump.SplitMapping")
 {

--- a/tests/mapping.cpp
+++ b/tests/mapping.cpp
@@ -1,8 +1,8 @@
 #include "common.h"
 
 #include <catch2/catch.hpp>
-#include <llama/llama.hpp>
 #include <llama/Concepts.hpp>
+#include <llama/llama.hpp>
 
 // clang-format off
 namespace tag {
@@ -254,7 +254,9 @@ TEST_CASE("address.SoA.fortran")
 {
     using ArrayDomain = llama::ArrayDomain<2>;
     auto arrayDomain = ArrayDomain{16, 16};
-    auto mapping = llama::mapping::SoA<ArrayDomain, Particle, llama::mapping::LinearizeArrayDomainFortran>{arrayDomain};
+    auto mapping
+        = llama::mapping::SoA<ArrayDomain, Particle, std::false_type, llama::mapping::LinearizeArrayDomainFortran>{
+            arrayDomain};
 
     {
         const auto coord = ArrayDomain{0, 0};
@@ -310,7 +312,9 @@ TEST_CASE("address.SoA.morton")
 
     using ArrayDomain = llama::ArrayDomain<2>;
     auto arrayDomain = ArrayDomain{16, 16};
-    auto mapping = llama::mapping::SoA<ArrayDomain, Particle, llama::mapping::LinearizeArrayDomainMorton>{arrayDomain};
+    auto mapping
+        = llama::mapping::SoA<ArrayDomain, Particle, std::false_type, llama::mapping::LinearizeArrayDomainMorton>{
+            arrayDomain};
 
     {
         const auto coord = ArrayDomain{0, 0};

--- a/tests/mapping.cpp
+++ b/tests/mapping.cpp
@@ -362,6 +362,58 @@ TEST_CASE("address.SoA.morton")
     }
 }
 
+TEST_CASE("address.SoA.MultiBlob")
+{
+    using ArrayDomain = llama::ArrayDomain<2>;
+    auto arrayDomain = ArrayDomain{16, 16};
+    auto mapping = llama::mapping::SoA<ArrayDomain, Particle, std::true_type>{arrayDomain};
+
+    {
+        const auto coord = ArrayDomain{0, 0};
+        CHECK(mapping.getBlobNrAndOffset<0, 0>(coord) == llama::NrAndOffset{0, 0});
+        CHECK(mapping.getBlobNrAndOffset<0, 1>(coord) == llama::NrAndOffset{1, 0});
+        CHECK(mapping.getBlobNrAndOffset<0, 2>(coord) == llama::NrAndOffset{2, 0});
+        CHECK(mapping.getBlobNrAndOffset<1>(coord   ) == llama::NrAndOffset{3, 0});
+        CHECK(mapping.getBlobNrAndOffset<2, 0>(coord) == llama::NrAndOffset{4, 0});
+        CHECK(mapping.getBlobNrAndOffset<2, 1>(coord) == llama::NrAndOffset{5, 0});
+        CHECK(mapping.getBlobNrAndOffset<2, 2>(coord) == llama::NrAndOffset{6, 0});
+        CHECK(mapping.getBlobNrAndOffset<3, 0>(coord) == llama::NrAndOffset{7, 0});
+        CHECK(mapping.getBlobNrAndOffset<3, 1>(coord) == llama::NrAndOffset{8, 0});
+        CHECK(mapping.getBlobNrAndOffset<3, 2>(coord) == llama::NrAndOffset{9, 0});
+        CHECK(mapping.getBlobNrAndOffset<3, 3>(coord) == llama::NrAndOffset{10, 0});
+    }
+
+    {
+        const auto coord = ArrayDomain{0, 1};
+        CHECK(mapping.getBlobNrAndOffset<0, 0>(coord) == llama::NrAndOffset{0,  8});
+        CHECK(mapping.getBlobNrAndOffset<0, 1>(coord) == llama::NrAndOffset{1,  8});
+        CHECK(mapping.getBlobNrAndOffset<0, 2>(coord) == llama::NrAndOffset{2,  8});
+        CHECK(mapping.getBlobNrAndOffset<1>(coord)    == llama::NrAndOffset{3,  4});
+        CHECK(mapping.getBlobNrAndOffset<2, 0>(coord) == llama::NrAndOffset{4,  8});
+        CHECK(mapping.getBlobNrAndOffset<2, 1>(coord) == llama::NrAndOffset{5,  8});
+        CHECK(mapping.getBlobNrAndOffset<2, 2>(coord) == llama::NrAndOffset{6,  8});
+        CHECK(mapping.getBlobNrAndOffset<3, 0>(coord) == llama::NrAndOffset{7,  1});
+        CHECK(mapping.getBlobNrAndOffset<3, 1>(coord) == llama::NrAndOffset{8,  1});
+        CHECK(mapping.getBlobNrAndOffset<3, 2>(coord) == llama::NrAndOffset{9,  1});
+        CHECK(mapping.getBlobNrAndOffset<3, 3>(coord) == llama::NrAndOffset{10, 1});
+    }
+
+    {
+        const auto coord = ArrayDomain{1, 0};
+        CHECK(mapping.getBlobNrAndOffset<0, 0>(coord) == llama::NrAndOffset{0,  128});
+        CHECK(mapping.getBlobNrAndOffset<0, 1>(coord) == llama::NrAndOffset{1,  128});
+        CHECK(mapping.getBlobNrAndOffset<0, 2>(coord) == llama::NrAndOffset{2,  128});
+        CHECK(mapping.getBlobNrAndOffset<1>(coord)    == llama::NrAndOffset{3,  64});
+        CHECK(mapping.getBlobNrAndOffset<2, 0>(coord) == llama::NrAndOffset{4,  128});
+        CHECK(mapping.getBlobNrAndOffset<2, 1>(coord) == llama::NrAndOffset{5,  128});
+        CHECK(mapping.getBlobNrAndOffset<2, 2>(coord) == llama::NrAndOffset{6,  128});
+        CHECK(mapping.getBlobNrAndOffset<3, 0>(coord) == llama::NrAndOffset{7,  16});
+        CHECK(mapping.getBlobNrAndOffset<3, 1>(coord) == llama::NrAndOffset{8,  16});
+        CHECK(mapping.getBlobNrAndOffset<3, 2>(coord) == llama::NrAndOffset{9,  16});
+        CHECK(mapping.getBlobNrAndOffset<3, 3>(coord) == llama::NrAndOffset{10, 16});
+    }
+}
+
 TEST_CASE("address.AoSoA.4")
 {
     using ArrayDomain = llama::ArrayDomain<2>;


### PR DESCRIPTION
A multi-blob version of the SoA mapping allows one blob per datum domain attribute.