### PR TITLE
Support statically sized arrays in datum domain

### DIFF
--- a/docs/pages/domains.rst
+++ b/docs/pages/domains.rst
@@ -91,18 +91,15 @@ A datum domain itself is just a :cpp:`DatumStruct` (or a fundamental type), as s
         llama::DE<alpha, char>
     >;
 
-A :cpp:`DatumArray` is essentially a :cpp:`DatumStruct` with multiple :cpp:`DatumElement`\ s of the same type.
-E.g. :cpp:`DatumArray<float, 4>` is the same as
+One-dimensional arrays of compile-time extent are also supported as arguments to :cpp:`llama::DE`, but not to  :cpp:`llama::DatumElement`.
+Such arrays are expanded into a :cpp:`DatumStruct` with multiple :cpp:`DatumElement`\ s of the same type.
+E.g. :cpp:`llama::DE<Tag, float[4]>` is expanded into
 
 .. code-block:: C++
 
-    llama::DS<
+    llama::DE<Tag, llama::DS<
         llama::DE<llama::Index<0>, float>,
         llama::DE<llama::Index<1>, float>,
         llama::DE<llama::Index<2>, float>,
         llama::DE<llama::Index<3>, float>
-    >
-
-LLAMA also defines a shortcuts for a datum array:
-
-* :cpp:`llama::DatumArray` → :cpp:`llama::DA`
+    >>

--- a/examples/simpletest/simpletest.cpp
+++ b/examples/simpletest/simpletest.cpp
@@ -52,7 +52,7 @@ using Name = llama::DS<
         llama::DE<st::Z, double>,
         llama::DE<st::X, double>>>,
     llama::DE<st::Weight, int>,
-    llama::DE<st::Options, llama::DA<bool, 4>>>;
+    llama::DE<st::Options, bool[4]>>;
 // clang-format on
 
 namespace

--- a/tests/core.cpp
+++ b/tests/core.cpp
@@ -316,11 +316,11 @@ namespace tag
 }
 
 using Arrays = llama::DS<
-    llama::DE<tag::A1, llama::DA<int, 3>>,
-    llama::DE<tag::A2, llama::DA<llama::DS<
+    llama::DE<tag::A1, int[3]>,
+    llama::DE<tag::A2, llama::DS<
         llama::DE<tag::X, float>
-    >, 3>>,
-    llama::DE<tag::A3, llama::DA<llama::DA<int, 2>, 2>>
+    >[3]>,
+    llama::DE<tag::A3, int[2][2]>
 >;
 // clang-format on
 

--- a/tests/core.cpp
+++ b/tests/core.cpp
@@ -28,7 +28,7 @@ using Particle = llama::DS<
         llama::DE<tag::Z, double>,
         llama::DE<tag::X, double>
     >>,
-    llama::DE<tag::Flags, llama::DA<bool, 4>>
+    llama::DE<tag::Flags, bool[4]>
 >;
 
 using Other = llama::DS<

--- a/tests/dump.cpp
+++ b/tests/dump.cpp
@@ -40,7 +40,7 @@ using Particle = llama::DS<
     llama::DE<tag::Pos, Vec>,
     llama::DE<tag::Vel, /*DVec*/Vec>,
     llama::DE<tag::Mass, float>,
-    llama::DE<tag::Flags, llama::DA<bool, 4>>
+    llama::DE<tag::Flags, bool[4]>
 >;
 
 // example with bad alignment:
@@ -51,7 +51,7 @@ using ParticleUnaligned = llama::DS<
         llama::DE<tag::Y, float>
     >>,
     llama::DE<tag::Mass, double>,
-    llama::DE<tag::Flags, llama::DA<bool, 3>>
+    llama::DE<tag::Flags, bool[3]>
 >;
 
 // bad alignment fixed with explicit padding:
@@ -64,7 +64,7 @@ using ParticleAligned = llama::DS<
     >>,
     llama::DE<tag::Pad, Padding<4>>,
     llama::DE<tag::Mass, double>,
-    llama::DE<tag::Flags, llama::DA<bool, 3>>,
+    llama::DE<tag::Flags, bool[3]>,
     llama::DE<tag::Pad, Padding<5>>
 >;
 // clang-format on

--- a/tests/mapping.cpp
+++ b/tests/mapping.cpp
@@ -28,7 +28,7 @@ using Particle = llama::DS<
         llama::DE<tag::Y, double>,
         llama::DE<tag::Z, double>
     >>,
-    llama::DE<tag::Flags, llama::DA<bool, 4>>
+    llama::DE<tag::Flags, bool[4]>
 >;
 // clang-format on
 

--- a/tests/proofs.cpp
+++ b/tests/proofs.cpp
@@ -26,7 +26,7 @@ using Particle = llama::DS<
         llama::DE<tag::Y, double>,
         llama::DE<tag::Z, double>
     >>,
-    llama::DE<tag::Flags, llama::DA<bool, 4>>
+    llama::DE<tag::Flags, bool[4]>
 >;
 // clang-format on
 

--- a/tests/splitmapping.cpp
+++ b/tests/splitmapping.cpp
@@ -29,7 +29,7 @@ using Particle = llama::DS<
         llama::DE<tag::Y, double>,
         llama::DE<tag::Z, double>
     >>,
-    llama::DE<tag::Flags, llama::DA<bool, 4>>
+    llama::DE<tag::Flags, bool[4]>
 >;
 // clang-format on
 

--- a/tests/treemap.cpp
+++ b/tests/treemap.cpp
@@ -60,7 +60,7 @@ using Name = llama::DS<
         llama::DE<tag::Y, double>,
         llama::DE<tag::X, double>
     >>,
-    llama::DE<tag::Flags, llama::DA<bool, 4>>
+    llama::DE<tag::Flags, bool[4]>
 >;
 // clang-format on
 

--- a/tests/view.cpp
+++ b/tests/view.cpp
@@ -137,7 +137,7 @@ using Particle = llama::DS<
         llama::DE<tag::Y, double>,
         llama::DE<tag::Z, double>
     >>,
-    llama::DE<tag::Flags, llama::DA<bool, 4>>
+    llama::DE<tag::Flags, bool[4]>
 >;
 // clang-format on
 


### PR DESCRIPTION
Allows us to use native arrays in the datum domain:
```c++
using Particle = llama::DS<
    llama::DE<tag::Pos, XYZ>,
    llama::DE<tag::Weight, float>,
    llama::DE<llama::NoName, int>,
    llama::DE<tag::Vel,llama::DS<
        llama::DE<tag::Z, double>,
        llama::DE<tag::X, double>
    >>,
    llama::DE<tag::Flags, bool[4]> // here
>;
```