### PR TITLE
Add PreconfiguredSoA, SingleBlobSoA and MultiBlobSoA

### DIFF
--- a/include/llama/mapping/SoA.hpp
+++ b/include/llama/mapping/SoA.hpp
@@ -109,6 +109,18 @@ namespace llama::mapping
     };
 
     template <
+        typename ArrayDomain,
+        typename DatumDomain,
+        typename LinearizeArrayDomainFunctor = LinearizeArrayDomainCpp>
+    using SingleBlobSoA = SoA<ArrayDomain, DatumDomain, std::false_type, LinearizeArrayDomainFunctor>;
+
+    template <
+        typename ArrayDomain,
+        typename DatumDomain,
+        typename LinearizeArrayDomainFunctor = LinearizeArrayDomainCpp>
+    using MultiBlobSoA = SoA<ArrayDomain, DatumDomain, std::true_type, LinearizeArrayDomainFunctor>;
+
+    template <
         typename SeparateBuffers = std::false_type,
         typename LinearizeArrayDomainFunctor = LinearizeArrayDomainCpp>
     struct PreconfiguredSoA

--- a/include/llama/mapping/SoA.hpp
+++ b/include/llama/mapping/SoA.hpp
@@ -107,4 +107,13 @@ namespace llama::mapping
 
         ArrayDomain arrayDomainSize;
     };
+
+    template <
+        typename SeparateBuffers = std::false_type,
+        typename LinearizeArrayDomainFunctor = LinearizeArrayDomainCpp>
+    struct PreconfiguredSoA
+    {
+        template <typename ArrayDomain, typename DatumDomain>
+        using type = SoA<ArrayDomain, DatumDomain, SeparateBuffers, LinearizeArrayDomainFunctor>;
+    };
 } // namespace llama::mapping


### PR DESCRIPTION
* Add `PreconfiguredSoA` metafunction: This allows to pass a preconfiguring SoA mapping to some template template parameters, like `llama::Split<...>`
* SingleBlobSoA and MultiBlobSoA are convenience alias templates for the SoA mapping.