### PR TITLE
Disable viewcopy installation and improve documentation wording

### DIFF
--- a/docs/pages/blobs.rst
+++ b/docs/pages/blobs.rst
@@ -11,10 +11,9 @@ The number of blobs and the size of each blob is a property determined by the ma
 All this is handled by :cpp:`llama::allocView()`, but I needs to be given an allocator to handle the actual allocation of each blob.
 
 Every time a view is copied, it's array of blobs is copied too.
-Depending on the type of blobs used, this can have different effects, especially wrt. the behavior when views are copied.
-
-If a :cpp:`std::vector<std::byte>` is used, the full storage will be copied.
-If a :cpp:`std::shared_ptr<std::byte[]>` is used, the storage is shared between each copy of the view.
+Depending on the type of blobs used, this can have different effects.
+If e.g. :cpp:`std::vector<std::byte>` is used, the full storage will be copied.
+Contrary, if a :cpp:`std::shared_ptr<std::byte[]>` is used, the storage is shared between each copy of the view.
 
 .. _label-allocators:
 
@@ -105,13 +104,13 @@ However, a pointer to the underlying storage can be obtained, which may be used 
 
 .. code-block:: C++
 
-    auto buffer = alpaka::mem::buf::alloc<std::byte, std::size_t>(dev, size);
-    auto view = llama::View<Mapping, std::byte*>{mapping, {alpaka::mem::view::getPtrNative(buffer)}};
+    auto buffer = alpaka::allocBuf<std::byte, std::size_t>(dev, size);
+    auto view = llama::View<Mapping, std::byte*>{mapping, {alpaka::getPtrNative(buffer)}};
 
 Shared memory is created by alpaka using a special function returning a reference to a shared variable.
 To allocate storage for LLAMA, we can allocate a shared byte array using alpaka and then pass the address of the first element to a LLAMA view.
 
 .. code-block:: C++
 
-    auto& sharedMem = alpaka::block::shared::st::allocVar<std::byte[sharedMemSize], __COUNTER__>(acc);
+    auto& sharedMem = alpaka::declareSharedVar<std::byte[sharedMemSize], __COUNTER__>(acc);
     auto view = llama::View<Mapping, std::byte*>{mapping, {&sharedMem[0]}};

--- a/docs/pages/copying.rst
+++ b/docs/pages/copying.rst
@@ -5,11 +5,11 @@
 Copying between views
 =====================
 
-Especially when working with hardware accelerators such as GPUs or offloading to
-many core procressors, explicit copy operations call for memory chunks as big as possible to reach good throughput performance.
+Especially when working with hardware accelerators such as GPUs or offloading to many core procressors,
+explicit copy operations call for memory chunks as big as possible to reach good throughput.
 
 It is trivial to copy a view from one memory region to another if mapping and size are identical.
-However if the mapping differs, a direct copy of the underlying memory is wrong.
+However, if the mapping differs, a direct copy of the underlying memory is wrong.
 In most cases only elementwise copy operations will be possible as the memory patterns are not compatible.
 There is a small class of remaining use cases where the mapping is the same, but the size of the view is different or mappings are
 very related to each other. E.g. when both mappings use struct of array, but one time with, one time without padding.
@@ -21,16 +21,15 @@ E.g. a mapping could implement struct of array if the view is bigger than :math:
 Three solutions exist for this challenge. One is to implement specializations
 for specific combinations of mappings, which reflect the properties of those
 mappings. This **can** be the way to go if the application shows significantly
-better run times for slightly different mappings and the copy operation has be
-shown to be the bottle neck. However this would be the very last optimization
-step as for every new mapping a new specialization would be needed.
+better run times for slightly different mappings and the copy operation is the bottle neck.
+However this would be the very last optimization step as for every new mapping a new specialization would be needed.
 
 Another solution would be a run time analysis of the two views to find
-contiguous memory chunks, but the overhead would be probably too big, especially
+contiguous memory chunks, but the overhead would probably be too big, especially
 if no contiguous memory chunks could be found. At least in that case it may make
 sense to use a (maybe smaller) intermediate view which connects the two worlds.
 
-This last solution means that we have e.g. a view in memory region :math:`A`
+This last solution is that we have e.g. a view in memory region :math:`A`
 with mapping :math:`A` and another view of the same size in memory region
 :math:`B` with mapping :math:`B`. A third view in memory region :math:`A` but
 with mapping :math:`B` could be used to reindex in region :math:`A` and then to
@@ -43,9 +42,9 @@ this approach with an asynchronous workflow where reindexing, copying and
 computation are overloayed as e.g. seen in the
 `async copy example <https://github.com/alpaka-group/llama/blob/master/examples/asynccopy/asynccopy.cpp>`_.
 
-Another benefit is, that the creating and copying of the intermediate view can
+Another benefit is, that the creation and copying of the intermediate view can
 be analyzed and optimized by the compiler (e.g. with vector operations).
-Furthermore different (sub) datum domains may be used. The above mentioned
+Furthermore different (sub) datum domains may be used. The above mentioned async copy
 example e.g. applies a bluring kernel to an RGB-image, but may work only on
 two or one channel instead of all three. Not used channels are not allocated and
 especially not copied at all.

--- a/docs/pages/install.rst
+++ b/docs/pages/install.rst
@@ -6,43 +6,49 @@ Installation
 Getting LLAMA
 -------------
 
-The most recent version of LLAMA can be found at
-`GitHub <https://github.com/alpaka-group/llama>`_.
+The most recent version of LLAMA can be found at `GitHub <https://github.com/alpaka-group/llama>`_.
 
-All examples use CMake and the library itself provides a
-:bash:`llama-config.cmake` to be found by CMake. Although LLAMA is a header-only
-library, it provides installation capabilities for this file, the header files,
-but also for the optionally built examples.
+.. code-block:: bash
+
+	git clone https://github.com/alpaka-group/llama
+	cd llama
+
+All examples use CMake and the library itself provides a :bash:`llama-config.cmake` to be found by CMake.
+Although LLAMA is a header-only library, it provides installation capabilities via CMake.
 
 Dependencies
 ------------
 
  - Boost 1.66.0 or higher
- - libfmt 6.2.1 or higher
+ - libfmt 6.2.1 or higher (optional) for building some examples and LLAMA supporting to dump mappings as SVG/HTML
  - `Alpaka <https://github.com/alpaka-group/alpaka>`_ (optional) for building some examples
  - `Vc <https://github.com/VcDevel/Vc>`_ (optional) for building some examples
 
 
-Building the examples
----------------------
+Build tests and examples
+------------------------
 
-As LLAMA is using CMake the examples can be easily built with
+As LLAMA is using CMake the tests and examples can be easily built with:
 
 .. code-block:: bash
 
 	mkdir build
 	cd build
 	cmake ..
+	ccmake .. // optionally change configuration after first run of cmake
+	cmake --build .
 
 This will search for all depenencies and create a build system for your platform.
-If Alpaka or Vc is not found, all Alpaka or Vc examples will be disabled for building and installing.
+If Alpaka or Vc is not found, the corresponding examples will be disabled.
+After the initial call to `cmake`, `ccmake` can be used to add search paths for missing libraries and to deactivate building tests and examples.
+The tests can be disabled by setting `BUILD_TESTING` to `OFF` (default: `ON`).
+The examples can be disabled by setting `LLAMA_BUILD_EXAMPLES` to `OFF` (default: `ON`).
 
+Install LLAMA
+-------------
 
-CMake settings after the initial generation may be changed again with:
+To install LLAMA on your system, you can run (with privileges):
 
 .. code-block:: bash
 
-	ccmake ..
-
-This can also be used to add search paths after the initial call to cmake for missing libraries and to deactivate the build and installation of examples.
-Finally, run :bash:`make install` or your platforms equivalent to install the llama-config.cmake, the header files of LLAMA **and** all built examples.
+	sudo cmake --install .

--- a/docs/pages/macros.rst
+++ b/docs/pages/macros.rst
@@ -5,22 +5,17 @@
 Macros
 ======
 
-Unfortunately C++ lacks some language features to express data and function
-locality as well as independence of data.
-
-The first shortcoming is what language extensions like cuda, OpenMP, OpenACC,
-you name it try to solve. The second is mostly tackled by vendor specific
-compiler extension. Both define new keywords and annotations to fill those gaps.
 As LLAMA tries to stay independent from specific compiler vendors and
-extensions, C preprocessor macros are used to define some directives only for a
-sub set of compilers but with a unified interface for the user. Some macros can
+extensions, C preprocessor macros are used to define some directives for a
+subset of compilers but with a unified interface for the user. Some macros can
 even be overwritten from the outside to enable interoperability with libraries
 such as alpaka.
 
-Function locality
------------------
+Offloading
+----------
 
-Every method which can be used on offloading devices (e.g. GPUs) uses the :cpp:`LLAMA_FN_HOST_ACC_INLINE` macro as attribute.
+We frequently have to deal with dialects of C++ which allow/require do specify to which target a function is compiled.
+To support his use, every method which can be used on offloading devices (e.g. GPUs) uses the :cpp:`LLAMA_FN_HOST_ACC_INLINE` macro as attribute.
 By default it is defined as:
 
 .. code-block:: C++
@@ -36,15 +31,13 @@ When LLAMA is used in conjunction with alpaka, please define it as :cpp:`ALPAKA_
 Data (in)dependence
 -------------------
 
-Compilers usually cannot assume that two data regions are
-independent if the data is not fully visible to the compiler (e.g. a value completely lying on the stack).
-One solution in C was the :cpp:`restrict` keyword which specifies that the memory pointed to by a pointer is not aliased by anything else.
+Compilers usually cannot assume that two data regions are independent of each other if the data is not fully visible to the compiler
+(e.g. a value completely lying on the stack or the compiler observing the allocation call).
+One solution in C is the :cpp:`restrict` keyword which specifies that the memory pointed to by a pointer is not aliased by anything else.
 However this does not work for more complex data structures containing pointers, and easily fails in other scenarios as well.
-The :cpp:`restrict` keyword was therefore not added to the C++ language.
 
 Another solution are compiler specific :cpp:`#pragma`\ s which tell the compiler that
-**each** data access inside a loop can be assumed to be independent of each other.
-This is handy and works with more complex data types, too.
-So LLAMA provides a macro called :cpp:`LLAMA_INDEPENDENT_DATA` which can be put
-in front of loops to tell the compiler that the data accesses in the
-loop body are independent of each other -- and can savely be vectorized (which is the goal).
+**each** memory access through a pointer inside a loop can be assumed to not interfere with other accesses through other pointers.
+The usual goal is to allow vectorization.
+Such :cpp:`#pragma`\ s are handy and work with more complex data types, too.
+LLAMA provides a macro called :cpp:`LLAMA_INDEPENDENT_DATA` which can be put in front of loops to communicate the independence of memory accesses to the compiler.

--- a/examples/viewcopy/CMakeLists.txt
+++ b/examples/viewcopy/CMakeLists.txt
@@ -19,6 +19,3 @@ if (CMAKE_CXX_COMPILER_ID STREQUAL "GNU" OR CMAKE_CXX_COMPILER_ID STREQUAL "Clan
 		target_link_libraries(${PROJECT_NAME} PRIVATE TBB::tbb Threads::Threads)
 	endif()
 endif()
-
-install(FILES "${PROJECT_BINARY_DIR}/${PROJECT_NAME}" DESTINATION "bin")
-


### PR DESCRIPTION
* disable installation of viewcopy example
* rework installation documentation
* fix formatting in introduction and add section on ROOT
* reflow paragraph on blobs and fix outdated alpaka API calls
* reword macros documentation
* slightly improve wording on copying page