### PR TITLE
Rename forEach into forEachLeave

### DIFF
--- a/examples/simpletest/simpletest.cpp
+++ b/examples/simpletest/simpletest.cpp
@@ -118,7 +118,7 @@ namespace
     }
 } // namespace
 
-/// Example functor for \ref llama::forEach which can also be used to print the
+/// Example functor for \ref llama::forEachLeave which can also be used to print the
 /// coordinates inside of a datum domain when called.
 template <typename VirtualDatum>
 struct SetZeroFunctor
@@ -190,10 +190,10 @@ int main(int argc, char** argv)
         SetZeroFunctor<decltype(view(x, y))> szf{view(x, y)};
         // Applying the functor for the sub tree 0,0 (pos.x), so basically
         // only for this element
-        llama::forEach<Name>(szf, llama::DatumCoord<0, 0>{});
+        llama::forEachLeave<Name>(szf, llama::DatumCoord<0, 0>{});
         // Applying the functor for the sub tree momentum (0), so basically
         // for momentum.z, and momentum.x
-        llama::forEach<Name>(szf, st::Momentum{});
+        llama::forEachLeave<Name>(szf, st::Momentum{});
         // the user domain address can be given as multiple comma separated
         // arguments or as one parameter of type user domain
         view({x, y}) = double(x + y) / double(udSize[0] + udSize[1]);

--- a/examples/viewcopy/viewcopy.cpp
+++ b/examples/viewcopy/viewcopy.cpp
@@ -53,7 +53,7 @@ void naive_copy(const llama::View<Mapping1, BlobType1>& srcView, llama::View<Map
 
     auto r = llama::ArrayDomainIndexRange{srcView.mapping.arrayDomainSize};
     std::for_each(ex, std::begin(r), std::end(r), [&](auto ad) {
-        llama::forEach<typename Mapping1::DatumDomain>([&](auto coord) {
+        llama::forEachLeave<typename Mapping1::DatumDomain>([&](auto coord) {
             dstView(ad)(coord) = srcView(ad)(coord);
             // std::memcpy(
             //    &dstView(ad)(coord),
@@ -138,7 +138,7 @@ void aosoa_copy(
 
             for (std::size_t i = start; i < stop; i += LanesSrc)
             {
-                llama::forEach<DatumDomain>([&](auto coord) {
+                llama::forEachLeave<DatumDomain>([&](auto coord) {
                     constexpr auto L = std::min(LanesSrc, LanesDst);
                     for (std::size_t j = 0; j < LanesSrc; j += L)
                     {
@@ -162,7 +162,7 @@ void aosoa_copy(
 
             for (std::size_t i = start; i < stop; i += LanesDst)
             {
-                llama::forEach<DatumDomain>([&](auto coord) {
+                llama::forEachLeave<DatumDomain>([&](auto coord) {
                     constexpr auto L = std::min(LanesSrc, LanesDst);
                     for (std::size_t j = 0; j < LanesDst; j += L)
                     {
@@ -181,7 +181,7 @@ auto hash(const llama::View<Mapping, BlobType>& view)
 {
     std::size_t acc = 0;
     for (auto ad : llama::ArrayDomainIndexRange{view.mapping.arrayDomainSize})
-        llama::forEach<Particle>([&](auto coord) { boost::hash_combine(acc, view(ad)(coord)); });
+        llama::forEachLeave<Particle>([&](auto coord) { boost::hash_combine(acc, view(ad)(coord)); });
     return acc;
 }
 template <typename Mapping>

--- a/include/llama/DumpMapping.hpp
+++ b/include/llama/DumpMapping.hpp
@@ -99,7 +99,7 @@ namespace llama
 
         for (auto udCoord : ArrayDomainIndexRange{mapping.arrayDomainSize})
         {
-            forEach<DatumDomain>([&](auto coord) {
+            forEachLeave<DatumDomain>([&](auto coord) {
                 constexpr int size = sizeof(GetType<DatumDomain, decltype(coord)>);
                 infos.push_back(DatumInfo{
                     udCoord,
@@ -218,7 +218,7 @@ namespace llama
 
         for (auto udCoord : ArrayDomainIndexRange{mapping.arrayDomainSize})
         {
-            forEach<DatumDomain>([&](auto coord) {
+            forEachLeave<DatumDomain>([&](auto coord) {
                 constexpr int size = sizeof(GetType<DatumDomain, decltype(coord)>);
                 infos.push_back(DatumInfo{
                     udCoord,
@@ -299,7 +299,7 @@ namespace llama
 }}
 )",
             byteSizeInPixel);
-        forEach<DatumDomain>([&](auto coord) {
+        forEachLeave<DatumDomain>([&](auto coord) {
             constexpr int size = sizeof(GetType<DatumDomain, decltype(coord)>);
 
             svg += fmt::format(

--- a/include/llama/Proofs.hpp
+++ b/include/llama/Proofs.hpp
@@ -69,7 +69,7 @@ namespace llama
         };
 
         bool collision = false;
-        llama::forEach<typename Mapping::DatumDomain>([&](auto coord) constexpr {
+        llama::forEachLeave<typename Mapping::DatumDomain>([&](auto coord) constexpr {
             if (collision)
                 return;
             for (auto ad : llama::ArrayDomainIndexRange{m.arrayDomainSize})

--- a/include/llama/View.hpp
+++ b/include/llama/View.hpp
@@ -99,9 +99,9 @@ namespace llama
             const VirtualDatum<RightView, RightBoundDatumDomain, RightOwnView>& right) -> LeftDatum&
         {
             using RightDatum = VirtualDatum<RightView, RightBoundDatumDomain, RightOwnView>;
-            forEach<typename LeftDatum::AccessibleDatumDomain>([&](auto leftCoord) {
+            forEachLeave<typename LeftDatum::AccessibleDatumDomain>([&](auto leftCoord) {
                 using LeftInnerCoord = decltype(leftCoord);
-                forEach<typename RightDatum::AccessibleDatumDomain>([&](auto rightCoord) {
+                forEachLeave<typename RightDatum::AccessibleDatumDomain>([&](auto rightCoord) {
                     using RightInnerCoord = decltype(rightCoord);
                     if constexpr (hasSameTags<
                                       typename LeftDatum::AccessibleDatumDomain,
@@ -119,7 +119,7 @@ namespace llama
         template <typename Functor, typename LeftDatum, typename T>
         LLAMA_FN_HOST_ACC_INLINE auto virtualDatumArithOperator(LeftDatum& left, const T& right) -> LeftDatum&
         {
-            forEach<typename LeftDatum::AccessibleDatumDomain>(
+            forEachLeave<typename LeftDatum::AccessibleDatumDomain>(
                 [&](auto leftCoord) { Functor{}(left(leftCoord), right); });
             return left;
         }
@@ -136,9 +136,9 @@ namespace llama
         {
             using RightDatum = VirtualDatum<RightView, RightBoundDatumDomain, RightOwnView>;
             bool result = true;
-            forEach<typename LeftDatum::AccessibleDatumDomain>([&](auto leftCoord) {
+            forEachLeave<typename LeftDatum::AccessibleDatumDomain>([&](auto leftCoord) {
                 using LeftInnerCoord = decltype(leftCoord);
-                forEach<typename RightDatum::AccessibleDatumDomain>([&](auto rightCoord) {
+                forEachLeave<typename RightDatum::AccessibleDatumDomain>([&](auto rightCoord) {
                     using RightInnerCoord = decltype(rightCoord);
                     if constexpr (hasSameTags<
                                       typename LeftDatum::AccessibleDatumDomain,
@@ -157,7 +157,7 @@ namespace llama
         LLAMA_FN_HOST_ACC_INLINE auto virtualDatumRelOperator(const LeftDatum& left, const T& right) -> bool
         {
             bool result = true;
-            forEach<typename LeftDatum::AccessibleDatumDomain>([&](auto leftCoord) {
+            forEachLeave<typename LeftDatum::AccessibleDatumDomain>([&](auto leftCoord) {
                 result &= Functor{}(
                     left(leftCoord),
                     static_cast<std::remove_reference_t<decltype(left(leftCoord))>>(right));

--- a/include/llama/mapping/SoA.hpp
+++ b/include/llama/mapping/SoA.hpp
@@ -27,7 +27,7 @@ namespace llama::mapping
             if constexpr (SeparateBuffers::value)
             {
                 std::size_t count = 0;
-                forEach<DatumDomain>([&](auto) constexpr { count++; });
+                forEachLeave<DatumDomain>([&](auto) constexpr { count++; });
                 return count;
             }
             else
@@ -51,7 +51,7 @@ namespace llama::mapping
                 {
                     llama::Array<std::size_t, blobCount> r{};
                     std::size_t i = 0;
-                    forEach<DatumDomain>([&](auto coord) constexpr {
+                    forEachLeave<DatumDomain>([&](auto coord) constexpr {
                         r[i++] = sizeof(GetType<DatumDomain, decltype(coord)>);
                     });
                     return r;
@@ -73,7 +73,7 @@ namespace llama::mapping
                 {
                     std::size_t index = 0;
                     bool found = false;
-                    forEach<DatumDomain>([&](auto c) constexpr {
+                    forEachLeave<DatumDomain>([&](auto c) constexpr {
                         if constexpr (std::is_same_v<decltype(c), TargetDatumCoord>)
                             found = true;
                         else if (!found)

--- a/include/llama/mapping/Trace.hpp
+++ b/include/llama/mapping/Trace.hpp
@@ -43,7 +43,7 @@ namespace llama::mapping
         LLAMA_FN_HOST_ACC_INLINE
         Trace(Mapping mapping) : mapping(mapping)
         {
-            forEach<DatumDomain>([&](auto coord) { datumHits[internal::coordName<DatumDomain>(coord)] = 0; });
+            forEachLeave<DatumDomain>([&](auto coord) { datumHits[internal::coordName<DatumDomain>(coord)] = 0; });
         }
 
         Trace(const Trace&) = delete;

--- a/tests/treemap.cpp
+++ b/tests/treemap.cpp
@@ -1061,7 +1061,7 @@ TEST_CASE("treemapping")
         for (size_t y = 0; y < arrayDomain[1]; ++y)
         {
             auto datum = view(x, y);
-            llama::forEach<Name>([&](auto coord) { datum(coord) = 0; }, tag::Momentum{});
+            llama::forEachLeave<Name>([&](auto coord) { datum(coord) = 0; }, tag::Momentum{});
         }
     double sum = 0.0;
     for (size_t x = 0; x < arrayDomain[0]; ++x)

--- a/tests/view.cpp
+++ b/tests/view.cpp
@@ -273,8 +273,8 @@ TEST_CASE("view.iteration-and-access")
         for (size_t y = 0; y < arrayDomain[1]; ++y)
         {
             SetZeroFunctor<decltype(view(x, y))> szf{view(x, y)};
-            llama::forEach<Particle>(szf, llama::DatumCoord<0, 0>{});
-            llama::forEach<Particle>(szf, tag::Momentum{});
+            llama::forEachLeave<Particle>(szf, llama::DatumCoord<0, 0>{});
+            llama::forEachLeave<Particle>(szf, tag::Momentum{});
             view({x, y}) = double(x + y) / double(arrayDomain[0] + arrayDomain[1]);
         }
 

--- a/tests/virtualview.cpp
+++ b/tests/virtualview.cpp
@@ -106,7 +106,7 @@ TEST_CASE("virtual view")
                 for (std::size_t b = 0; b < validMiniSize[1]; ++b)
                 {
                     SqrtFunctor<decltype(miniView(a, b))> sqrtF{miniView(a, b)};
-                    llama::forEach<Particle>(sqrtF);
+                    llama::forEachLeave<Particle>(sqrtF);
                 }
 
             for (std::size_t a = 0; a < validMiniSize[0]; ++a)


### PR DESCRIPTION
The current `forEach` iterates just over the datum domain. LLAMA is likely going to need a foreach algorithm in the future that iterates over all values accessible via a view. Or expresses something to be done on all elements. So I would like to free up the name `forEach`, or `foreach`, for this algorithm.