### PR TITLE
Replace boost string algorithms and small improvements

### DIFF
--- a/docs/pages/views.rst
+++ b/docs/pages/views.rst
@@ -85,8 +85,5 @@ Virtual views can be created on top of existing views, offering shifted access t
 .. code-block:: C++
 
     auto view = ...;
-    llama::VirtualView<decltype(view)> virtualView{
-        view,
-        {23, 42}, // offset
-        {13, 37} // size
-    };
+    llama::VirtualView virtualView{view, {10, 20, 30}};
+    virtualView(1, 2, 3)(color{}, g{}) = 1.0; // accesses record {11, 22, 33}

--- a/docs/pages/views.rst
+++ b/docs/pages/views.rst
@@ -57,23 +57,16 @@ It is also possible to access the array dimensions with one compound argument li
     view({1, 2, 3})(color{}, g{}) = 1.0;
 
 The values :cpp:`color{}` and :cpp:`g{}` are not used and just serve as a way to specify the template arguments.
-A direct call of the :cpp:`operator()` is also possible and looks like this:
-
-.. code-block:: C++
-
-    view(1, 2, 3).operator()<color, g>() = 1.0;
-
-Alternatively, if the use of tag types is not desired or if the algorithm wants to iterate over the record dimension at compile time,
-an adressing with integral record coordinates is possible like this:
+Alternatively, an addressing with integral record coordinates is possible like this:
 
 .. code-block:: C++
 
     view(1, 2, 3)(llama::RecordCoord<0, 1>{}) = 1.0; // color.g
 
-This record coordinates are zero-based, nested indices reflecting the nested tuple-like structure of the record dimension.
+These record coordinates are zero-based, nested indices reflecting the nested tuple-like structure of the record dimension.
 
 Notice that the :cpp:`operator()` is invoked twice in the last example and that an intermediate object is needed for this to work.
-This object is a central data type of LLAMA called :cpp:`llama::VirtualRecord`.
+This object is a :cpp:`llama::VirtualRecord`.
 
 .. _label-virtualview:
 

--- a/examples/alpaka/asyncblur/asyncblur.cpp
+++ b/examples/alpaka/asyncblur/asyncblur.cpp
@@ -308,7 +308,7 @@ try
             const ArrayDims validMiniSize{
                 ((chunk_y < chunks[0] - 1) ? CHUNK_SIZE : (img_y - 1) % CHUNK_SIZE + 1) + 2 * KERNEL_SIZE,
                 ((chunk_x < chunks[1] - 1) ? CHUNK_SIZE : (img_x - 1) % CHUNK_SIZE + 1) + 2 * KERNEL_SIZE};
-            llama::VirtualView virtualHost(hostView, {chunk_y * CHUNK_SIZE, chunk_x * CHUNK_SIZE}, validMiniSize);
+            llama::VirtualView virtualHost(hostView, {chunk_y * CHUNK_SIZE, chunk_x * CHUNK_SIZE});
 
             // Find free chunk stream
             std::size_t chunkNr = virtualHostList.size();

--- a/include/llama/Core.hpp
+++ b/include/llama/Core.hpp
@@ -190,7 +190,10 @@ namespace llama
             };
 
             static constexpr auto tagIndex = boost::mp11::mp_find_if<boost::mp11::mp_list<Fields...>, HasTag>::value;
-            static_assert(tagIndex < sizeof...(Fields), "FirstTag was not found inside this Record");
+            static_assert(
+                tagIndex < sizeof...(Fields),
+                "FirstTag was not found inside this DatumStruct. Does your datum domain contain the tag you access "
+                "with?");
 
             using ChildType = GetFieldType<boost::mp11::mp_at_c<Record<Fields...>, tagIndex>>;
 

--- a/include/llama/Tuple.hpp
+++ b/include/llama/Tuple.hpp
@@ -5,6 +5,8 @@
 
 #include "macros.hpp"
 
+#include <boost/mp11.hpp>
+
 namespace llama
 {
     /// Tuple class like `std::tuple` but suitable for use with offloading

--- a/include/llama/View.hpp
+++ b/include/llama/View.hpp
@@ -10,7 +10,6 @@
 #include "macros.hpp"
 #include "mapping/One.hpp"
 
-#include <boost/preprocessor/cat.hpp>
 #include <type_traits>
 
 namespace llama

--- a/include/llama/View.hpp
+++ b/include/llama/View.hpp
@@ -1036,10 +1036,7 @@ namespace llama
 
         /// Creates a VirtualView given a parent \ref View, offset and size.
         LLAMA_FN_HOST_ACC_INLINE
-        VirtualView(ParentView& parentView, ArrayDims offset, ArrayDims size)
-            : parentView(parentView)
-            , offset(offset)
-            , size(size)
+        VirtualView(ParentView& parentView, ArrayDims offset) : parentView(parentView), offset(offset)
         {
         }
 
@@ -1102,6 +1099,5 @@ namespace llama
         ParentView& parentView; ///< reference to parent view.
         const ArrayDims offset; ///< offset this view's \ref ArrayDims coordinates are
                                 ///< shifted to the parent view.
-        const ArrayDims size;
     };
 } // namespace llama

--- a/include/llama/mapping/tree/TreeFromDimensions.hpp
+++ b/include/llama/mapping/tree/TreeFromDimensions.hpp
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 #pragma once
 
+#include "../../Core.hpp"
 #include "../../Tuple.hpp"
 
 #include <cstddef>

--- a/tests/core.cpp
+++ b/tests/core.cpp
@@ -43,7 +43,7 @@ TEST_CASE("prettyPrintType")
 {
     auto str = prettyPrintType(Particle());
 #ifdef _WIN32
-    boost::replace_all(str, "__int64", "long");
+    replace_all(str, "__int64", "long");
 #endif
     const auto ref = R"(llama::Record<
     llama::Field<

--- a/tests/treemap.cpp
+++ b/tests/treemap.cpp
@@ -788,7 +788,7 @@ TEST_CASE("treemapping")
 
     auto raw = prettyPrintType(mapping.basicTree);
 #ifdef _WIN32
-    boost::replace_all(raw, "__int64", "long");
+    replace_all(raw, "__int64", "long");
 #endif
     const auto ref = R"(llama::mapping::tree::Node<
     llama::NoName,
@@ -929,7 +929,7 @@ TEST_CASE("treemapping")
 
     auto raw2 = prettyPrintType(mapping.resultTree);
 #ifdef _WIN32
-    boost::replace_all(raw2, "__int64", "long");
+    replace_all(raw2, "__int64", "long");
 #endif
     const auto ref2 = R"(llama::mapping::tree::Node<
     llama::NoName,

--- a/tests/virtualview.cpp
+++ b/tests/virtualview.cpp
@@ -46,7 +46,7 @@ TEST_CASE("virtual view CTAD")
     constexpr ArrayDims viewSize{4096, 4096};
     auto view = allocView(llama::mapping::SoA<ArrayDims, Particle>(viewSize));
 
-    llama::VirtualView virtualView{view, {23, 42}, {13, 37}};
+    llama::VirtualView virtualView{view, {23, 42}};
 }
 
 TEST_CASE("fast virtual view")
@@ -61,14 +61,9 @@ TEST_CASE("fast virtual view")
         for (std::size_t y = 0; y < viewSize[1]; ++y)
             view(x, y) = x * y;
 
-    llama::VirtualView<decltype(view)> virtualView{
-        view,
-        {23, 42}, // offset
-        {13, 37} // size
-    };
+    llama::VirtualView<decltype(view)> virtualView{view, {23, 42}};
 
     CHECK(virtualView.offset == ArrayDims{23, 42});
-    CHECK(virtualView.size == ArrayDims{13, 37});
 
     CHECK(view(virtualView.offset)(tag::Pos(), tag::X()) == 966);
     CHECK(virtualView({0, 0})(tag::Pos(), tag::X()) == 966);
@@ -100,7 +95,7 @@ TEST_CASE("virtual view")
                 (x < iterations[0] - 1) ? miniSize[0] : (viewSize[0] - 1) % miniSize[0] + 1,
                 (y < iterations[1] - 1) ? miniSize[1] : (viewSize[1] - 1) % miniSize[1] + 1};
 
-            llama::VirtualView<decltype(view)> virtualView(view, {x * miniSize[0], y * miniSize[1]}, miniSize);
+            llama::VirtualView<decltype(view)> virtualView(view, {x * miniSize[0], y * miniSize[1]});
 
             using MiniMapping = llama::mapping::SoA<ArrayDims, Particle>;
             auto miniView = allocView(

--- a/tests/virtualview.cpp
+++ b/tests/virtualview.cpp
@@ -40,6 +40,15 @@ struct SqrtFunctor
     VirtualRecord vd;
 };
 
+TEST_CASE("virtual view CTAD")
+{
+    using ArrayDims = llama::ArrayDims<2>;
+    constexpr ArrayDims viewSize{4096, 4096};
+    auto view = allocView(llama::mapping::SoA<ArrayDims, Particle>(viewSize));
+
+    llama::VirtualView virtualView{view, {23, 42}, {13, 37}};
+}
+
 TEST_CASE("fast virtual view")
 {
     using ArrayDims = llama::ArrayDims<2>;


### PR DESCRIPTION
* replace the remaining boost string algorithms by the `replace_all` implementation in the tree mapping. Partially related to #159.
* add a test that VirtualView is constructible using CTAD.
* remove obsolete include directive.
* improve error message on using non-existing tag.
* remove unnecessary size of a VirtualView
* reword View documentation and remove showing direct call of `VirtualRecord::operator()`