### PR TITLE
Replace parallel STL by OpenMP for viewcopy

### DIFF
--- a/examples/viewcopy/CMakeLists.txt
+++ b/examples/viewcopy/CMakeLists.txt
@@ -3,19 +3,9 @@ project(llama-viewcopy)
 
 set(CMAKE_CXX_STANDARD 20)
 
+find_package(OpenMP REQUIRED)
 if (NOT TARGET llama::llama)
 	find_package(llama REQUIRED)
 endif()
 add_executable(${PROJECT_NAME} viewcopy.cpp ../common/Stopwatch.hpp)
-target_link_libraries(${PROJECT_NAME} PRIVATE llama::llama)
-
-if (CMAKE_CXX_COMPILER_ID STREQUAL "GNU" OR CMAKE_CXX_COMPILER_ID STREQUAL "Clang")
-	# GCC will try to find TBB and if it is installed use it for the parallel STL
-	# unfortunately, it does not link against TBB automatically
-	find_package(TBB CONFIG QUIET)
-	if (TBB_FOUND)
-		# TBB needs pthreads
-		find_package(Threads REQUIRED)
-		target_link_libraries(${PROJECT_NAME} PRIVATE TBB::tbb Threads::Threads)
-	endif()
-endif()
+target_link_libraries(${PROJECT_NAME} PRIVATE llama::llama OpenMP::OpenMP_CXX)

--- a/examples/viewcopy/viewcopy.cpp
+++ b/examples/viewcopy/viewcopy.cpp
@@ -40,30 +40,6 @@ namespace llamaex
 {
     using namespace llama;
 
-    namespace internal
-    {
-        template <std::size_t Dim>
-        constexpr auto popFront(ArrayDomain<Dim> ad)
-        {
-            ArrayDomain<Dim - 1> result;
-            for (std::size_t i = 0; i < Dim - 1; i++)
-                result[i] = ad[i + 1];
-            return result;
-        }
-    } // namespace internal
-
-    template <std::size_t Dim, typename Func, typename... OuterIndices>
-    void forEachADCoord(ArrayDomain<Dim> adSize, Func&& func, OuterIndices... outerIndices)
-    {
-        for (std::size_t i = 0; i < adSize[0]; i++)
-        {
-            if constexpr (Dim > 1)
-                forEachADCoord(internal::popFront(adSize), std::forward<Func>(func), outerIndices..., i);
-            else
-                std::forward<Func>(func)(ArrayDomain<sizeof...(outerIndices) + 1>{outerIndices..., i});
-        }
-    }
-
     template <std::size_t Dim, typename Func>
     void parallelForEachADCoord(ArrayDomain<Dim> adSize, std::size_t numThreads, Func&& func)
     {

--- a/include/llama/Core.hpp
+++ b/include/llama/Core.hpp
@@ -431,4 +431,28 @@ namespace llama
             s = s.substr(pos + 1);
         return s;
     }
+
+    namespace internal
+    {
+        template <std::size_t Dim>
+        constexpr auto popFront(ArrayDomain<Dim> ad)
+        {
+            ArrayDomain<Dim - 1> result;
+            for (std::size_t i = 0; i < Dim - 1; i++)
+                result[i] = ad[i + 1];
+            return result;
+        }
+    } // namespace internal
+
+    template <std::size_t Dim, typename Func, typename... OuterIndices>
+    void forEachADCoord(ArrayDomain<Dim> adSize, Func&& func, OuterIndices... outerIndices)
+    {
+        for (std::size_t i = 0; i < adSize[0]; i++)
+        {
+            if constexpr (Dim > 1)
+                forEachADCoord(internal::popFront(adSize), std::forward<Func>(func), outerIndices..., i);
+            else
+                std::forward<Func>(func)(ArrayDomain<sizeof...(outerIndices) + 1>{outerIndices..., i});
+        }
+    }
 } // namespace llama

--- a/tests/arraydomain.cpp
+++ b/tests/arraydomain.cpp
@@ -240,3 +240,41 @@ TEST_CASE("Morton")
     CHECK(lin(ArrayDomain{3, 2}, {}) == 14);
     CHECK(lin(ArrayDomain{3, 3}, {}) == 15);
 }
+
+TEST_CASE("forEachADCoord_1D")
+{
+    llama::ArrayDomain<1> adSize{3};
+
+    std::vector<llama::ArrayDomain<1>> coords;
+    llama::forEachADCoord(adSize, [&](llama::ArrayDomain<1> coord) { coords.push_back(coord); });
+
+    CHECK(coords == std::vector<llama::ArrayDomain<1>>{{0}, {1}, {2}});
+}
+
+TEST_CASE("forEachADCoord_2D")
+{
+    llama::ArrayDomain<2> adSize{3, 3};
+
+    std::vector<llama::ArrayDomain<2>> coords;
+    llama::forEachADCoord(adSize, [&](llama::ArrayDomain<2> coord) { coords.push_back(coord); });
+
+    CHECK(
+        coords
+        == std::vector<llama::ArrayDomain<2>>{{0, 0}, {0, 1}, {0, 2}, {1, 0}, {1, 1}, {1, 2}, {2, 0}, {2, 1}, {2, 2}});
+}
+
+TEST_CASE("forEachADCoord_3D")
+{
+    llama::ArrayDomain<3> adSize{3, 3, 3};
+
+    std::vector<llama::ArrayDomain<3>> coords;
+    llama::forEachADCoord(adSize, [&](llama::ArrayDomain<3> coord) { coords.push_back(coord); });
+
+    CHECK(
+        coords
+        == std::vector<llama::ArrayDomain<3>>{
+            {0, 0, 0}, {0, 0, 1}, {0, 0, 2}, {0, 1, 0}, {0, 1, 1}, {0, 1, 2}, {0, 2, 0}, {0, 2, 1}, {0, 2, 2},
+            {1, 0, 0}, {1, 0, 1}, {1, 0, 2}, {1, 1, 0}, {1, 1, 1}, {1, 1, 2}, {1, 2, 0}, {1, 2, 1}, {1, 2, 2},
+            {2, 0, 0}, {2, 0, 1}, {2, 0, 2}, {2, 1, 0}, {2, 1, 1}, {2, 1, 2}, {2, 2, 0}, {2, 2, 1}, {2, 2, 2},
+        });
+}


### PR DESCRIPTION
* The parallel STL backend in libstdc++ depends on TBB and oneTBB is incompatible, thus breaking libstdc++.
* Lift `forEachADCoord` into llama.