### PR TITLE
Remove unused header and replace boost::replace_all

### DIFF
--- a/examples/simpletest/simpletest.cpp
+++ b/examples/simpletest/simpletest.cpp
@@ -99,10 +99,11 @@ namespace
 
     std::string addLineBreaks(std::string raw)
     {
-        boost::replace_all(raw, "<", "<\n");
-        boost::replace_all(raw, ", ", ",\n");
-        boost::replace_all(raw, " >", ">");
-        boost::replace_all(raw, ">", "\n>");
+        using llama::mapping::tree::internal::replace_all;
+        replace_all(raw, "<", "<\n");
+        replace_all(raw, ", ", ",\n");
+        replace_all(raw, " >", ">");
+        replace_all(raw, ">", "\n>");
         auto tokens = split(raw, '\n');
         std::string result = "";
         int indent = 0;

--- a/include/llama/Core.hpp
+++ b/include/llama/Core.hpp
@@ -7,7 +7,6 @@
 #include "DatumCoord.hpp"
 
 #include <boost/core/demangle.hpp>
-#include <boost/iterator/iterator_facade.hpp>
 #include <boost/mp11.hpp>
 #include <iostream>
 #include <type_traits>

--- a/include/llama/mapping/tree/toString.hpp
+++ b/include/llama/mapping/tree/toString.hpp
@@ -5,7 +5,6 @@
 
 #include "TreeFromDomains.hpp"
 
-#include <boost/algorithm/string/replace.hpp>
 #include <boost/core/demangle.hpp>
 #include <string>
 #include <typeinfo>
@@ -41,6 +40,16 @@ namespace llama::mapping::tree
 
     namespace internal
     {
+        inline void replace_all(std::string& str, const std::string& search, const std::string& replace)
+        {
+            std::string::size_type i = 0;
+            while ((i = str.find(search, i)) != std::string::npos)
+            {
+                str.replace(i, search.length(), replace);
+                i += replace.length();
+            }
+        }
+
         template <typename NodeOrLeaf>
         auto countAndIdentToString(const NodeOrLeaf& nodeOrLeaf) -> std::string
         {
@@ -59,15 +68,16 @@ namespace llama::mapping::tree
     {
         return internal::countAndIdentToString(node) + "[ " + toString(node.childs) + " ]";
     }
+
     template <typename Identifier, typename Type, typename CountType>
     auto toString(const Leaf<Identifier, Type, CountType>& leaf) -> std::string
     {
         auto raw = boost::core::demangle(typeid(Type).name());
 #ifdef _MSC_VER
-        boost::replace_all(raw, " __cdecl(void)", "");
+        internal::replace_all(raw, " __cdecl(void)", "");
 #endif
 #ifdef __GNUG__
-        boost::replace_all(raw, " ()", "");
+        internal::replace_all(raw, " ()", "");
 #endif
         return internal::countAndIdentToString(leaf) + "(" + raw + ")";
     }


### PR DESCRIPTION
* Remove unused header
* Replace boost::replace_all by custom implementation. This avoids pulling in boost::mpl, which causes issues with nvcc, and improves compile times.