### PR TITLE
Add Heatmap mapping

### DIFF
--- a/examples/nbody/nbody.cpp
+++ b/examples/nbody/nbody.cpp
@@ -23,6 +23,7 @@ using FP = float;
 constexpr auto PROBLEM_SIZE = 16 * 1024;
 constexpr auto STEPS = 5;
 constexpr auto TRACE = false;
+constexpr auto HEATMAP = false;
 constexpr auto DUMP_MAPPING = false;
 constexpr auto ALLOW_RSQRT = true; // rsqrt can be way faster, but less accurate
 constexpr auto NEWTON_RAPHSON_AFTER_RSQRT
@@ -155,7 +156,14 @@ namespace usellama
                 return std::move(mapping);
         }();
 
-        auto particles = llama::allocView(std::move(tmapping));
+        auto hmapping = [&] {
+            if constexpr (HEATMAP)
+                return llama::mapping::Heatmap{std::move(tmapping)};
+            else
+                return std::move(tmapping);
+        }();
+
+        auto particles = llama::allocView(std::move(hmapping));
         watch.printAndReset("alloc");
 
         std::default_random_engine engine;
@@ -186,6 +194,9 @@ namespace usellama
             plotFile << std::quoted(title) << "\t" << sumUpdate / STEPS << '\t' << sumMove / STEPS << '\t';
         else
             plotFile << sumUpdate / STEPS << '\t' << sumMove / STEPS << '\n';
+
+        if constexpr (HEATMAP)
+            std::ofstream{"nbody_heatmap_" + mappingName(Mapping) + ".dat"} << particles.mapping.toGnuplotDatFile();
 
         return 0;
     }

--- a/include/llama/llama.hpp
+++ b/include/llama/llama.hpp
@@ -43,6 +43,7 @@
 #include "macros.hpp"
 #include "mapping/AoS.hpp"
 #include "mapping/AoSoA.hpp"
+#include "mapping/Heatmap.hpp"
 #include "mapping/One.hpp"
 #include "mapping/SoA.hpp"
 #include "mapping/Split.hpp"

--- a/include/llama/mapping/Heatmap.hpp
+++ b/include/llama/mapping/Heatmap.hpp
@@ -1,0 +1,73 @@
+#pragma once
+
+#include "Common.hpp"
+
+#include <array>
+#include <atomic>
+#include <sstream>
+#include <vector>
+
+namespace llama::mapping
+{
+    /// Forwards all calls to the inner mapping. Counts all accesses made to all bytes, allowing to extract a heatmap.
+    /// \tparam Mapping The type of the inner mapping.
+    template <typename Mapping, typename CountType = std::size_t>
+    struct Heatmap
+    {
+        using ArrayDomain = typename Mapping::ArrayDomain;
+        using DatumDomain = typename Mapping::DatumDomain;
+        static constexpr std::size_t blobCount = Mapping::blobCount;
+
+        constexpr Heatmap() = default;
+
+        LLAMA_FN_HOST_ACC_INLINE
+        Heatmap(Mapping mapping) : mapping(mapping)
+        {
+            for (auto i = 0; i < blobCount; i++)
+                byteHits[i] = std::vector<std::atomic<CountType>>(blobSize(i));
+        }
+
+        Heatmap(const Heatmap&) = delete;
+        auto operator=(const Heatmap&) -> Heatmap& = delete;
+
+        Heatmap(Heatmap&&) noexcept = default;
+        auto operator=(Heatmap&&) noexcept -> Heatmap& = default;
+
+        LLAMA_FN_HOST_ACC_INLINE constexpr auto blobSize(std::size_t i) const -> std::size_t
+        {
+            LLAMA_FORCE_INLINE_RECURSIVE
+            return mapping.blobSize(i);
+        }
+
+        template <std::size_t... DatumDomainCoord>
+        LLAMA_FN_HOST_ACC_INLINE auto blobNrAndOffset(ArrayDomain coord) const -> NrAndOffset
+        {
+            LLAMA_FORCE_INLINE_RECURSIVE const auto nao = mapping.template blobNrAndOffset<DatumDomainCoord...>(coord);
+            for (auto i = 0; i < sizeof(GetType<DatumDomain, DatumCoord<DatumDomainCoord...>>); i++)
+                byteHits[nao.nr][nao.offset + i]++;
+            return nao;
+        }
+
+        // gnuplot with:
+        // set view map
+        // set yrange [] reverse
+        // splot "./file.dat" matrix with image
+        auto toGnuplotDatFile() const -> std::string
+        {
+            std::stringstream f;
+            for (auto i = 0; i < blobCount; i++)
+            {
+                std::size_t byteCount = 0;
+                for (const auto& hits : byteHits[i])
+                    f << hits << ((++byteCount % 64 == 0) ? '\n' : ' ');
+                while (byteCount++ % 64 != 0)
+                    f << "0 ";
+                f << '\n';
+            }
+            return f.str();
+        }
+
+        Mapping mapping;
+        mutable std::array<std::vector<std::atomic<CountType>>, blobCount> byteHits;
+    };
+} // namespace llama::mapping

--- a/tests/heatmap.cpp
+++ b/tests/heatmap.cpp
@@ -1,0 +1,68 @@
+#include <catch2/catch.hpp>
+#include <fstream>
+#include <llama/llama.hpp>
+
+namespace
+{
+    // clang-format off
+    namespace tag
+    {
+        struct Pos{};
+        struct Vel{};
+        struct X{};
+        struct Y{};
+        struct Z{};
+        struct Mass{};
+    }
+
+    using Particle = llama::DS<
+        llama::DE<tag::Pos, llama::DS<
+            llama::DE<tag::X, float>,
+            llama::DE<tag::Y, float>,
+            llama::DE<tag::Z, float>
+        >>,
+        llama::DE<tag::Vel, llama::DS<
+            llama::DE<tag::X, float>,
+            llama::DE<tag::Y, float>,
+            llama::DE<tag::Z, float>
+        >>,
+        llama::DE<tag::Mass, float>
+    >;
+    // clang-format on
+} // namespace
+
+TEST_CASE("Heatmap.3body")
+{
+    constexpr auto N = 100;
+    auto run = [&](std::string name, auto mapping) {
+        auto particles = llama::allocView(llama::mapping::Heatmap{mapping});
+
+        for (std::size_t i = 0; i < N; i++)
+            particles(i) = 0;
+
+        constexpr float TIMESTEP = 0.0001f;
+        constexpr float EPS2 = 0.01f;
+        for (std::size_t i = 0; i < N; i++)
+            for (std::size_t j = 0; j < N; ++j)
+            {
+                auto pi = particles(i);
+                auto pj = particles(j);
+                auto dist = pi(tag::Pos{}) - pj(tag::Pos{});
+                dist *= dist;
+                const float distSqr = EPS2 + dist(tag::X{}) + dist(tag::Y{}) + dist(tag::Z{});
+                const float distSixth = distSqr * distSqr * distSqr;
+                const float invDistCube = 1.0f / std::sqrt(distSixth);
+                const float sts = pj(tag::Mass{}) * invDistCube * TIMESTEP;
+                pi(tag::Vel{}) += dist * sts;
+            }
+        for (std::size_t i = 0; i < N; i++)
+            particles(i)(tag::Pos{}) += particles(i)(tag::Vel{}) * TIMESTEP;
+
+        std::ofstream{"Heatmap." + name + ".dat"} << particles.mapping.toGnuplotDatFile();
+    };
+
+    using ArrayDomain = llama::ArrayDomain<1>;
+    auto arrayDomain = ArrayDomain{N};
+    run("AlignedAoS", llama::mapping::AlignedAoS<ArrayDomain, Particle>{arrayDomain});
+    run("SingleBlobSoA", llama::mapping::SingleBlobSoA<ArrayDomain, Particle>{arrayDomain});
+}


### PR DESCRIPTION
The Heatmap mapping wraps around other mappings and is tracking bytewise memory accesses.
A gnuplot compatible file can be dumped and plotted, showing a heatmap of blob access:

n-body AoS heatmap
![image](https://user-images.githubusercontent.com/1224051/112353796-645d8680-8ccc-11eb-94c6-3cc6b7ab4f98.png)

n-body SoA heatmap
![image](https://user-images.githubusercontent.com/1224051/112354077-a25aaa80-8ccc-11eb-8ae8-1ac64797790f.png)
