### PR TITLE
VirtualDatum asTuple, load and store

### DIFF
--- a/include/llama/View.hpp
+++ b/include/llama/View.hpp
@@ -502,22 +502,22 @@ namespace llama
 
         struct Loader
         {
-            VirtualDatum vd;
+            const VirtualDatum& vd;
 
             template <typename T>
-            operator T()
+            operator T() const
             {
                 return vd.loadAs<T>();
             }
         };
 
-        auto load() -> Loader
+        auto load() const -> Loader
         {
             return Loader{*this};
         }
 
         template <typename T>
-        auto loadAs() -> T
+        auto loadAs() const -> T
         {
             return std::make_from_tuple<T>(asTuple());
         }

--- a/tests/virtualdatum.cpp
+++ b/tests/virtualdatum.cpp
@@ -503,11 +503,31 @@ TEST_CASE("VirtualDatum.load")
         CHECK(pos.a == 1);
         CHECK(pos.y == 1);
 
-        pos.a = 2;
-        pos.y = 3;
+        datum = 2;
+        MyPos pos2 = std::as_const(datum)(tag::Pos{}).load();
+        CHECK(pos2.a == 2);
+        CHECK(pos2.y == 2);
+    }
+}
+
+TEST_CASE("VirtualDatum.store")
+{
+    auto datum = llama::allocVirtualDatumStack<Name>();
+    datum = 1;
+
+    {
+        MyPos pos{2, 3};
         datum(tag::Pos{}).store(pos);
         CHECK(datum(tag::Pos{}, tag::A{}) == 2);
         CHECK(datum(tag::Pos{}, tag::Y{}) == 3);
+        CHECK(datum(tag::Vel{}, tag::X{}) == 1);
+        CHECK(datum(tag::Vel{}, tag::Y{}) == 1);
+        CHECK(datum(tag::Vel{}, tag::Z{}) == 1);
+        CHECK(datum(tag::Weight{}) == 1);
+
+        datum(tag::Pos{}).store(MyPos{5, 6});
+        CHECK(datum(tag::Pos{}, tag::A{}) == 5);
+        CHECK(datum(tag::Pos{}, tag::Y{}) == 6);
         CHECK(datum(tag::Vel{}, tag::X{}) == 1);
         CHECK(datum(tag::Vel{}, tag::Y{}) == 1);
         CHECK(datum(tag::Vel{}, tag::Z{}) == 1);


### PR DESCRIPTION
`asTuple` resolves all memory locations a `VirtualDatum` refers to and creates a tuple holding these. This has interesting applications like allowing structured bindings on to be used together with virtual datums.

Furthermore, `load` and `store` now allow to load and store the values referenced by a virtual datum from and to any tuple like type.