### PR TITLE
Extend sizeOf<> and offsetOf<> to support alignment and padding

### DIFF
--- a/include/llama/mapping/AoS.hpp
+++ b/include/llama/mapping/AoS.hpp
@@ -8,12 +8,14 @@
 namespace llama::mapping
 {
     /// Array of struct mapping. Used to create a \ref View via \ref allocView.
-    /// \tparam LinearizeArrayDomainFunctor Defines how the
-    /// user domain should be mapped into linear numbers and how big the linear
-    /// domain gets.
+    /// \tparam AlignAndPad If true, padding bytes are inserted to guarantee that struct members are properly aligned.
+    /// If false, struct members are tighly packed.
+    /// \tparam LinearizeArrayDomainFunctor Defines how the user domain
+    /// should be mapped into linear numbers and how big the linear domain gets.
     template <
         typename T_ArrayDomain,
         typename T_DatumDomain,
+        bool AlignAndPad = false,
         typename LinearizeArrayDomainFunctor = LinearizeArrayDomainCpp>
     struct AoS
     {
@@ -30,7 +32,7 @@ namespace llama::mapping
 
         LLAMA_FN_HOST_ACC_INLINE constexpr auto getBlobSize(std::size_t) const -> std::size_t
         {
-            return LinearizeArrayDomainFunctor{}.size(arrayDomainSize) * sizeOf<DatumDomain>;
+            return LinearizeArrayDomainFunctor{}.size(arrayDomainSize) * sizeOf<DatumDomain, AlignAndPad>;
         }
 
         template <std::size_t... DatumDomainCoord>
@@ -38,10 +40,30 @@ namespace llama::mapping
         {
             LLAMA_FORCE_INLINE_RECURSIVE
             const auto offset = LinearizeArrayDomainFunctor{}(coord, arrayDomainSize)
-                    * sizeOf<DatumDomain> + offsetOf<DatumDomain, DatumCoord<DatumDomainCoord...>>;
+                    * sizeOf<DatumDomain,
+                             AlignAndPad> + offsetOf<DatumDomain, DatumCoord<DatumDomainCoord...>, AlignAndPad>;
             return {0, offset};
         }
 
         ArrayDomain arrayDomainSize;
+    };
+
+    template <
+        typename ArrayDomain,
+        typename DatumDomain,
+        typename LinearizeArrayDomainFunctor = LinearizeArrayDomainCpp>
+    using AlignedAoS = AoS<ArrayDomain, DatumDomain, true, LinearizeArrayDomainFunctor>;
+
+    template <
+        typename ArrayDomain,
+        typename DatumDomain,
+        typename LinearizeArrayDomainFunctor = LinearizeArrayDomainCpp>
+    using PackedAoS = AoS<ArrayDomain, DatumDomain, false, LinearizeArrayDomainFunctor>;
+
+    template <bool AlignAndPad = false, typename LinearizeArrayDomainFunctor = LinearizeArrayDomainCpp>
+    struct PreconfiguredAoS
+    {
+        template <typename ArrayDomain, typename DatumDomain>
+        using type = AoS<ArrayDomain, DatumDomain, AlignAndPad, LinearizeArrayDomainFunctor>;
     };
 } // namespace llama::mapping

--- a/tests/core.cpp
+++ b/tests/core.cpp
@@ -15,12 +15,13 @@ namespace tag
     struct Weight {};
 }
 
+using XYZ = llama::DS<
+    llama::DE<tag::X, double>,
+    llama::DE<tag::Y, double>,
+    llama::DE<tag::Z, double>
+>;
 using Particle = llama::DS<
-    llama::DE<tag::Pos, llama::DS<
-        llama::DE<tag::X, double>,
-        llama::DE<tag::Y, double>,
-        llama::DE<tag::Z, double>
-    >>,
+    llama::DE<tag::Pos, XYZ>,
     llama::DE<tag::Weight, float>,
     llama::DE<llama::NoName, int>,
     llama::DE<tag::Vel,llama::DS<
@@ -117,11 +118,15 @@ TEST_CASE("prettyPrintType")
 
 TEST_CASE("sizeOf")
 {
+    STATIC_REQUIRE(llama::sizeOf<float> == 4);
+    STATIC_REQUIRE(llama::sizeOf<XYZ> == 24);
     STATIC_REQUIRE(llama::sizeOf<Particle> == 52);
 }
 
 TEST_CASE("sizeOf.Align")
 {
+    STATIC_REQUIRE(llama::sizeOf<float, true> == 4);
+    STATIC_REQUIRE(llama::sizeOf<XYZ, true> == 24);
     STATIC_REQUIRE(llama::sizeOf<Particle, true> == 56);
 }
 
@@ -163,6 +168,9 @@ TEST_CASE("offsetOf.Align")
     STATIC_REQUIRE(llama::offsetOf<Particle, llama::DatumCoord<4, 3>, true> == 51);
 }
 
+template <int i>
+struct S;
+
 TEST_CASE("alignment")
 {
     using DD = llama::DS<
@@ -183,7 +191,7 @@ TEST_CASE("alignment")
     STATIC_REQUIRE(llama::offsetOf<DD, llama::DatumCoord<1>, true> == 8); // aligned
     STATIC_REQUIRE(llama::offsetOf<DD, llama::DatumCoord<2>, true> == 16);
     STATIC_REQUIRE(llama::offsetOf<DD, llama::DatumCoord<3>, true> == 18); // aligned
-    STATIC_REQUIRE(llama::sizeOf<DD, true> == 24);
+    STATIC_REQUIRE(llama::sizeOf<DD, true> == 20);
 }
 
 TEST_CASE("GetCoordFromTags")

--- a/tests/core.cpp
+++ b/tests/core.cpp
@@ -119,6 +119,12 @@ TEST_CASE("sizeOf")
 {
     STATIC_REQUIRE(llama::sizeOf<Particle> == 52);
 }
+
+TEST_CASE("sizeOf.Align")
+{
+    STATIC_REQUIRE(llama::sizeOf<Particle, true> == 56);
+}
+
 TEST_CASE("offsetOf")
 {
     STATIC_REQUIRE(llama::offsetOf<Particle, llama::DatumCoord<>> == 0);
@@ -136,6 +142,48 @@ TEST_CASE("offsetOf")
     STATIC_REQUIRE(llama::offsetOf<Particle, llama::DatumCoord<4, 1>> == 49);
     STATIC_REQUIRE(llama::offsetOf<Particle, llama::DatumCoord<4, 2>> == 50);
     STATIC_REQUIRE(llama::offsetOf<Particle, llama::DatumCoord<4, 3>> == 51);
+}
+
+TEST_CASE("offsetOf.Align")
+{
+    STATIC_REQUIRE(llama::offsetOf<Particle, llama::DatumCoord<>, true> == 0);
+    STATIC_REQUIRE(llama::offsetOf<Particle, llama::DatumCoord<0>, true> == 0);
+    STATIC_REQUIRE(llama::offsetOf<Particle, llama::DatumCoord<0, 0>, true> == 0);
+    STATIC_REQUIRE(llama::offsetOf<Particle, llama::DatumCoord<0, 1>, true> == 8);
+    STATIC_REQUIRE(llama::offsetOf<Particle, llama::DatumCoord<0, 2>, true> == 16);
+    STATIC_REQUIRE(llama::offsetOf<Particle, llama::DatumCoord<1>, true> == 24);
+    STATIC_REQUIRE(llama::offsetOf<Particle, llama::DatumCoord<2>, true> == 28);
+    STATIC_REQUIRE(llama::offsetOf<Particle, llama::DatumCoord<3>, true> == 32);
+    STATIC_REQUIRE(llama::offsetOf<Particle, llama::DatumCoord<3, 0>, true> == 32);
+    STATIC_REQUIRE(llama::offsetOf<Particle, llama::DatumCoord<3, 1>, true> == 40);
+    STATIC_REQUIRE(llama::offsetOf<Particle, llama::DatumCoord<4>, true> == 48);
+    STATIC_REQUIRE(llama::offsetOf<Particle, llama::DatumCoord<4, 0>, true> == 48);
+    STATIC_REQUIRE(llama::offsetOf<Particle, llama::DatumCoord<4, 1>, true> == 49);
+    STATIC_REQUIRE(llama::offsetOf<Particle, llama::DatumCoord<4, 2>, true> == 50);
+    STATIC_REQUIRE(llama::offsetOf<Particle, llama::DatumCoord<4, 3>, true> == 51);
+}
+
+TEST_CASE("alignment")
+{
+    using DD = llama::DS<
+        llama::DE<tag::X, float>,
+        llama::DE<tag::Y, double>,
+        llama::DE<tag::Z, bool>,
+        llama::DE<tag::Weight, std::uint16_t>>;
+
+    STATIC_REQUIRE(llama::offsetOf<DD, llama::DatumCoord<>, false> == 0);
+    STATIC_REQUIRE(llama::offsetOf<DD, llama::DatumCoord<0>, false> == 0);
+    STATIC_REQUIRE(llama::offsetOf<DD, llama::DatumCoord<1>, false> == 4);
+    STATIC_REQUIRE(llama::offsetOf<DD, llama::DatumCoord<2>, false> == 12);
+    STATIC_REQUIRE(llama::offsetOf<DD, llama::DatumCoord<3>, false> == 13);
+    STATIC_REQUIRE(llama::sizeOf<DD, false> == 15);
+
+    STATIC_REQUIRE(llama::offsetOf<DD, llama::DatumCoord<>, true> == 0);
+    STATIC_REQUIRE(llama::offsetOf<DD, llama::DatumCoord<0>, true> == 0);
+    STATIC_REQUIRE(llama::offsetOf<DD, llama::DatumCoord<1>, true> == 8); // aligned
+    STATIC_REQUIRE(llama::offsetOf<DD, llama::DatumCoord<2>, true> == 16);
+    STATIC_REQUIRE(llama::offsetOf<DD, llama::DatumCoord<3>, true> == 18); // aligned
+    STATIC_REQUIRE(llama::sizeOf<DD, true> == 24);
 }
 
 TEST_CASE("GetCoordFromTags")

--- a/tests/dump.cpp
+++ b/tests/dump.cpp
@@ -163,12 +163,17 @@ TEST_CASE("dump.Split.AoSoA8.AoS.One.SoA.4Buffer")
         "Split.AoSoA8.AoS.One.SoA.4Buffer");
 }
 
-TEST_CASE("dump.AoS.Weird")
+TEST_CASE("dump.AoS.Unaligned")
 {
-    dump(llama::mapping::AoS{arrayDomain, ParticleUnaligned{}}, "AoS.Weird");
+    dump(llama::mapping::AoS{arrayDomain, ParticleUnaligned{}}, "AoS.Unaligned");
 }
 
-TEST_CASE("dump.AoS.WeirdExplicitAlignment")
+TEST_CASE("dump.AoS.Aligned")
 {
-    dump(llama::mapping::AoS{arrayDomain, ParticleAligned{}}, "AoS.WeirdExplicitAlignment");
+    dump(llama::mapping::AoS<decltype(arrayDomain), ParticleUnaligned, true>{arrayDomain}, "AoS.Aligned");
+}
+
+TEST_CASE("dump.AoS.AlignedExplicit")
+{
+    dump(llama::mapping::AoS{arrayDomain, ParticleAligned{}}, "AoS.AlignedExplicit");
 }

--- a/tests/dump.cpp
+++ b/tests/dump.cpp
@@ -111,8 +111,9 @@ TEST_CASE("dump.Split.SoA.AoS.1Buffer")
 {
     // split out velocity (written in nbody, the rest is read)
     dump(
-        llama::mapping::Split<ArrayDomain, Particle, llama::DatumCoord<1>, llama::mapping::SoA, llama::mapping::AoS>{
-            arrayDomain},
+        llama::mapping::
+            Split<ArrayDomain, Particle, llama::DatumCoord<1>, llama::mapping::SoA, llama::mapping::PackedAoS>{
+                arrayDomain},
         "Split.SoA.AoS.1Buffer");
 }
 
@@ -121,7 +122,7 @@ TEST_CASE("dump.Split.SoA.AoS.2Buffer")
     // split out velocity as AoS into separate buffer
     dump(
         llama::mapping::
-            Split<ArrayDomain, Particle, llama::DatumCoord<1>, llama::mapping::SoA, llama::mapping::AoS, true>{
+            Split<ArrayDomain, Particle, llama::DatumCoord<1>, llama::mapping::SoA, llama::mapping::PackedAoS, true>{
                 arrayDomain},
         "Split.SoA.AoS.2Buffer");
 }
@@ -135,8 +136,8 @@ TEST_CASE("dump.Split.AoSoA8.AoS.One.3Buffer")
             Particle,
             llama::DatumCoord<1>,
             llama::mapping::PreconfiguredAoSoA<8>::type,
-            llama::mapping::PreconfiguredSplit<llama::DatumCoord<1>, llama::mapping::One, llama::mapping::AoS, true>::
-                type,
+            llama::mapping::
+                PreconfiguredSplit<llama::DatumCoord<1>, llama::mapping::One, llama::mapping::PackedAoS, true>::type,
             true>{arrayDomain},
         "Split.AoSoA8.SoA.One.3Buffer");
 }
@@ -155,7 +156,8 @@ TEST_CASE("dump.Split.AoSoA8.AoS.One.SoA.4Buffer")
                 llama::DatumCoord<1>,
                 llama::mapping::One,
                 llama::mapping::
-                    PreconfiguredSplit<llama::DatumCoord<0>, llama::mapping::AoS, llama::mapping::SoA, true>::type,
+                    PreconfiguredSplit<llama::DatumCoord<0>, llama::mapping::PackedAoS, llama::mapping::SoA, true>::
+                        type,
                 true>::type,
             true>{arrayDomain},
         "Split.AoSoA8.AoS.One.SoA.4Buffer");

--- a/tests/mapping.cpp
+++ b/tests/mapping.cpp
@@ -98,7 +98,8 @@ TEST_CASE("address.AoS.fortran")
 {
     using ArrayDomain = llama::ArrayDomain<2>;
     auto arrayDomain = ArrayDomain{16, 16};
-    auto mapping = llama::mapping::AoS<ArrayDomain, Particle, llama::mapping::LinearizeArrayDomainFortran>{arrayDomain};
+    auto mapping
+        = llama::mapping::AoS<ArrayDomain, Particle, false, llama::mapping::LinearizeArrayDomainFortran>{arrayDomain};
 
     {
         const auto coord = ArrayDomain{0, 0};
@@ -150,7 +151,8 @@ TEST_CASE("address.AoS.morton")
 {
     using ArrayDomain = llama::ArrayDomain<2>;
     auto arrayDomain = ArrayDomain{16, 16};
-    auto mapping = llama::mapping::AoS<ArrayDomain, Particle, llama::mapping::LinearizeArrayDomainMorton>{arrayDomain};
+    auto mapping
+        = llama::mapping::AoS<ArrayDomain, Particle, false, llama::mapping::LinearizeArrayDomainMorton>{arrayDomain};
 
     {
         const auto coord = ArrayDomain{0, 0};
@@ -195,6 +197,58 @@ TEST_CASE("address.AoS.morton")
         CHECK(mapping.getBlobNrAndOffset<3, 1>(coord).offset == 165);
         CHECK(mapping.getBlobNrAndOffset<3, 2>(coord).offset == 166);
         CHECK(mapping.getBlobNrAndOffset<3, 3>(coord).offset == 167);
+    }
+}
+
+TEST_CASE("address.AoS.aligned")
+{
+    using ArrayDomain = llama::ArrayDomain<2>;
+    auto arrayDomain = ArrayDomain{16, 16};
+    auto mapping = llama::mapping::AoS<ArrayDomain, Particle, true>{arrayDomain};
+
+    {
+        const auto coord = ArrayDomain{0, 0};
+        CHECK(mapping.getBlobNrAndOffset<0, 0>(coord).offset == 0);
+        CHECK(mapping.getBlobNrAndOffset<0, 1>(coord).offset == 8);
+        CHECK(mapping.getBlobNrAndOffset<0, 2>(coord).offset == 16);
+        CHECK(mapping.getBlobNrAndOffset<1>(coord).offset == 24);
+        CHECK(mapping.getBlobNrAndOffset<2, 0>(coord).offset == 32);
+        CHECK(mapping.getBlobNrAndOffset<2, 1>(coord).offset == 40);
+        CHECK(mapping.getBlobNrAndOffset<2, 2>(coord).offset == 48);
+        CHECK(mapping.getBlobNrAndOffset<3, 0>(coord).offset == 56);
+        CHECK(mapping.getBlobNrAndOffset<3, 1>(coord).offset == 57);
+        CHECK(mapping.getBlobNrAndOffset<3, 2>(coord).offset == 58);
+        CHECK(mapping.getBlobNrAndOffset<3, 3>(coord).offset == 59);
+    }
+
+    {
+        const auto coord = ArrayDomain{0, 1};
+        CHECK(mapping.getBlobNrAndOffset<0, 0>(coord).offset == 64);
+        CHECK(mapping.getBlobNrAndOffset<0, 1>(coord).offset == 72);
+        CHECK(mapping.getBlobNrAndOffset<0, 2>(coord).offset == 80);
+        CHECK(mapping.getBlobNrAndOffset<1>(coord).offset == 88);
+        CHECK(mapping.getBlobNrAndOffset<2, 0>(coord).offset == 96);
+        CHECK(mapping.getBlobNrAndOffset<2, 1>(coord).offset == 104);
+        CHECK(mapping.getBlobNrAndOffset<2, 2>(coord).offset == 112);
+        CHECK(mapping.getBlobNrAndOffset<3, 0>(coord).offset == 120);
+        CHECK(mapping.getBlobNrAndOffset<3, 1>(coord).offset == 121);
+        CHECK(mapping.getBlobNrAndOffset<3, 2>(coord).offset == 122);
+        CHECK(mapping.getBlobNrAndOffset<3, 3>(coord).offset == 123);
+    }
+
+    {
+        const auto coord = ArrayDomain{1, 0};
+        CHECK(mapping.getBlobNrAndOffset<0, 0>(coord).offset == 1024);
+        CHECK(mapping.getBlobNrAndOffset<0, 1>(coord).offset == 1032);
+        CHECK(mapping.getBlobNrAndOffset<0, 2>(coord).offset == 1040);
+        CHECK(mapping.getBlobNrAndOffset<1>(coord).offset == 1048);
+        CHECK(mapping.getBlobNrAndOffset<2, 0>(coord).offset == 1056);
+        CHECK(mapping.getBlobNrAndOffset<2, 1>(coord).offset == 1064);
+        CHECK(mapping.getBlobNrAndOffset<2, 2>(coord).offset == 1072);
+        CHECK(mapping.getBlobNrAndOffset<3, 0>(coord).offset == 1080);
+        CHECK(mapping.getBlobNrAndOffset<3, 1>(coord).offset == 1081);
+        CHECK(mapping.getBlobNrAndOffset<3, 2>(coord).offset == 1082);
+        CHECK(mapping.getBlobNrAndOffset<3, 3>(coord).offset == 1083);
     }
 }
 

--- a/tests/splitmapping.cpp
+++ b/tests/splitmapping.cpp
@@ -39,9 +39,8 @@ TEST_CASE("Split.SoA.AoS.1Buffer")
     auto arrayDomain = ArrayDomain{16, 16};
 
     // we layout Pos as SoA, the rest as AoS
-    auto mapping
-        = llama::mapping::Split<ArrayDomain, Particle, llama::DatumCoord<0>, llama::mapping::SoA, llama::mapping::AoS>{
-            arrayDomain};
+    auto mapping = llama::mapping::
+        Split<ArrayDomain, Particle, llama::DatumCoord<0>, llama::mapping::SoA, llama::mapping::PackedAoS>{arrayDomain};
 
     constexpr auto mapping1Size = 6120;
     const auto coord = ArrayDomain{0, 0};
@@ -72,8 +71,8 @@ TEST_CASE("Split.AoSoA8.AoS.One.SoA.4Buffer")
         llama::mapping::PreconfiguredSplit<
             llama::DatumCoord<1>,
             llama::mapping::One,
-            llama::mapping::PreconfiguredSplit<llama::DatumCoord<0>, llama::mapping::AoS, llama::mapping::SoA, true>::
-                type,
+            llama::mapping::
+                PreconfiguredSplit<llama::DatumCoord<0>, llama::mapping::PackedAoS, llama::mapping::SoA, true>::type,
             true>::type,
         true>{arrayDomain};
 


### PR DESCRIPTION
If we turn this on in the AoS mapping, we can turn this mess:
![image](https://user-images.githubusercontent.com/1224051/109235235-982cb580-77cd-11eb-9721-b808311f337d.png)
into this nicety:
![image](https://user-images.githubusercontent.com/1224051/109719265-b2d5a480-7ba8-11eb-9a80-f1a46d4dd162.png)


Afterwards we would need a struct member permutation algorithm that minimizes padding. But that's for another day.