### PR TITLE
Add proof of concept to proof a mapping property at compile time

### DIFF
--- a/include/llama/Proofs.hpp
+++ b/include/llama/Proofs.hpp
@@ -1,0 +1,91 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#pragma once
+
+// FIXME: this test is actually not correct, because __cpp_constexpr_dynamic_alloc only guarantees constexpr
+// std::allocator
+#ifdef __cpp_constexpr_dynamic_alloc
+
+#    include "ArrayDomainRange.hpp"
+#    include "Core.hpp"
+
+namespace llama
+{
+    namespace internal
+    {
+        template <typename Mapping, std::size_t... Is, typename ArrayDomain>
+        constexpr auto getBlobNrAndOffset(const Mapping& m, llama::DatumCoord<Is...>, ArrayDomain ad)
+        {
+            return m.template getBlobNrAndOffset<Is...>(ad);
+        }
+
+        constexpr auto divRoundUp(std::size_t dividend, std::size_t divisor) -> std::size_t
+        {
+            return (dividend + divisor - 1) / divisor;
+        }
+
+        template <typename T>
+        struct DynArray
+        {
+            constexpr DynArray() = default;
+
+            constexpr DynArray(std::size_t n)
+            {
+                data = new T[n]{};
+            }
+
+            constexpr ~DynArray()
+            {
+                delete[] data;
+            }
+
+            constexpr void resize(std::size_t n)
+            {
+                delete[] data;
+                data = new T[n]{};
+            }
+
+            T* data = nullptr;
+        };
+    } // namespace internal
+
+    // Proofs by exhaustion of the array and datum domain, that all values mapped to memory do not overlap.
+    // Unfortunately, this only works for smallish array domains, because of compiler limits on constexpr evaluation
+    // depth.
+    template <typename Mapping>
+    constexpr auto mapsNonOverlappingly(const Mapping& m) -> bool
+    {
+        internal::DynArray<internal::DynArray<std::uint64_t>> blobByteMapped(m.blobCount);
+        for (auto i = 0; i < m.blobCount; i++)
+            blobByteMapped.data[i].resize(internal::divRoundUp(m.getBlobSize(i), 64));
+
+        auto testAndSet = [&](auto blob, auto offset) constexpr
+        {
+            const auto bit = std::uint64_t{1} << (offset % 64);
+            if (blobByteMapped.data[blob].data[offset / 64] & bit)
+                return true;
+            blobByteMapped.data[blob].data[offset / 64] |= bit;
+            return false;
+        };
+
+        bool collision = false;
+        llama::forEach<typename Mapping::DatumDomain>([&](auto coord) constexpr {
+            if (collision)
+                return;
+            for (auto ad : llama::ArrayDomainIndexRange{m.arrayDomainSize})
+            {
+                using Type = llama::GetType<typename Mapping::DatumDomain, decltype(coord)>;
+                const auto [blob, offset] = internal::getBlobNrAndOffset(m, coord, ad);
+                for (auto b = 0; b < sizeof(Type); b++)
+                    if (testAndSet(blob, offset + b))
+                    {
+                        collision = true;
+                        break;
+                    }
+            }
+        });
+        return !collision;
+    }
+} // namespace llama
+
+#endif

--- a/tests/proofs.cpp
+++ b/tests/proofs.cpp
@@ -1,6 +1,7 @@
 #include <catch2/catch.hpp>
 #include <llama/Proofs.hpp>
 #include <llama/llama.hpp>
+#include <numeric>
 
 // clang-format off
 namespace tag {
@@ -29,7 +30,6 @@ using Particle = llama::DS<
 >;
 // clang-format on
 
-
 TEST_CASE("mapsNonOverlappingly.AoS")
 {
     using ArrayDomain = llama::ArrayDomain<2>;
@@ -38,6 +38,100 @@ TEST_CASE("mapsNonOverlappingly.AoS")
 
 #ifdef __cpp_constexpr_dynamic_alloc
     STATIC_REQUIRE(llama::mapsNonOverlappingly(mapping));
+#else
+    INFO("Test disabled because compiler does not support __cpp_constexpr_dynamic_alloc");
+#endif
+}
+
+namespace
+{
+    template <typename T_ArrayDomain, typename T_DatumDomain>
+    struct MapEverythingToZero
+    {
+        using ArrayDomain = T_ArrayDomain;
+        using DatumDomain = T_DatumDomain;
+        static constexpr std::size_t blobCount = 1;
+
+        LLAMA_FN_HOST_ACC_INLINE
+        constexpr MapEverythingToZero(ArrayDomain size, DatumDomain = {}) : arrayDomainSize(size)
+        {
+        }
+
+        constexpr auto getBlobSize(std::size_t) const -> std::size_t
+        {
+            return std::reduce(
+                       std::begin(arrayDomainSize),
+                       std::end(arrayDomainSize),
+                       std::size_t{1},
+                       std::multiplies{})
+                * llama::sizeOf<DatumDomain>;
+        }
+
+        template <std::size_t... DDCs>
+        constexpr auto getBlobNrAndOffset(ArrayDomain coord) const -> llama::NrAndOffset
+        {
+            return {0, 0};
+        }
+
+        ArrayDomain arrayDomainSize;
+    };
+} // namespace
+
+TEST_CASE("mapsNonOverlappingly.MapEverythingToZero")
+{
+#ifdef __cpp_constexpr_dynamic_alloc
+    STATIC_REQUIRE(llama::mapsNonOverlappingly(MapEverythingToZero{llama::ArrayDomain<1>{1}, double{}}));
+    STATIC_REQUIRE(!llama::mapsNonOverlappingly(MapEverythingToZero{llama::ArrayDomain<1>{2}, double{}}));
+    STATIC_REQUIRE(!llama::mapsNonOverlappingly(MapEverythingToZero{llama::ArrayDomain<2>{32, 32}, Particle{}}));
+#else
+    INFO("Test disabled because compiler does not support __cpp_constexpr_dynamic_alloc");
+#endif
+}
+
+namespace
+{
+    // maps each element of the datum domain into a separate blobs. Each blob stores Modulus elements. If the array
+    // domain is larger than Modulus, elements are overwritten.
+    template <typename T_ArrayDomain, typename T_DatumDomain, std::size_t Modulus>
+    struct ModulusMapping
+    {
+        using ArrayDomain = T_ArrayDomain;
+        using DatumDomain = T_DatumDomain;
+        static constexpr std::size_t blobCount = boost::mp11::mp_size<llama::FlattenDatumDomain<DatumDomain>>::value;
+
+        LLAMA_FN_HOST_ACC_INLINE
+        constexpr ModulusMapping(ArrayDomain size, DatumDomain = {}) : arrayDomainSize(size)
+        {
+        }
+
+        constexpr auto getBlobSize(std::size_t) const -> std::size_t
+        {
+            return Modulus * llama::sizeOf<DatumDomain>;
+        }
+
+        template <std::size_t... DDCs>
+        constexpr auto getBlobNrAndOffset(ArrayDomain coord) const -> llama::NrAndOffset
+        {
+            const auto blob = llama::flatDatumCoord<DatumDomain, llama::DatumCoord<DDCs...>>;
+            const auto offset = (llama::mapping::LinearizeArrayDomainCpp{}(coord, arrayDomainSize) % Modulus)
+                * sizeof(llama::GetType<DatumDomain, llama::DatumCoord<DDCs...>>);
+            return {blob, offset};
+        }
+
+        ArrayDomain arrayDomainSize;
+    };
+} // namespace
+
+TEST_CASE("mapsNonOverlappingly.ModulusMapping")
+{
+    using Modulus10Mapping = ModulusMapping<llama::ArrayDomain<1>, Particle, 10>;
+
+#ifdef __cpp_constexpr_dynamic_alloc
+    STATIC_REQUIRE(llama::mapsNonOverlappingly(Modulus10Mapping{llama::ArrayDomain<1>{1}}));
+    STATIC_REQUIRE(llama::mapsNonOverlappingly(Modulus10Mapping{llama::ArrayDomain<1>{9}}));
+    STATIC_REQUIRE(llama::mapsNonOverlappingly(Modulus10Mapping{llama::ArrayDomain<1>{10}}));
+    STATIC_REQUIRE(!llama::mapsNonOverlappingly(Modulus10Mapping{llama::ArrayDomain<1>{11}}));
+    STATIC_REQUIRE(!llama::mapsNonOverlappingly(Modulus10Mapping{llama::ArrayDomain<1>{25}}));
 #else
     INFO("Test disabled because compiler does not support __cpp_constexpr_dynamic_alloc");
 #endif

--- a/tests/proofs.cpp
+++ b/tests/proofs.cpp
@@ -1,0 +1,44 @@
+#include <catch2/catch.hpp>
+#include <llama/Proofs.hpp>
+#include <llama/llama.hpp>
+
+// clang-format off
+namespace tag {
+    struct Pos {};
+    struct X {};
+    struct Y {};
+    struct Z {};
+    struct Momentum {};
+    struct Weight {};
+    struct Flags {};
+}
+
+using Particle = llama::DS<
+    llama::DE<tag::Pos, llama::DS<
+        llama::DE<tag::X, double>,
+        llama::DE<tag::Y, double>,
+        llama::DE<tag::Z, double>
+    >>,
+    llama::DE<tag::Weight, float>,
+    llama::DE<tag::Momentum, llama::DS<
+        llama::DE<tag::X, double>,
+        llama::DE<tag::Y, double>,
+        llama::DE<tag::Z, double>
+    >>,
+    llama::DE<tag::Flags, llama::DA<bool, 4>>
+>;
+// clang-format on
+
+
+TEST_CASE("mapsNonOverlappingly.AoS")
+{
+    using ArrayDomain = llama::ArrayDomain<2>;
+    constexpr auto arrayDomain = ArrayDomain{32, 32};
+    constexpr auto mapping = llama::mapping::AoS<ArrayDomain, Particle>{arrayDomain};
+
+#ifdef __cpp_constexpr_dynamic_alloc
+    STATIC_REQUIRE(llama::mapsNonOverlappingly(mapping));
+#else
+    INFO("Test disabled because compiler does not support __cpp_constexpr_dynamic_alloc");
+#endif
+}


### PR DESCRIPTION
This is a proof of concept that for a given constexpr mapping we can proof certain properties at compile time. This proof relies on exhaustion by iterating the space of all possible mapping's inputs and observing the mapping's outputs. It is thus not an algebraic proof, but has the advantage of not needing to know the implementation of the mapping (which is hard to obtain without some kind of expression reflection or reformulating mappings as some kind of template expression trees).

Concretly, the implemented property checks whether any of the mapped values by the mapping do not overlap with any other mapped value. Or in other words, if all memory regions where values are mapped to are distinct from each other.