### PR TITLE
Make ArrayDomainIndexIterator and ArrayDomainIndexRange constexpr

### DIFF
--- a/include/llama/ArrayDomainRange.hpp
+++ b/include/llama/ArrayDomainRange.hpp
@@ -2,19 +2,20 @@
 
 #include "Core.hpp"
 
-#include <boost/stl_interfaces/iterator_interface.hpp>
+#include <iterator>
 
 namespace llama
 {
     /// Iterator supporting \ref ArrayDomainIndexRange.
     template <std::size_t Dim>
     struct ArrayDomainIndexIterator
-        : boost::stl_interfaces::iterator_interface<
-              ArrayDomainIndexIterator<Dim>,
-              std::forward_iterator_tag,
-              ArrayDomain<Dim>,
-              ArrayDomain<Dim>>
     {
+        using value_type = ArrayDomain<Dim>;
+        using difference_type = std::ptrdiff_t;
+        using reference = value_type;
+        using pointer = value_type*;
+        using iterator_category = std::forward_iterator_tag;
+
         constexpr ArrayDomainIndexIterator() noexcept = default;
 
         constexpr ArrayDomainIndexIterator(ArrayDomain<Dim> size, ArrayDomain<Dim> current) noexcept
@@ -22,6 +23,9 @@ namespace llama
             , current(current)
         {
         }
+
+        constexpr ArrayDomainIndexIterator(const ArrayDomainIndexIterator&) noexcept = default;
+        constexpr auto operator=(const ArrayDomainIndexIterator&) noexcept -> ArrayDomainIndexIterator& = default;
 
         constexpr auto operator*() const noexcept -> ArrayDomain<Dim>
         {
@@ -37,8 +41,9 @@ namespace llama
                     return *this;
                 current[i] = 0;
             }
-            // we reached the end
-            current[0] = size[0];
+            // we reached the end, the iterator now needs to compare equal to a value initialized one
+            current = {};
+            size = {};
             return *this;
         }
 
@@ -47,12 +52,18 @@ namespace llama
             return ++*this;
         }
 
-        //template <std::size_t Dim>
         friend constexpr auto operator==(
             const ArrayDomainIndexIterator<Dim>& a,
             const ArrayDomainIndexIterator<Dim>& b) noexcept -> bool
         {
             return a.size == b.size && a.current == b.current;
+        }
+
+        friend constexpr auto operator!=(
+            const ArrayDomainIndexIterator<Dim>& a,
+            const ArrayDomainIndexIterator<Dim>& b) noexcept -> bool
+        {
+            return !(a == b);
         }
 
     private:
@@ -75,9 +86,7 @@ namespace llama
 
         constexpr auto end() const -> ArrayDomainIndexIterator<Dim>
         {
-            ArrayDomain<Dim> e{};
-            e[0] = size[0];
-            return {size, e};
+            return {};
         }
 
     private:

--- a/include/llama/ArrayDomainRange.hpp
+++ b/include/llama/ArrayDomainRange.hpp
@@ -2,49 +2,60 @@
 
 #include "Core.hpp"
 
+#include <boost/stl_interfaces/iterator_interface.hpp>
+
 namespace llama
 {
     /// Iterator supporting \ref ArrayDomainIndexRange.
     template <std::size_t Dim>
     struct ArrayDomainIndexIterator
-        : boost::iterator_facade<
+        : boost::stl_interfaces::iterator_interface<
               ArrayDomainIndexIterator<Dim>,
-              ArrayDomain<Dim>,
               std::forward_iterator_tag,
+              ArrayDomain<Dim>,
               ArrayDomain<Dim>>
     {
-        ArrayDomainIndexIterator() = default;
+        constexpr ArrayDomainIndexIterator() noexcept = default;
 
-        ArrayDomainIndexIterator(ArrayDomain<Dim> size, ArrayDomain<Dim> current) : size(size), current(current)
+        constexpr ArrayDomainIndexIterator(ArrayDomain<Dim> size, ArrayDomain<Dim> current) noexcept
+            : size(size)
+            , current(current)
         {
         }
 
-    private:
-        friend class boost::iterator_core_access;
-
-        auto dereference() const -> ArrayDomain<Dim>
+        constexpr auto operator*() const noexcept -> ArrayDomain<Dim>
         {
             return current;
         }
 
-        void increment()
+        constexpr auto operator++() noexcept -> ArrayDomainIndexIterator&
         {
             for (auto i = (int) Dim - 1; i >= 0; i--)
             {
                 current[i]++;
                 if (current[i] != size[i])
-                    return;
+                    return *this;
                 current[i] = 0;
             }
             // we reached the end
             current[0] = size[0];
+            return *this;
         }
 
-        auto equal(const ArrayDomainIndexIterator& other) const -> bool
+        constexpr auto operator++(int) noexcept -> ArrayDomainIndexIterator&
         {
-            return size == other.size && current == other.current;
+            return ++*this;
         }
 
+        //template <std::size_t Dim>
+        friend constexpr auto operator==(
+            const ArrayDomainIndexIterator<Dim>& a,
+            const ArrayDomainIndexIterator<Dim>& b) noexcept -> bool
+        {
+            return a.size == b.size && a.current == b.current;
+        }
+
+    private:
         ArrayDomain<Dim> size;
         ArrayDomain<Dim> current;
     };
@@ -53,16 +64,16 @@ namespace llama
     template <std::size_t Dim>
     struct ArrayDomainIndexRange
     {
-        ArrayDomainIndexRange(ArrayDomain<Dim> size) : size(size)
+        constexpr ArrayDomainIndexRange(ArrayDomain<Dim> size) : size(size)
         {
         }
 
-        auto begin() const -> ArrayDomainIndexIterator<Dim>
+        constexpr auto begin() const -> ArrayDomainIndexIterator<Dim>
         {
             return {size, ArrayDomain<Dim>{}};
         }
 
-        auto end() const -> ArrayDomainIndexIterator<Dim>
+        constexpr auto end() const -> ArrayDomainIndexIterator<Dim>
         {
             ArrayDomain<Dim> e{};
             e[0] = size[0];

--- a/tests/arraydomain.cpp
+++ b/tests/arraydomain.cpp
@@ -119,6 +119,23 @@ TEST_CASE("ArrayDomainIndexIterator")
     CHECK(*it == llama::ArrayDomain{0, 2});
 }
 
+TEST_CASE("ArrayDomainIndexIterator.constexpr")
+{
+    constexpr auto r = [&]() constexpr
+    {
+        bool b = true;
+        llama::ArrayDomainIndexIterator it = std::begin(llama::ArrayDomainIndexRange{llama::ArrayDomain<2>{3, 3}});
+        b &= *it == llama::ArrayDomain{0, 0};
+        it++;
+        b &= *it == llama::ArrayDomain{0, 1};
+        ++it;
+        b &= *it == llama::ArrayDomain{0, 2};
+        return b;
+    }
+    ();
+    STATIC_REQUIRE(r);
+}
+
 TEST_CASE("ArrayDomainIndexRange1D")
 {
     llama::ArrayDomain<1> ud{3};
@@ -158,6 +175,29 @@ TEST_CASE("ArrayDomainIndexRange3D")
             {1, 0, 0}, {1, 0, 1}, {1, 0, 2}, {1, 1, 0}, {1, 1, 1}, {1, 1, 2}, {1, 2, 0}, {1, 2, 1}, {1, 2, 2},
             {2, 0, 0}, {2, 0, 1}, {2, 0, 2}, {2, 1, 0}, {2, 1, 1}, {2, 1, 2}, {2, 2, 0}, {2, 2, 1}, {2, 2, 2},
         });
+}
+
+TEST_CASE("ArrayDomainIndexRange1D.constexpr")
+{
+    constexpr auto r = []() constexpr
+    {
+        llama::ArrayDomain<1> ud{3};
+        int i = 0;
+        for (auto coord : llama::ArrayDomainIndexRange{ud})
+        {
+            if (i == 0 && coord != llama::ArrayDomain<1>{0})
+                return false;
+            if (i == 1 && coord != llama::ArrayDomain<1>{1})
+                return false;
+            if (i == 2 && coord != llama::ArrayDomain<1>{2})
+                return false;
+            i++;
+        }
+
+        return true;
+    }
+    ();
+    STATIC_REQUIRE(r);
 }
 
 TEST_CASE("ArrayDomainIndexRange3D.destructering")


### PR DESCRIPTION
That changes the required Boost verison to 1.74 because of Boost.StlInterfaces, which is fairly new. I should consider writing the iterator myself.