### PR TITLE
Replace allocVirtualDatumStack<>() by One<>

### DIFF
--- a/examples/alpaka/asyncblur/asyncblur.cpp
+++ b/examples/alpaka/asyncblur/asyncblur.cpp
@@ -127,7 +127,7 @@ struct BlurKernel
             LLAMA_INDEPENDENT_DATA
         for (auto x = start[1]; x < end[1]; ++x)
         {
-            auto sum = llama::allocVirtualDatumStack<PixelOnAcc>();
+            llama::One<PixelOnAcc> sum;
             sum = 0;
 
             using ItType = long int;

--- a/examples/alpaka/nbody/nbody.cpp
+++ b/examples/alpaka/nbody/nbody.cpp
@@ -217,15 +217,15 @@ int main()
     LLAMA_INDEPENDENT_DATA
     for (std::size_t i = 0; i < PROBLEM_SIZE; ++i)
     {
-        auto temp = llama::allocVirtualDatumStack<Particle>();
-        temp(tag::Pos(), tag::X()) = distribution(generator);
-        temp(tag::Pos(), tag::Y()) = distribution(generator);
-        temp(tag::Pos(), tag::Z()) = distribution(generator);
-        temp(tag::Vel(), tag::X()) = distribution(generator) / FP(10);
-        temp(tag::Vel(), tag::Y()) = distribution(generator) / FP(10);
-        temp(tag::Vel(), tag::Z()) = distribution(generator) / FP(10);
-        temp(tag::Mass()) = distribution(generator) / FP(100);
-        hostView(i) = temp;
+        llama::One<Particle> p;
+        p(tag::Pos(), tag::X()) = distribution(generator);
+        p(tag::Pos(), tag::Y()) = distribution(generator);
+        p(tag::Pos(), tag::Z()) = distribution(generator);
+        p(tag::Vel(), tag::X()) = distribution(generator) / FP(10);
+        p(tag::Vel(), tag::Y()) = distribution(generator) / FP(10);
+        p(tag::Vel(), tag::Z()) = distribution(generator) / FP(10);
+        p(tag::Mass()) = distribution(generator) / FP(100);
+        hostView(i) = p;
     }
 
     chrono.printAndReset("Init");

--- a/examples/cuda/nbody/nbody.cu
+++ b/examples/cuda/nbody/nbody.cu
@@ -103,7 +103,7 @@ __global__ void updateSM(View particles)
     const auto ti = threadIdx.x + blockIdx.x * blockDim.x;
     const auto tbi = blockIdx.x;
 
-    auto pi = llama::allocVirtualDatumStack<Particle>();
+    llama::One<Particle> pi;
     if constexpr (UseAccumulator)
         pi = particles(ti);
     for (std::size_t blockOffset = 0; blockOffset < ProblemSize; blockOffset += BlockSize)
@@ -132,7 +132,7 @@ __global__ void update(View particles)
 {
     const auto ti = threadIdx.x + blockIdx.x * blockDim.x;
 
-    auto pi = llama::allocVirtualDatumStack<Particle>();
+    llama::One<Particle> pi;
     if constexpr (UseAccumulator)
         pi = particles(ti);
     LLAMA_INDEPENDENT_DATA
@@ -218,15 +218,15 @@ try
     std::normal_distribution<FP> distribution(FP(0), FP(1));
     for (std::size_t i = 0; i < PROBLEM_SIZE; ++i)
     {
-        auto temp = llama::allocVirtualDatumStack<Particle>();
-        temp(tag::Pos(), tag::X()) = distribution(generator);
-        temp(tag::Pos(), tag::Y()) = distribution(generator);
-        temp(tag::Pos(), tag::Z()) = distribution(generator);
-        temp(tag::Vel(), tag::X()) = distribution(generator) / FP(10);
-        temp(tag::Vel(), tag::Y()) = distribution(generator) / FP(10);
-        temp(tag::Vel(), tag::Z()) = distribution(generator) / FP(10);
-        temp(tag::Mass()) = distribution(generator) / FP(100);
-        hostView(i) = temp;
+        llama::One<Particle> p;
+        p(tag::Pos(), tag::X()) = distribution(generator);
+        p(tag::Pos(), tag::Y()) = distribution(generator);
+        p(tag::Pos(), tag::Z()) = distribution(generator);
+        p(tag::Vel(), tag::X()) = distribution(generator) / FP(10);
+        p(tag::Vel(), tag::Y()) = distribution(generator) / FP(10);
+        p(tag::Vel(), tag::Z()) = distribution(generator) / FP(10);
+        p(tag::Mass()) = distribution(generator) / FP(100);
+        hostView(i) = p;
     }
 
     watch.printAndReset("init");

--- a/examples/nbody/nbody.cpp
+++ b/examples/nbody/nbody.cpp
@@ -81,7 +81,7 @@ namespace usellama
         LLAMA_INDEPENDENT_DATA
         for (std::size_t i = 0; i < PROBLEM_SIZE; i++)
         {
-            auto pi = llama::allocVirtualDatumStack<Particle>();
+            llama::One<Particle> pi;
             if constexpr (UseAccumulator)
                 pi = particles(i);
             LLAMA_INDEPENDENT_DATA

--- a/include/llama/View.hpp
+++ b/include/llama/View.hpp
@@ -54,12 +54,6 @@ namespace llama
         return allocView(Mapping{}, llama::allocator::Stack<sizeOf<DatumDomain>>{});
     }
 
-    template <typename View>
-    inline constexpr auto IsView = false;
-
-    template <typename Mapping, typename BlobType>
-    inline constexpr auto IsView<View<Mapping, BlobType>> = true;
-
     template <typename View, typename BoundDatumDomain = DatumCoord<>, bool OwnView = false>
     struct VirtualDatum;
 
@@ -622,6 +616,12 @@ namespace llama
             return reinterpret_cast<Type&>(storageBlobs[nr][offset]);
         }
     };
+
+    template <typename View>
+    inline constexpr auto IsView = false;
+
+    template <typename Mapping, typename BlobType>
+    inline constexpr auto IsView<View<Mapping, BlobType>> = true;
 
     /// Acts like a \ref View, but shows only a smaller and/or shifted part of
     /// another view it references, the parent view.

--- a/tests/view.cpp
+++ b/tests/view.cpp
@@ -182,7 +182,7 @@ TEST_CASE("view.assign-one-datum")
     Mapping mapping{arrayDomain};
     auto view = allocView(mapping);
 
-    auto datum = llama::allocVirtualDatumStack<Particle>();
+    llama::One<Particle> datum;
     datum(tag::Pos{}, tag::X{}) = 14.0f;
     datum(tag::Pos{}, tag::Y{}) = 15.0f;
     datum(tag::Pos{}, tag::Z{}) = 16.0f;

--- a/tests/virtualdatum.cpp
+++ b/tests/virtualdatum.cpp
@@ -29,7 +29,7 @@ using Name = llama::DS<
 
 TEST_CASE("VirtualDatum.operator=")
 {
-    auto datum = llama::allocVirtualDatumStack<Name>();
+    llama::One<Name> datum;
 
     // scalar to multiple elements in virtual datum
     datum(tag::Pos{}) = 1;
@@ -84,7 +84,7 @@ namespace
 {
     auto allocVc()
     {
-        auto datum = llama::allocVirtualDatumStack<Name>();
+        llama::One<Name> datum;
         datum(tag::Pos{}, tag::A{}) = 1;
         datum(tag::Pos{}, tag::Y{}) = 2;
         datum(tag::Vel{}, tag::X{}) = 3;
@@ -267,7 +267,7 @@ using Name2 = llama::DS<
 
 TEST_CASE("VirtualDatum.operator=.propagation")
 {
-    auto datum = llama::allocVirtualDatumStack<Name2>();
+    llama::One<Name2> datum;
 
     datum(tag::Part1{}) = 1;
     datum(tag::Part2{}) = 2;
@@ -295,8 +295,8 @@ TEST_CASE("VirtualDatum.operator=.propagation")
 
 TEST_CASE("VirtualDatum.operator=.multiview")
 {
-    auto datum1 = llama::allocVirtualDatumStack<Name>();
-    auto datum2 = llama::allocVirtualDatumStack<Name2>();
+    llama::One<Name> datum1;
+    llama::One<Name2> datum2;
 
     datum2 = 1;
     datum1 = datum2;
@@ -318,7 +318,7 @@ TEST_CASE("VirtualDatum.operator=.multiview")
 
 TEST_CASE("VirtualDatum.operator==")
 {
-    auto datum = llama::allocVirtualDatumStack<Name>();
+    llama::One<Name> datum;
 
     datum = 1;
 
@@ -342,7 +342,7 @@ TEST_CASE("VirtualDatum.operator==")
 
 TEST_CASE("VirtualDatum.operator<")
 {
-    auto datum = llama::allocVirtualDatumStack<Name>();
+    llama::One<Name> datum;
 
     datum = 1;
 
@@ -380,14 +380,14 @@ TEST_CASE("VirtualDatum.operator<")
 TEST_CASE("VirtualDatum.asTuple.types")
 {
     {
-        auto datum = llama::allocVirtualDatumStack<Name>();
+        llama::One<Name> datum;
 
         std::tuple<int&, int&> pos = datum(tag::Pos{}).asTuple();
         std::tuple<int&, int&, int&> vel = datum(tag::Vel{}).asTuple();
         std::tuple<int&, int&, int&, int&, int&, int&> name = datum.asTuple();
     }
     {
-        const auto datum = llama::allocVirtualDatumStack<Name>();
+        const llama::One<Name> datum;
 
         std::tuple<const int&, const int&> pos = datum(tag::Pos{}).asTuple();
         std::tuple<const int&, const int&, const int&> vel = datum(tag::Vel{}).asTuple();
@@ -397,7 +397,7 @@ TEST_CASE("VirtualDatum.asTuple.types")
 
 TEST_CASE("VirtualDatum.asTuple.assign")
 {
-    auto datum = llama::allocVirtualDatumStack<Name>();
+    llama::One<Name> datum;
 
     datum(tag::Pos{}).asTuple() = std::tuple{1, 1};
     CHECK(datum(tag::Pos{}, tag::A{}) == 1);
@@ -426,7 +426,7 @@ TEST_CASE("VirtualDatum.asTuple.assign")
 
 TEST_CASE("VirtualDatum.asTuple.structuredBindings")
 {
-    auto datum = llama::allocVirtualDatumStack<Name>();
+    llama::One<Name> datum;
 
     {
         auto [a, y] = datum(tag::Pos{}).asTuple();


### PR DESCRIPTION
The current `allocVirtualDatumStack<DatumDomain>()` interface to create a single instance of the datum domain is quite verbose. So here is a less verbose replacement: `llama::One<DatumDomain>`.