### PR TITLE
Replace Index<I> by DatumCoord<I> and literal operator

### DIFF
--- a/include/llama/Core.hpp
+++ b/include/llama/Core.hpp
@@ -83,10 +83,6 @@ namespace llama
         }
     } // namespace internal
 
-    /// Alias for \ref DatumCoord<I>. Describs an index used to access members of a \ref DatumArray.
-    template <std::size_t I>
-    using Index = DatumCoord<I>;
-
     /// An array of identical \ref DatumElement with \ref Index specialized on
     /// consecutive numbers. Can be used anywhere where \ref DatumStruct may
     /// used.

--- a/include/llama/Core.hpp
+++ b/include/llama/Core.hpp
@@ -74,18 +74,18 @@ namespace llama
     template <typename Identifier, typename Type>
     using DE = DatumElement<Identifier, Type>;
 
-    /// Tag describing an index. Used to access members of a \ref DatumArray.
-    template <std::size_t I>
-    using Index = boost::mp11::mp_size_t<I>;
-
     namespace internal
     {
         template <typename ChildType, std::size_t... Is>
         auto makeDatumArray(std::index_sequence<Is...>)
         {
-            return DatumStruct<DatumElement<Index<Is>, ChildType>...>{};
+            return DatumStruct<DatumElement<DatumCoord<Is>, ChildType>...>{};
         }
     } // namespace internal
+
+    /// Alias for \ref DatumCoord<I>. Describs an index used to access members of a \ref DatumArray.
+    template <std::size_t I>
+    using Index = DatumCoord<I>;
 
     /// An array of identical \ref DatumElement with \ref Index specialized on
     /// consecutive numbers. Can be used anywhere where \ref DatumStruct may

--- a/include/llama/DatumCoord.hpp
+++ b/include/llama/DatumCoord.hpp
@@ -30,6 +30,28 @@ namespace llama
         static constexpr std::size_t size = 0;
     };
 
+    inline namespace literals
+    {
+        template <char... Digits>
+        constexpr auto operator"" _DC()
+        {
+            constexpr auto coord = []() constexpr
+            {
+                char digits[] = {(Digits - 48)...};
+                std::size_t acc = 0;
+                std ::size_t powerOf10 = 1;
+                for (int i = sizeof...(Digits) - 1; i >= 0; i--)
+                {
+                    acc += digits[i] * powerOf10;
+                    powerOf10 *= 10;
+                }
+                return acc;
+            }
+            ();
+            return DatumCoord<coord>{};
+        }
+    } // namespace literals
+
     namespace internal
     {
         template <class L>

--- a/include/llama/DumpMapping.hpp
+++ b/include/llama/DumpMapping.hpp
@@ -26,8 +26,9 @@ namespace llama
             return structName(tag);
         }
 
+        // handle array indices
         template <std::size_t N>
-        auto tagToString(Index<N>)
+        auto tagToString(DatumCoord<N>)
         {
             return std::to_string(N);
         }

--- a/include/llama/mapping/tree/toString.hpp
+++ b/include/llama/mapping/tree/toString.hpp
@@ -18,8 +18,9 @@ namespace llama::mapping::tree
         return "Unknown";
     }
 
+    // handles array indices
     template <std::size_t I>
-    inline auto toString(Index<I>) -> std::string
+    inline auto toString(DatumCoord<I>) -> std::string
     {
         return "";
     }

--- a/tests/core.cpp
+++ b/tests/core.cpp
@@ -140,21 +140,22 @@ TEST_CASE("offsetOf")
 
 TEST_CASE("GetCoordFromTags")
 {
+    using namespace llama::literals;
     // clang-format off
-    STATIC_REQUIRE(std::is_same_v<llama::GetCoordFromTags<Particle                             >, llama::DatumCoord<    >>);
-    STATIC_REQUIRE(std::is_same_v<llama::GetCoordFromTags<Particle, tag::Pos                   >, llama::DatumCoord<0   >>);
-    STATIC_REQUIRE(std::is_same_v<llama::GetCoordFromTags<Particle, tag::Pos, tag::X           >, llama::DatumCoord<0, 0>>);
-    STATIC_REQUIRE(std::is_same_v<llama::GetCoordFromTags<Particle, tag::Pos, tag::Y           >, llama::DatumCoord<0, 1>>);
-    STATIC_REQUIRE(std::is_same_v<llama::GetCoordFromTags<Particle, tag::Pos, tag::Z           >, llama::DatumCoord<0, 2>>);
-    STATIC_REQUIRE(std::is_same_v<llama::GetCoordFromTags<Particle, tag::Weight                >, llama::DatumCoord<1   >>);
-    STATIC_REQUIRE(std::is_same_v<llama::GetCoordFromTags<Particle, llama::NoName              >, llama::DatumCoord<2   >>);
-    STATIC_REQUIRE(std::is_same_v<llama::GetCoordFromTags<Particle, tag::Vel, tag::Z           >, llama::DatumCoord<3, 0>>);
-    STATIC_REQUIRE(std::is_same_v<llama::GetCoordFromTags<Particle, tag::Vel, tag::X           >, llama::DatumCoord<3, 1>>);
-    STATIC_REQUIRE(std::is_same_v<llama::GetCoordFromTags<Particle, tag::Flags                 >, llama::DatumCoord<4   >>);
-    STATIC_REQUIRE(std::is_same_v<llama::GetCoordFromTags<Particle, tag::Flags, llama::Index<0>>, llama::DatumCoord<4, 0>>);
-    STATIC_REQUIRE(std::is_same_v<llama::GetCoordFromTags<Particle, tag::Flags, llama::Index<1>>, llama::DatumCoord<4, 1>>);
-    STATIC_REQUIRE(std::is_same_v<llama::GetCoordFromTags<Particle, tag::Flags, llama::Index<2>>, llama::DatumCoord<4, 2>>);
-    STATIC_REQUIRE(std::is_same_v<llama::GetCoordFromTags<Particle, tag::Flags, llama::Index<3>>, llama::DatumCoord<4, 3>>);
+    STATIC_REQUIRE(std::is_same_v<llama::GetCoordFromTags<Particle                                  >, llama::DatumCoord<    >>);
+    STATIC_REQUIRE(std::is_same_v<llama::GetCoordFromTags<Particle, tag::Pos                        >, llama::DatumCoord<0   >>);
+    STATIC_REQUIRE(std::is_same_v<llama::GetCoordFromTags<Particle, tag::Pos, tag::X                >, llama::DatumCoord<0, 0>>);
+    STATIC_REQUIRE(std::is_same_v<llama::GetCoordFromTags<Particle, tag::Pos, tag::Y                >, llama::DatumCoord<0, 1>>);
+    STATIC_REQUIRE(std::is_same_v<llama::GetCoordFromTags<Particle, tag::Pos, tag::Z                >, llama::DatumCoord<0, 2>>);
+    STATIC_REQUIRE(std::is_same_v<llama::GetCoordFromTags<Particle, tag::Weight                     >, llama::DatumCoord<1   >>);
+    STATIC_REQUIRE(std::is_same_v<llama::GetCoordFromTags<Particle, llama::NoName                   >, llama::DatumCoord<2   >>);
+    STATIC_REQUIRE(std::is_same_v<llama::GetCoordFromTags<Particle, tag::Vel, tag::Z                >, llama::DatumCoord<3, 0>>);
+    STATIC_REQUIRE(std::is_same_v<llama::GetCoordFromTags<Particle, tag::Vel, tag::X                >, llama::DatumCoord<3, 1>>);
+    STATIC_REQUIRE(std::is_same_v<llama::GetCoordFromTags<Particle, tag::Flags                      >, llama::DatumCoord<4   >>);
+    STATIC_REQUIRE(std::is_same_v<llama::GetCoordFromTags<Particle, tag::Flags, llama::DatumCoord<0>>, llama::DatumCoord<4, 0>>);
+    STATIC_REQUIRE(std::is_same_v<llama::GetCoordFromTags<Particle, tag::Flags, llama::DatumCoord<1>>, llama::DatumCoord<4, 1>>);
+    STATIC_REQUIRE(std::is_same_v<llama::GetCoordFromTags<Particle, tag::Flags, llama::DatumCoord<2>>, llama::DatumCoord<4, 2>>);
+    STATIC_REQUIRE(std::is_same_v<llama::GetCoordFromTags<Particle, tag::Flags, llama::DatumCoord<3>>, llama::DatumCoord<4, 3>>);
     // clang-format on
 }
 
@@ -269,16 +270,17 @@ using Arrays = llama::DS<
 
 TEST_CASE("arrays")
 {
-    auto v = llama::allocView(llama::mapping::AoS{llama::ArrayDomain{1}, Arrays{}});
+    using namespace llama::literals;
 
-    v(0u)(tag::A1{}, llama::Index<0>{});
-    v(0u)(tag::A1{}, llama::Index<1>{});
-    v(0u)(tag::A1{}, llama::Index<2>{});
-    v(0u)(tag::A2{}, llama::Index<0>{}, tag::X{});
-    v(0u)(tag::A2{}, llama::Index<1>{}, tag::X{});
-    v(0u)(tag::A2{}, llama::Index<2>{}, tag::X{});
-    v(0u)(tag::A3{}, llama::Index<0>{}, llama::Index<0>{});
-    v(0u)(tag::A3{}, llama::Index<0>{}, llama::Index<1>{});
-    v(0u)(tag::A3{}, llama::Index<1>{}, llama::Index<0>{});
-    v(0u)(tag::A3{}, llama::Index<1>{}, llama::Index<1>{});
+    auto v = llama::allocView(llama::mapping::AoS{llama::ArrayDomain{1}, Arrays{}});
+    v(0u)(tag::A1{}, 0_DC);
+    v(0u)(tag::A1{}, 1_DC);
+    v(0u)(tag::A1{}, 2_DC);
+    v(0u)(tag::A2{}, 0_DC, tag::X{});
+    v(0u)(tag::A2{}, 1_DC, tag::X{});
+    v(0u)(tag::A2{}, 2_DC, tag::X{});
+    v(0u)(tag::A3{}, 0_DC, 0_DC);
+    v(0u)(tag::A3{}, 0_DC, 1_DC);
+    v(0u)(tag::A3{}, 1_DC, 0_DC);
+    v(0u)(tag::A3{}, 1_DC, 1_DC);
 }

--- a/tests/core.cpp
+++ b/tests/core.cpp
@@ -87,29 +87,25 @@ TEST_CASE("prettyPrintType")
         tag::Flags,
         llama::DatumStruct<
             llama::DatumElement<
-                std::integral_constant<
-                    unsigned long,
+                llama::DatumCoord<
                     0
                 >,
                 bool
             >,
             llama::DatumElement<
-                std::integral_constant<
-                    unsigned long,
+                llama::DatumCoord<
                     1
                 >,
                 bool
             >,
             llama::DatumElement<
-                std::integral_constant<
-                    unsigned long,
+                llama::DatumCoord<
                     2
                 >,
                 bool
             >,
             llama::DatumElement<
-                std::integral_constant<
-                    unsigned long,
+                llama::DatumCoord<
                     3
                 >,
                 bool

--- a/tests/datumcoord.cpp
+++ b/tests/datumcoord.cpp
@@ -27,3 +27,12 @@ TEST_CASE("DatumCoordCommonPrefixIsBigger")
     STATIC_REQUIRE(!llama::DatumCoordCommonPrefixIsBigger<llama::DatumCoord<0      >, llama::DatumCoord<0, 0, 1>>);
     // clang-format on
 }
+
+TEST_CASE("_DT")
+{
+    using namespace llama::literals;
+    STATIC_REQUIRE(std::is_same_v<llama::DatumCoord<0>, decltype(0_DC)>);
+    STATIC_REQUIRE(std::is_same_v<llama::DatumCoord<1>, decltype(1_DC)>);
+    STATIC_REQUIRE(std::is_same_v<llama::DatumCoord<10>, decltype(10_DC)>);
+    STATIC_REQUIRE(std::is_same_v<llama::DatumCoord<165463135>, decltype(165463135_DC)>);
+}

--- a/tests/treemap.cpp
+++ b/tests/treemap.cpp
@@ -874,8 +874,7 @@ TEST_CASE("treemapping")
                     tag::Flags,
                     llama::Tuple<
                         llama::mapping::tree::Leaf<
-                            std::integral_constant<
-                                unsigned long,
+                            llama::DatumCoord<
                                 0
                             >,
                             bool,
@@ -885,8 +884,7 @@ TEST_CASE("treemapping")
                             >
                         >,
                         llama::mapping::tree::Leaf<
-                            std::integral_constant<
-                                unsigned long,
+                            llama::DatumCoord<
                                 1
                             >,
                             bool,
@@ -896,8 +894,7 @@ TEST_CASE("treemapping")
                             >
                         >,
                         llama::mapping::tree::Leaf<
-                            std::integral_constant<
-                                unsigned long,
+                            llama::DatumCoord<
                                 2
                             >,
                             bool,
@@ -907,8 +904,7 @@ TEST_CASE("treemapping")
                             >
                         >,
                         llama::mapping::tree::Leaf<
-                            std::integral_constant<
-                                unsigned long,
+                            llama::DatumCoord<
                                 3
                             >,
                             bool,
@@ -997,32 +993,28 @@ TEST_CASE("treemapping")
                     tag::Flags,
                     llama::Tuple<
                         llama::mapping::tree::Leaf<
-                            std::integral_constant<
-                                unsigned long,
+                            llama::DatumCoord<
                                 0
                             >,
                             bool,
                             unsigned long
                         >,
                         llama::mapping::tree::Leaf<
-                            std::integral_constant<
-                                unsigned long,
+                            llama::DatumCoord<
                                 1
                             >,
                             bool,
                             unsigned long
                         >,
                         llama::mapping::tree::Leaf<
-                            std::integral_constant<
-                                unsigned long,
+                            llama::DatumCoord<
                                 2
                             >,
                             bool,
                             unsigned long
                         >,
                         llama::mapping::tree::Leaf<
-                            std::integral_constant<
-                                unsigned long,
+                            llama::DatumCoord<
                                 3
                             >,
                             bool,

--- a/tests/view.cpp
+++ b/tests/view.cpp
@@ -166,8 +166,9 @@ TEST_CASE("view.access")
         CHECK(&x == &view(pos)(tag::Pos{}, tag::X{}));
 
         // also test arrays
+        using namespace llama::literals;
         const bool& o0 = view(pos)(tag::Flags{})(llama::DatumCoord<0>{});
-        CHECK(&o0 == &view(pos)(tag::Flags{})(llama::Index<0>{}));
+        CHECK(&o0 == &view(pos)(tag::Flags{})(0_DC));
     };
     l(view);
     l(std::as_const(view));
@@ -175,6 +176,8 @@ TEST_CASE("view.access")
 
 TEST_CASE("view.assign-one-datum")
 {
+    using namespace llama::literals;
+
     using ArrayDomain = llama::ArrayDomain<2>;
     ArrayDomain arrayDomain{16, 16};
 
@@ -188,10 +191,10 @@ TEST_CASE("view.assign-one-datum")
     datum(tag::Pos{}, tag::Z{}) = 16.0f;
     datum(tag::Momentum{}) = 0;
     datum(tag::Weight{}) = 500.0f;
-    datum(tag::Flags{})(llama::Index<0>{}) = true;
-    datum(tag::Flags{})(llama::Index<1>{}) = false;
-    datum(tag::Flags{})(llama::Index<2>{}) = true;
-    datum(tag::Flags{})(llama::Index<3>{}) = false;
+    datum(tag::Flags{})(0_DC) = true;
+    datum(tag::Flags{})(1_DC) = false;
+    datum(tag::Flags{})(2_DC) = true;
+    datum(tag::Flags{})(3_DC) = false;
 
     view({3, 4}) = datum;
 
@@ -202,14 +205,16 @@ TEST_CASE("view.assign-one-datum")
     CHECK(datum(tag::Momentum{}, tag::Y{}) == 0);
     CHECK(datum(tag::Momentum{}, tag::Z{}) == 0);
     CHECK(datum(tag::Weight{}) == 500.0f);
-    CHECK(datum(tag::Flags{})(llama::Index<0>{}) == true);
-    CHECK(datum(tag::Flags{})(llama::Index<1>{}) == false);
-    CHECK(datum(tag::Flags{})(llama::Index<2>{}) == true);
-    CHECK(datum(tag::Flags{})(llama::Index<3>{}) == false);
+    CHECK(datum(tag::Flags{})(0_DC) == true);
+    CHECK(datum(tag::Flags{})(1_DC) == false);
+    CHECK(datum(tag::Flags{})(2_DC) == true);
+    CHECK(datum(tag::Flags{})(3_DC) == false);
 }
 
 TEST_CASE("view.addresses")
 {
+    using namespace llama::literals;
+
     using ArrayDomain = llama::ArrayDomain<2>;
     ArrayDomain arrayDomain{16, 16};
 
@@ -225,10 +230,10 @@ TEST_CASE("view.addresses")
     auto& mx = view(pos)(tag::Momentum{}, tag::X{});
     auto& my = view(pos)(tag::Momentum{}, tag::Y{});
     auto& mz = view(pos)(tag::Momentum{}, tag::Z{});
-    auto& o0 = view(pos)(tag::Flags{})(llama::Index<0>{});
-    auto& o1 = view(pos)(tag::Flags{})(llama::Index<1>{});
-    auto& o2 = view(pos)(tag::Flags{})(llama::Index<2>{});
-    auto& o3 = view(pos)(tag::Flags{})(llama::Index<3>{});
+    auto& o0 = view(pos)(tag::Flags{})(0_DC);
+    auto& o1 = view(pos)(tag::Flags{})(1_DC);
+    auto& o2 = view(pos)(tag::Flags{})(2_DC);
+    auto& o3 = view(pos)(tag::Flags{})(3_DC);
 
     CHECK((size_t) &y - (size_t) &x == 2048);
     CHECK((size_t) &z - (size_t) &x == 4096);


### PR DESCRIPTION
* Remove `llama::Index<I>`
* Add a literal operator `_DT` that creates a DatumCoord. E.g. `17_DC` is an instance of `llama::DatumCoord<17>`.