### PR TITLE
Add concept StorageBlob

### DIFF
--- a/include/llama/Allocators.hpp
+++ b/include/llama/Allocators.hpp
@@ -4,6 +4,7 @@
 #pragma once
 
 #include "Array.hpp"
+#include "Concepts.hpp"
 #include "macros.hpp"
 
 #include <cstddef>
@@ -26,6 +27,9 @@ namespace llama::allocator
             return {};
         }
     };
+#ifdef __cpp_concepts
+    static_assert(StorageBlob<decltype(Stack<64>{}(0))>);
+#endif
 
     /// Allocates heap memory managed by a `std::shared_ptr` for a \ref View.
     /// This memory is shared between all copies of a \ref View.
@@ -41,6 +45,9 @@ namespace llama::allocator
             return std::shared_ptr<std::byte[]>{ptr, deleter};
         }
     };
+#ifdef __cpp_concepts
+    static_assert(StorageBlob<decltype(SharedPtr{}(0))>);
+#endif
 
     template <typename T, std::size_t Alignment>
     struct AlignedAllocator
@@ -94,4 +101,7 @@ namespace llama::allocator
             return std::vector<std::byte, AlignedAllocator<std::byte, Alignment>>(count);
         }
     };
+#ifdef __cpp_concepts
+    static_assert(StorageBlob<decltype(Vector{}(0))>);
+#endif
 } // namespace llama::allocator

--- a/include/llama/Concepts.hpp
+++ b/include/llama/Concepts.hpp
@@ -5,6 +5,7 @@
 #    include "Core.hpp"
 
 #    include <concepts>
+#    include <type_traits>
 
 namespace llama
 {
@@ -18,6 +19,14 @@ namespace llama
         { m.getBlobNrAndOffset(typename M::ArrayDomain{}) } -> std::same_as<NrAndOffset>;
     };
     // clang-format on
+
+    template <typename B>
+    concept StorageBlob = requires(B b, std::size_t i)
+    {
+        // according to http://eel.is/c++draft/intro.object#3 only std::byte and unsigned char can provide storage for
+        // other types
+        std::is_same_v<decltype(b[i]), std::byte&> || std::is_same_v<decltype(b[i]), unsigned char&>;
+    };
 } // namespace llama
 
 #endif

--- a/include/llama/View.hpp
+++ b/include/llama/View.hpp
@@ -5,6 +5,7 @@
 
 #include "Allocators.hpp"
 #include "Array.hpp"
+#include "Concepts.hpp"
 #include "Core.hpp"
 #include "macros.hpp"
 #include "mapping/One.hpp"
@@ -14,7 +15,11 @@
 
 namespace llama
 {
-    template <typename Mapping, typename BlobType>
+#ifdef __cpp_concepts
+    template <typename T_Mapping, StorageBlob BlobType>
+#else
+    template <typename T_Mapping, typename BlobType>
+#endif
     struct View;
 
     namespace internal
@@ -681,7 +686,11 @@ namespace llama
     /// memory.
     /// \tparam BlobType The storage type used by the view holding
     /// memory.
+#ifdef __cpp_concepts
+    template <typename T_Mapping, StorageBlob BlobType>
+#else
     template <typename T_Mapping, typename BlobType>
+#endif
     struct View
     {
         using Mapping = T_Mapping;


### PR DESCRIPTION
Add concept StorageBlob and assert that View and allocators satisfy it.

This concept demands a StorageBlob type to support bytewise subscription.
For a StorageBlob `b` and a `size_t i` the expression `b[i]` must yield an lvalue reference to `std::byte` or `unsigned char`.

Practically, this allows raw pointers to bytes, arrays of bytes, `std::vector`, smart pointers, pointers retrieved from alpaka or CUDA buffers, SYCL accessors, ... as storage blobs for a LLAMA View.

@j-stephan 