### PR TITLE
Rename allocators to blob allocators

### DIFF
--- a/docs/pages/api.rst
+++ b/docs/pages/api.rst
@@ -79,16 +79,16 @@ View creation
 .. doxygentypedef:: llama::One
 .. doxygenfunction:: llama::copyVirtualDatumStack
 
-.. _label-api-allocators:
+.. _label-api-bloballocators:
 
-Allocators
-^^^^^^^^^^
+Blob allocators
+^^^^^^^^^^^^^^^
 
-.. doxygenstruct:: llama::allocator::Vector
+.. doxygenstruct:: llama::bloballoc::Vector
    :members:
-.. doxygenstruct:: llama::allocator::SharedPtr
+.. doxygenstruct:: llama::bloballoc::SharedPtr
    :members:
-.. doxygenstruct:: llama::allocator::Stack
+.. doxygenstruct:: llama::bloballoc::Stack
    :members:
 
 Mappings

--- a/docs/pages/blobs.rst
+++ b/docs/pages/blobs.rst
@@ -15,47 +15,47 @@ Depending on the type of blobs used, this can have different effects.
 If e.g. :cpp:`std::vector<std::byte>` is used, the full storage will be copied.
 Contrary, if a :cpp:`std::shared_ptr<std::byte[]>` is used, the storage is shared between each copy of the view.
 
-.. _label-allocators:
+.. _label-bloballocators:
 
-Allocators
-----------
+Blob allocators
+---------------
 
-An allocator is used for :cpp:`llama::allocView()` to choose a strategy for creating blobs.
-There is a number of a buildin allocators:
+A blob allocator is used for :cpp:`llama::allocView()` to choose a strategy for creating blobs.
+There is a number of a buildin blob allocators:
 
 Shared memory
 ^^^^^^^^^^^^^
 
-:cpp:`llama::allocator::SharedPtr` is an allocator creating blobs of type :cpp:`std::shared_ptr<std::byte[]>`.
+:cpp:`llama::bloballoc::SharedPtr` is a blob allocator creating blobs of type :cpp:`std::shared_ptr<std::byte[]>`.
 These blobs will be shared between each copy of the view and only destroyed then the last view is destroyed.
 
-Furthermore a compile time alignment value can be given to the allocator to specify the byte alignment of the allocated block of memory.
+Furthermore a compile time alignment value can be given to the blob allocator to specify the byte alignment of the allocated block of memory.
 This has implications on the read/write speed on some CPU architectures and may even lead to CPU exceptions if data is not properly aligned.
 
 .. code-block:: C++
 
-    llama::allocator::SharedPtr<256>
+    llama::bloballoc::SharedPtr<256>
 
 Vector
 ^^^^^^
 
 
-:cpp:`llama::allocator::Vector` is an allocator creating blobs of type :cpp:`std::vector<std::byte>`.
+:cpp:`llama::bloballoc::Vector` is a blob allocator creating blobs of type :cpp:`std::vector<std::byte>`.
 This means every time a view is copied, the whole memory is copied
 too. When the view is moved, no extra allocation or copy operation happens.
 
-Analogous to :cpp:`llama::allocator::SharedPtr` an alignment value may be passed to the allocator.
+Analogous to :cpp:`llama::bloballoc::SharedPtr` an alignment value may be passed to the blob allocator.
 
 .. code-block:: C++
 
-    llama::allocator::Vector<256>
+    llama::bloballoc::Vector<256>
 
 Stack
 ^^^^^
 
 When working with small amounts of memory or temporary views created often, it is usually beneficial to store the data directly on the stack.
 
-:cpp:`llama::allocator::Stack` addresses this issue and creates blobs of type :cpp:`llama::Array<std::byte, N>`, where :cpp:`N` is a compile time value passed to the allocator.
+:cpp:`llama::bloballoc::Stack` addresses this issue and creates blobs of type :cpp:`llama::Array<std::byte, N>`, where :cpp:`N` is a compile time value passed to the allocator.
 These blobs are copied every time their view is copied.
 
 Creating a small view of :math:`4 \times 4` may look like this:
@@ -66,11 +66,11 @@ Creating a small view of :math:`4 \times 4` may look like this:
     constexpr ArrayDomain miniSize{4, 4};
 
     using Mapping = /* some simple mapping */;
-    using Allocator = llama::allocator::Stack<
+    using BlobAllocator = llama::bloballoc::Stack<
         miniSize[0] * miniSize[1] * llama::sizeOf</* some datum domain */>::value
     >;
 
-    auto miniView = llama::allocView(Mapping{miniSize}, Allocator{});
+    auto miniView = llama::allocView(Mapping{miniSize}, BlobAllocator{});
 
 For :math:`N`-dimensional one-element views a shortcut exists, returning a view
 with just one element without any padding, aligment, or whatever on the stack:

--- a/docs/pages/introduction.rst
+++ b/docs/pages/introduction.rst
@@ -87,9 +87,9 @@ LLAMA offers many kinds of mappings and users can also provide their own mapping
 Mappings are constructed from a :ref:`Datum domain <label-dd>`, containing tags, and an :ref:`Array domain <label-ad>`.
 In addition to a mapping defining the memory layout, an array of :ref:`Blobs <label-blobs>` is needed for a view, supplying the actual storage behind the view.
 A blob is any object representing a contiguous chunk of memory, byte-wise addressable using :cpp:`operator[]`.
-A suitable Blob array is either directly provided by the user or built using an :ref:`Allocator <label-allocators>` when a view is created by a call to `allocView`.
-An allocator is again an abstract concept and any object returning a blob of a requested size when calling :cpp:`operator()`.
-LLAMA comes with a set of predefined allocators and users can again provider their own.
+A suitable Blob array is either directly provided by the user or built using a :ref:`BlobAllocator <label-bloballocators>` when a view is created by a call to `allocView`.
+A blob allocator is again an abstract concept and any object returning a blob of a requested size when calling :cpp:`operator()`.
+LLAMA comes with a set of predefined blob allocators and users can again provider their own.
 
 Once a view is created, the user can navigate on the data managed by the view.
 On top of a view, a :ref:`VirtualView <label-virtualview>` can be created, offering access to a subrange of the array domain.

--- a/docs/pages/views.rst
+++ b/docs/pages/views.rst
@@ -16,16 +16,16 @@ elements inside the datum domain at once.
 View allocation
 ---------------
 
-The factory creates the view. For this it takes the domains, a
-:ref:`mapping <label-mappings>` and an optional :ref:`allocator <label-allocators>`.
+A view is allocated using the helper function :cpp:`allocView`, which takes a
+:ref:`mapping <label-mappings>` and an optional :ref:`blob allocator <label-bloballocators>`.
 
 .. code-block:: C++
 
     using Mapping = ...; // see next section about mappings
     Mapping mapping(arrayDomainSize); // see section about domains
-    auto view = allocView(mapping); // optional allocator as 2nd argument
+    auto view = allocView(mapping); // optional blob allocator as 2nd argument
 
-The :ref:`mapping <label-mappings>` and :ref:`allocator <label-allocators>`
+The :ref:`mapping <label-mappings>` and :ref:`blob allocator <label-bloballocators>`
 will be explained later. For now, it is just
 important to know that all those run time and compile time parameters come
 together to create the view.

--- a/examples/nbody/nbody.cpp
+++ b/examples/nbody/nbody.cpp
@@ -437,7 +437,7 @@ namespace manualSoA
         std::cout << title << "\n";
         Stopwatch watch;
 
-        using Vector = std::vector<FP, llama::allocator::AlignedAllocator<FP, 64>>;
+        using Vector = std::vector<FP, llama::bloballoc::AlignedAllocator<FP, 64>>;
         Vector posx(PROBLEM_SIZE);
         Vector posy(PROBLEM_SIZE);
         Vector posz(PROBLEM_SIZE);

--- a/examples/nbody_benchmark/nbody.cpp
+++ b/examples/nbody_benchmark/nbody.cpp
@@ -93,7 +93,7 @@ void run(std::ostream& plotFile)
             return llama::mapping::SoA{arrayDomain, Particle{}, std::true_type{}};
     }();
 
-    auto particles = llama::allocView(std::move(mapping), llama::allocator::Vector<Alignment>{});
+    auto particles = llama::allocView(std::move(mapping), llama::bloballoc::Vector<Alignment>{});
 
     if constexpr (PRINT_BLOCK_PLACEMENT)
     {

--- a/examples/vectoradd/vectoradd.cpp
+++ b/examples/vectoradd/vectoradd.cpp
@@ -172,7 +172,7 @@ namespace manualSoA
         std::cout << "\nSoA\n";
         Stopwatch watch;
 
-        using Vector = std::vector<float, llama::allocator::AlignedAllocator<float, 64>>;
+        using Vector = std::vector<float, llama::bloballoc::AlignedAllocator<float, 64>>;
         Vector ax(PROBLEM_SIZE);
         Vector ay(PROBLEM_SIZE);
         Vector az(PROBLEM_SIZE);

--- a/include/llama/BlobAllocators.hpp
+++ b/include/llama/BlobAllocators.hpp
@@ -14,7 +14,7 @@
 #    include <aligned_new>
 #endif
 
-namespace llama::allocator
+namespace llama::bloballoc
 {
     /// Allocates stack memory for a \ref View, which is copied each time a \ref
     /// View is copied.
@@ -104,4 +104,4 @@ namespace llama::allocator
 #ifdef __cpp_concepts
     static_assert(BlobAllocator<Vector<>>);
 #endif
-} // namespace llama::allocator
+} // namespace llama::bloballoc

--- a/include/llama/Concepts.hpp
+++ b/include/llama/Concepts.hpp
@@ -21,7 +21,7 @@ namespace llama
     // clang-format on
 
     template <typename B>
-    concept StorageBlob = requires(B b, std::size_t i)
+    concept Blob = requires(B b, std::size_t i)
     {
         // according to http://eel.is/c++draft/intro.object#3 only std::byte and unsigned char can provide storage for
         // other types
@@ -31,7 +31,7 @@ namespace llama
     // clang-format off
     template <typename BA>
     concept BlobAllocator = requires(BA ba, std::size_t i) {
-        { ba(i) } -> StorageBlob;
+        { ba(i) } -> Blob;
     };
     // clang-format on
 } // namespace llama

--- a/include/llama/View.hpp
+++ b/include/llama/View.hpp
@@ -3,8 +3,8 @@
 
 #pragma once
 
-#include "Allocators.hpp"
 #include "Array.hpp"
+#include "BlobAllocators.hpp"
 #include "Concepts.hpp"
 #include "Core.hpp"
 #include "macros.hpp"
@@ -16,7 +16,7 @@
 namespace llama
 {
 #ifdef __cpp_concepts
-    template <typename T_Mapping, StorageBlob BlobType>
+    template <typename T_Mapping, Blob BlobType>
 #else
     template <typename T_Mapping, typename BlobType>
 #endif
@@ -39,12 +39,12 @@ namespace llama
 
     /// Creates a view based on the given mapping, e.g. \ref mapping::AoS or \ref mapping::SoA. For allocating the
     /// view's underlying memory, the specified allocator callable is used (or the default one, which is \ref
-    /// allocator::Vector). The allocator callable is called with the size of bytes to allocate for each blob of the
+    /// bloballoc::Vector). The allocator callable is called with the size of bytes to allocate for each blob of the
     /// mapping. This function is the preferred way to create a \ref View.
 #ifdef __cpp_concepts
-    template <typename Mapping, BlobAllocator Allocator = allocator::Vector<>>
+    template <typename Mapping, BlobAllocator Allocator = bloballoc::Vector<>>
 #else
-    template <typename Mapping, typename Allocator = allocator::Vector<>>
+    template <typename Mapping, typename Allocator = bloballoc::Vector<>>
 #endif
     LLAMA_FN_HOST_ACC_INLINE auto allocView(Mapping mapping = {}, const Allocator& alloc = {})
         -> View<Mapping, internal::AllocatorBlobType<Allocator>>
@@ -54,13 +54,13 @@ namespace llama
     }
 
     /// Allocates a \ref View holding a single datum backed by stack memory
-    /// (\ref allocator::Stack).
+    /// (\ref bloballoc::Stack).
     /// \tparam Dim Dimension of the \ref ArrayDomain of the \ref View.
     template <std::size_t Dim, typename DatumDomain>
     LLAMA_FN_HOST_ACC_INLINE auto allocViewStack() -> decltype(auto)
     {
         using Mapping = llama::mapping::One<ArrayDomain<Dim>, DatumDomain>;
-        return allocView(Mapping{}, llama::allocator::Stack<sizeOf<DatumDomain>>{});
+        return allocView(Mapping{}, llama::bloballoc::Stack<sizeOf<DatumDomain>>{});
     }
 
     template <typename View, typename BoundDatumDomain = DatumCoord<>, bool OwnView = false>
@@ -871,7 +871,7 @@ namespace llama
     /// \tparam BlobType The storage type used by the view holding
     /// memory.
 #ifdef __cpp_concepts
-    template <typename T_Mapping, StorageBlob BlobType>
+    template <typename T_Mapping, Blob BlobType>
 #else
     template <typename T_Mapping, typename BlobType>
 #endif

--- a/include/llama/llama.hpp
+++ b/include/llama/llama.hpp
@@ -36,8 +36,8 @@
 #    pragma diag_suppress 940
 #endif
 
-#include "Allocators.hpp"
 #include "ArrayDomainRange.hpp"
+#include "BlobAllocators.hpp"
 #include "Core.hpp"
 #include "View.hpp"
 #include "macros.hpp"

--- a/tests/common.h
+++ b/tests/common.h
@@ -3,7 +3,7 @@
 #include <boost/algorithm/string/replace.hpp>
 #include <boost/algorithm/string/split.hpp>
 #include <boost/core/demangle.hpp>
-#include <llama/Allocators.hpp>
+#include <llama/BlobAllocators.hpp>
 #include <numeric>
 #include <regex>
 #include <string>

--- a/tests/view.cpp
+++ b/tests/view.cpp
@@ -64,7 +64,7 @@ TEST_CASE("view.allocator.Vector")
     constexpr ArrayDomain viewSize{16, 16};
 
     using Mapping = llama::mapping::SoA<ArrayDomain, DatumDomain>;
-    auto view = allocView(Mapping(viewSize), llama::allocator::Vector{});
+    auto view = allocView(Mapping(viewSize), llama::bloballoc::Vector{});
 
     for (auto i : llama::ArrayDomainIndexRange{viewSize})
         view(i) = 42;
@@ -76,7 +76,7 @@ TEST_CASE("view.allocator.SharedPtr")
     constexpr ArrayDomain viewSize{16, 16};
 
     using Mapping = llama::mapping::SoA<ArrayDomain, DatumDomain>;
-    auto view = allocView(Mapping(viewSize), llama::allocator::SharedPtr{});
+    auto view = allocView(Mapping(viewSize), llama::bloballoc::SharedPtr{});
 
     for (auto i : llama::ArrayDomainIndexRange{viewSize})
         view(i) = 42;
@@ -88,7 +88,7 @@ TEST_CASE("view.allocator.stack")
     constexpr ArrayDomain viewSize{16, 16};
 
     using Mapping = llama::mapping::SoA<ArrayDomain, DatumDomain>;
-    auto view = allocView(Mapping(viewSize), llama::allocator::Stack<16 * 16 * llama::sizeOf<DatumDomain>>{});
+    auto view = allocView(Mapping(viewSize), llama::bloballoc::Stack<16 * 16 * llama::sizeOf<DatumDomain>>{});
 
     for (auto i : llama::ArrayDomainIndexRange{viewSize})
         view(i) = 42;

--- a/tests/virtualview.cpp
+++ b/tests/virtualview.cpp
@@ -96,7 +96,7 @@ TEST_CASE("virtual view")
             using MiniMapping = llama::mapping::SoA<ArrayDomain, Particle>;
             auto miniView = allocView(
                 MiniMapping(miniSize),
-                llama::allocator::Stack<miniSize[0] * miniSize[1] * llama::sizeOf<Particle>>{});
+                llama::bloballoc::Stack<miniSize[0] * miniSize[1] * llama::sizeOf<Particle>>{});
 
             for (std::size_t a = 0; a < validMiniSize[0]; ++a)
                 for (std::size_t b = 0; b < validMiniSize[1]; ++b)


### PR DESCRIPTION
* Rename namespace llama::allocator to llama::bloballoc.
* Update documentation.
* Rename Allocators.hpp to BlobAllocators.hpp.