### PR TITLE
Add hierarchical asTuple

### DIFF
--- a/include/llama/View.hpp
+++ b/include/llama/View.hpp
@@ -211,16 +211,16 @@ namespace llama
         };
 
         template <typename TWithOptionalConst, typename T>
-        LLAMA_FN_HOST_ACC_INLINE auto asTupleImpl(TWithOptionalConst& leaf, T)
+        LLAMA_FN_HOST_ACC_INLINE auto asFlatTupleImpl(TWithOptionalConst& leaf, T)
             -> std::enable_if_t<!is_VirtualDatum<std::decay_t<TWithOptionalConst>>, std::tuple<TWithOptionalConst&>>
         {
             return {leaf};
         }
 
         template <typename VirtualDatum, typename... Elements>
-        LLAMA_FN_HOST_ACC_INLINE auto asTupleImpl(VirtualDatum&& vd, DatumStruct<Elements...>)
+        LLAMA_FN_HOST_ACC_INLINE auto asFlatTupleImpl(VirtualDatum&& vd, DatumStruct<Elements...>)
         {
-            return std::tuple_cat(asTupleImpl(vd(GetDatumElementTag<Elements>{}), GetDatumElementType<Elements>{})...);
+            return std::tuple_cat(asFlatTupleImpl(vd(GetDatumElementTag<Elements>{}), GetDatumElementType<Elements>{})...);
         }
     } // namespace internal
 
@@ -483,14 +483,14 @@ namespace llama
             return vd <= t;
         }
 
-        auto asTuple()
+        auto asFlatTuple()
         {
-            return internal::asTupleImpl(*this, AccessibleDatumDomain{});
+            return internal::asFlatTupleImpl(*this, AccessibleDatumDomain{});
         }
 
-        auto asTuple() const
+        auto asFlatTuple() const
         {
-            return internal::asTupleImpl(*this, AccessibleDatumDomain{});
+            return internal::asFlatTupleImpl(*this, AccessibleDatumDomain{});
         }
     };
 

--- a/tests/virtualdatum.cpp
+++ b/tests/virtualdatum.cpp
@@ -377,29 +377,29 @@ TEST_CASE("VirtualDatum.operator<")
     CHECK(!(datum(tag::Pos{}) < datum(tag::Vel{})));
 }
 
-TEST_CASE("VirtualDatum.asTuple.types")
+TEST_CASE("VirtualDatum.asFlatTuple.types")
 {
     {
         llama::One<Name> datum;
 
-        std::tuple<int&, int&> pos = datum(tag::Pos{}).asTuple();
-        std::tuple<int&, int&, int&> vel = datum(tag::Vel{}).asTuple();
-        std::tuple<int&, int&, int&, int&, int&, int&> name = datum.asTuple();
+        std::tuple<int&, int&> pos = datum(tag::Pos{}).asFlatTuple();
+        std::tuple<int&, int&, int&> vel = datum(tag::Vel{}).asFlatTuple();
+        std::tuple<int&, int&, int&, int&, int&, int&> name = datum.asFlatTuple();
     }
     {
         const llama::One<Name> datum;
 
-        std::tuple<const int&, const int&> pos = datum(tag::Pos{}).asTuple();
-        std::tuple<const int&, const int&, const int&> vel = datum(tag::Vel{}).asTuple();
-        std::tuple<const int&, const int&, const int&, const int&, const int&, const int&> name = datum.asTuple();
+        std::tuple<const int&, const int&> pos = datum(tag::Pos{}).asFlatTuple();
+        std::tuple<const int&, const int&, const int&> vel = datum(tag::Vel{}).asFlatTuple();
+        std::tuple<const int&, const int&, const int&, const int&, const int&, const int&> name = datum.asFlatTuple();
     }
 }
 
-TEST_CASE("VirtualDatum.asTuple.assign")
+TEST_CASE("VirtualDatum.asFlatTuple.assign")
 {
     llama::One<Name> datum;
 
-    datum(tag::Pos{}).asTuple() = std::tuple{1, 1};
+    datum(tag::Pos{}).asFlatTuple() = std::tuple{1, 1};
     CHECK(datum(tag::Pos{}, tag::A{}) == 1);
     CHECK(datum(tag::Pos{}, tag::Y{}) == 1);
     CHECK(datum(tag::Vel{}, tag::X{}) == 0);
@@ -407,7 +407,7 @@ TEST_CASE("VirtualDatum.asTuple.assign")
     CHECK(datum(tag::Vel{}, tag::Z{}) == 0);
     CHECK(datum(tag::Weight{}) == 0);
 
-    datum(tag::Vel{}).asTuple() = std::tuple{2, 2, 2};
+    datum(tag::Vel{}).asFlatTuple() = std::tuple{2, 2, 2};
     CHECK(datum(tag::Pos{}, tag::A{}) == 1);
     CHECK(datum(tag::Pos{}, tag::Y{}) == 1);
     CHECK(datum(tag::Vel{}, tag::X{}) == 2);
@@ -415,7 +415,7 @@ TEST_CASE("VirtualDatum.asTuple.assign")
     CHECK(datum(tag::Vel{}, tag::Z{}) == 2);
     CHECK(datum(tag::Weight{}) == 0);
 
-    datum.asTuple() = std::tuple{3, 3, 3, 3, 3, 3};
+    datum.asFlatTuple() = std::tuple{3, 3, 3, 3, 3, 3};
     CHECK(datum(tag::Pos{}, tag::A{}) == 3);
     CHECK(datum(tag::Pos{}, tag::Y{}) == 3);
     CHECK(datum(tag::Vel{}, tag::X{}) == 3);
@@ -424,12 +424,12 @@ TEST_CASE("VirtualDatum.asTuple.assign")
     CHECK(datum(tag::Weight{}) == 3);
 }
 
-TEST_CASE("VirtualDatum.asTuple.structuredBindings")
+TEST_CASE("VirtualDatum.asFlatTuple.structuredBindings")
 {
     llama::One<Name> datum;
 
     {
-        auto [a, y] = datum(tag::Pos{}).asTuple();
+        auto [a, y] = datum(tag::Pos{}).asFlatTuple();
         a = 1;
         y = 2;
         CHECK(datum(tag::Pos{}, tag::A{}) == 1);
@@ -441,7 +441,7 @@ TEST_CASE("VirtualDatum.asTuple.structuredBindings")
     }
 
     {
-        auto [x, y, z] = datum(tag::Vel{}).asTuple();
+        auto [x, y, z] = datum(tag::Vel{}).asFlatTuple();
         x = 3;
         y = 4;
         z = 5;
@@ -454,7 +454,7 @@ TEST_CASE("VirtualDatum.asTuple.structuredBindings")
     }
 
     {
-        auto [a, y1, x, y2, z, w] = datum.asTuple();
+        auto [a, y1, x, y2, z, w] = datum.asFlatTuple();
         a = 10;
         y1 = 20;
         x = 30;

--- a/tests/virtualdatum.cpp
+++ b/tests/virtualdatum.cpp
@@ -377,6 +377,103 @@ TEST_CASE("VirtualDatum.operator<")
     CHECK(!(datum(tag::Pos{}) < datum(tag::Vel{})));
 }
 
+TEST_CASE("VirtualDatum.asTuple.types")
+{
+    {
+        llama::One<Name> datum;
+
+        std::tuple<int&, int&> pos = datum(tag::Pos{}).asTuple();
+        std::tuple<int&, int&, int&> vel = datum(tag::Vel{}).asTuple();
+        std::tuple<std::tuple<int&, int&>, std::tuple<int&, int&, int&>, int&> name = datum.asTuple();
+    }
+    {
+        const llama::One<Name> datum;
+
+        std::tuple<const int&, const int&> pos = datum(tag::Pos{}).asTuple();
+        std::tuple<const int&, const int&, const int&> vel = datum(tag::Vel{}).asTuple();
+        std::tuple<std::tuple<const int&, const int&>, std::tuple<const int&, const int&, const int&>, const int&> name
+            = datum.asTuple();
+    }
+}
+
+TEST_CASE("VirtualDatum.asTuple.assign")
+{
+    llama::One<Name> datum;
+
+    datum(tag::Pos{}).asTuple() = std::tuple{1, 1};
+    CHECK(datum(tag::Pos{}, tag::A{}) == 1);
+    CHECK(datum(tag::Pos{}, tag::Y{}) == 1);
+    CHECK(datum(tag::Vel{}, tag::X{}) == 0);
+    CHECK(datum(tag::Vel{}, tag::Y{}) == 0);
+    CHECK(datum(tag::Vel{}, tag::Z{}) == 0);
+    CHECK(datum(tag::Weight{}) == 0);
+
+    datum(tag::Vel{}).asTuple() = std::tuple{2, 2, 2};
+    CHECK(datum(tag::Pos{}, tag::A{}) == 1);
+    CHECK(datum(tag::Pos{}, tag::Y{}) == 1);
+    CHECK(datum(tag::Vel{}, tag::X{}) == 2);
+    CHECK(datum(tag::Vel{}, tag::Y{}) == 2);
+    CHECK(datum(tag::Vel{}, tag::Z{}) == 2);
+    CHECK(datum(tag::Weight{}) == 0);
+
+    datum.asTuple() = std::tuple{std::tuple{3, 3}, std::tuple{3, 3, 3}, 3};
+    CHECK(datum(tag::Pos{}, tag::A{}) == 3);
+    CHECK(datum(tag::Pos{}, tag::Y{}) == 3);
+    CHECK(datum(tag::Vel{}, tag::X{}) == 3);
+    CHECK(datum(tag::Vel{}, tag::Y{}) == 3);
+    CHECK(datum(tag::Vel{}, tag::Z{}) == 3);
+    CHECK(datum(tag::Weight{}) == 3);
+}
+
+TEST_CASE("VirtualDatum.asTuple.structuredBindings")
+{
+    llama::One<Name> datum;
+
+    {
+        auto [a, y] = datum(tag::Pos{}).asTuple();
+        a = 1;
+        y = 2;
+        CHECK(datum(tag::Pos{}, tag::A{}) == 1);
+        CHECK(datum(tag::Pos{}, tag::Y{}) == 2);
+        CHECK(datum(tag::Vel{}, tag::X{}) == 0);
+        CHECK(datum(tag::Vel{}, tag::Y{}) == 0);
+        CHECK(datum(tag::Vel{}, tag::Z{}) == 0);
+        CHECK(datum(tag::Weight{}) == 0);
+    }
+
+    {
+        auto [x, y, z] = datum(tag::Vel{}).asTuple();
+        x = 3;
+        y = 4;
+        z = 5;
+        CHECK(datum(tag::Pos{}, tag::A{}) == 1);
+        CHECK(datum(tag::Pos{}, tag::Y{}) == 2);
+        CHECK(datum(tag::Vel{}, tag::X{}) == 3);
+        CHECK(datum(tag::Vel{}, tag::Y{}) == 4);
+        CHECK(datum(tag::Vel{}, tag::Z{}) == 5);
+        CHECK(datum(tag::Weight{}) == 0);
+    }
+
+    {
+        auto [pos, vel, w] = datum.asTuple();
+        auto [a, y1] = pos;
+        auto [x, y2, z] = vel;
+        a = 10;
+        y1 = 20;
+        x = 30;
+        y2 = 40;
+        z = 50;
+        w = 60;
+        CHECK(datum(tag::Pos{}, tag::A{}) == 10);
+        CHECK(datum(tag::Pos{}, tag::Y{}) == 20);
+        CHECK(datum(tag::Vel{}, tag::X{}) == 30);
+        CHECK(datum(tag::Vel{}, tag::Y{}) == 40);
+        CHECK(datum(tag::Vel{}, tag::Z{}) == 50);
+        CHECK(datum(tag::Weight{}) == 60);
+    }
+}
+
+
 TEST_CASE("VirtualDatum.asFlatTuple.types")
 {
     {


### PR DESCRIPTION
Rename `asTuple` into `asFlatTuple` and add a new function `asTuple` to `VirtualDatum` which reflects the datum domains hierarchy.