### PR TITLE
Add arrayDims() getter to all mappings

### DIFF
--- a/examples/bufferguard/bufferguard.cpp
+++ b/examples/bufferguard/bufferguard.cpp
@@ -41,6 +41,11 @@ struct GuardMapping2D
     {
     }
 
+    constexpr auto arrayDims() const -> ArrayDims
+    {
+        return arrayDimsSize;
+    }
+
     constexpr auto blobSize(std::size_t i) const -> std::size_t
     {
         if (i >= centerOff)
@@ -177,6 +182,7 @@ private:
 public:
     static constexpr auto blobCount = centerOff + decltype(center)::blobCount;
 
+private:
     ArrayDims arrayDimsSize;
 };
 

--- a/examples/viewcopy/viewcopy.cpp
+++ b/examples/viewcopy/viewcopy.cpp
@@ -62,11 +62,11 @@ void naive_copy(
 {
     static_assert(std::is_same_v<typename Mapping1::RecordDim, typename Mapping2::RecordDim>);
 
-    if (srcView.mapping.arrayDimsSize != dstView.mapping.arrayDimsSize)
+    if (srcView.mapping.arrayDims() != dstView.mapping.arrayDims())
         throw std::runtime_error{"Array dimensions sizes are different"};
 
     llamaex::parallelForEachADCoord(
-        srcView.mapping.arrayDimsSize,
+        srcView.mapping.arrayDims(),
         numThreads,
         [&](auto ad)
         {
@@ -115,12 +115,12 @@ void aosoa_copy(
     static_assert(decltype(srcView.storageBlobs)::rank == 1);
     static_assert(decltype(dstView.storageBlobs)::rank == 1);
 
-    if (srcView.mapping.arrayDimsSize != dstView.mapping.arrayDimsSize)
+    if (srcView.mapping.arrayDims() != dstView.mapping.arrayDims())
         throw std::runtime_error{"Array dimensions sizes are different"};
 
     const auto flatSize = std::reduce(
-        std::begin(dstView.mapping.arrayDimsSize),
-        std::end(dstView.mapping.arrayDimsSize),
+        std::begin(dstView.mapping.arrayDims()),
+        std::end(dstView.mapping.arrayDims()),
         std::size_t{1},
         std::multiplies<>{});
 
@@ -199,7 +199,7 @@ template <typename Mapping, typename BlobType>
 auto hash(const llama::View<Mapping, BlobType>& view)
 {
     std::size_t acc = 0;
-    for (auto ad : llama::ArrayDimsIndexRange{view.mapping.arrayDimsSize})
+    for (auto ad : llama::ArrayDimsIndexRange{view.mapping.arrayDims()})
         llama::forEachLeaf<Particle>([&](auto coord) { boost::hash_combine(acc, view(ad)(coord)); });
     return acc;
 }
@@ -209,7 +209,7 @@ auto prepareViewAndHash(Mapping mapping)
     auto view = llama::allocView(mapping);
 
     auto value = 0.0f;
-    for (auto ad : llama::ArrayDimsIndexRange{mapping.arrayDimsSize})
+    for (auto ad : llama::ArrayDimsIndexRange{mapping.arrayDims()})
     {
         auto p = view(ad);
         p(tag::Pos{}, tag::X{}) = value++;

--- a/include/llama/Concepts.hpp
+++ b/include/llama/Concepts.hpp
@@ -15,6 +15,7 @@ namespace llama
     concept Mapping = requires(M m) {
         typename M::ArrayDims;
         typename M::RecordDim;
+        { m.arrayDims() } -> std::same_as<typename M::ArrayDims>;
         { M::blobCount } -> std::convertible_to<std::size_t>;
         Array<int, M::blobCount>{}; // validates constexpr-ness
         { m.blobSize(std::size_t{}) } -> std::same_as<std::size_t>;

--- a/include/llama/DumpMapping.hpp
+++ b/include/llama/DumpMapping.hpp
@@ -120,7 +120,7 @@ namespace llama
 
             std::vector<FieldBox<Mapping::ArrayDims::rank>> infos;
 
-            for (auto adCoord : ArrayDimsIndexRange{mapping.arrayDimsSize})
+            for (auto adCoord : ArrayDimsIndexRange{mapping.arrayDims()})
             {
                 forEachLeaf<RecordDim>(
                     [&](auto coord)

--- a/include/llama/Proofs.hpp
+++ b/include/llama/Proofs.hpp
@@ -74,7 +74,7 @@ namespace llama
                                          {
                                              if (collision)
                                                  return;
-                                             for (auto ad : llama::ArrayDimsIndexRange{m.arrayDimsSize})
+                                             for (auto ad : llama::ArrayDimsIndexRange{m.arrayDims()})
                                              {
                                                  using Type
                                                      = llama::GetType<typename Mapping::RecordDim, decltype(coord)>;

--- a/include/llama/View.hpp
+++ b/include/llama/View.hpp
@@ -938,12 +938,12 @@ namespace llama
 
         auto begin() -> iterator
         {
-            return {ArrayDimsIndexRange<ArrayDims::rank>{mapping.arrayDimsSize}.begin(), this};
+            return {ArrayDimsIndexRange<ArrayDims::rank>{mapping.arrayDims()}.begin(), this};
         }
 
         auto end() -> iterator
         {
-            return {ArrayDimsIndexRange<ArrayDims::rank>{mapping.arrayDimsSize}.end(), this};
+            return {ArrayDimsIndexRange<ArrayDims::rank>{mapping.arrayDims()}.end(), this};
         }
 
         Mapping mapping;

--- a/include/llama/mapping/AoS.hpp
+++ b/include/llama/mapping/AoS.hpp
@@ -30,6 +30,11 @@ namespace llama::mapping
         {
         }
 
+        LLAMA_FN_HOST_ACC_INLINE constexpr auto arrayDims() const -> ArrayDims
+        {
+            return arrayDimsSize;
+        }
+
         LLAMA_FN_HOST_ACC_INLINE constexpr auto blobSize(std::size_t) const -> std::size_t
         {
             return LinearizeArrayDimsFunctor{}.size(arrayDimsSize) * sizeOf<RecordDim, AlignAndPad>;
@@ -43,6 +48,7 @@ namespace llama::mapping
             return {0, offset};
         }
 
+    private:
         ArrayDims arrayDimsSize;
     };
 

--- a/include/llama/mapping/AoSoA.hpp
+++ b/include/llama/mapping/AoSoA.hpp
@@ -47,6 +47,11 @@ namespace llama::mapping
         {
         }
 
+        LLAMA_FN_HOST_ACC_INLINE constexpr auto arrayDims() const -> ArrayDims
+        {
+            return arrayDimsSize;
+        }
+
         LLAMA_FN_HOST_ACC_INLINE constexpr auto blobSize(std::size_t) const -> std::size_t
         {
             return LinearizeArrayDimsFunctor{}.size(arrayDimsSize) * sizeOf<RecordDim>;
@@ -64,6 +69,7 @@ namespace llama::mapping
             return {0, offset};
         }
 
+    private:
         ArrayDims arrayDimsSize;
     };
 

--- a/include/llama/mapping/Heatmap.hpp
+++ b/include/llama/mapping/Heatmap.hpp
@@ -33,6 +33,11 @@ namespace llama::mapping
         Heatmap(Heatmap&&) noexcept = default;
         auto operator=(Heatmap&&) noexcept -> Heatmap& = default;
 
+        LLAMA_FN_HOST_ACC_INLINE constexpr auto arrayDims() const -> ArrayDims
+        {
+            return mapping.arrayDims();
+        }
+
         LLAMA_FN_HOST_ACC_INLINE constexpr auto blobSize(std::size_t i) const -> std::size_t
         {
             LLAMA_FORCE_INLINE_RECURSIVE

--- a/include/llama/mapping/One.hpp
+++ b/include/llama/mapping/One.hpp
@@ -25,6 +25,15 @@ namespace llama::mapping
         {
         }
 
+        LLAMA_FN_HOST_ACC_INLINE constexpr auto arrayDims() const -> ArrayDims
+        {
+            // TODO: not sure if this is the right approach, since we take any ArrayDims in the ctor
+            ArrayDims ad;
+            for (auto i = 0; i < ArrayDims::rank; i++)
+                ad[i] = 1;
+            return ad;
+        }
+
         LLAMA_FN_HOST_ACC_INLINE constexpr auto blobSize(std::size_t) const -> std::size_t
         {
             return sizeOf<RecordDim>;

--- a/include/llama/mapping/SoA.hpp
+++ b/include/llama/mapping/SoA.hpp
@@ -32,6 +32,11 @@ namespace llama::mapping
         {
         }
 
+        LLAMA_FN_HOST_ACC_INLINE constexpr auto arrayDims() const -> ArrayDims
+        {
+            return arrayDimsSize;
+        }
+
         LLAMA_FN_HOST_ACC_INLINE
         constexpr auto blobSize(std::size_t blobIndex) const -> std::size_t
         {
@@ -95,6 +100,7 @@ namespace llama::mapping
             }
         }
 
+    private:
         ArrayDims arrayDimsSize;
     };
 

--- a/include/llama/mapping/Split.hpp
+++ b/include/llama/mapping/Split.hpp
@@ -80,8 +80,13 @@ namespace llama::mapping
         constexpr Split() = default;
 
         LLAMA_FN_HOST_ACC_INLINE
-        constexpr Split(ArrayDims size) : arrayDimsSize(size), mapping1(size), mapping2(size)
+        constexpr Split(ArrayDims size) : mapping1(size), mapping2(size)
         {
+        }
+
+        LLAMA_FN_HOST_ACC_INLINE constexpr auto arrayDims() const -> ArrayDims
+        {
+            return mapping1.arrayDims();
         }
 
         LLAMA_FN_HOST_ACC_INLINE constexpr auto blobSize(std::size_t i) const -> std::size_t
@@ -135,7 +140,6 @@ namespace llama::mapping
         }
 
     public:
-        ArrayDims arrayDimsSize = {};
         Mapping1 mapping1;
         Mapping2 mapping2;
     };

--- a/include/llama/mapping/Trace.hpp
+++ b/include/llama/mapping/Trace.hpp
@@ -64,6 +64,11 @@ namespace llama::mapping
             }
         }
 
+        LLAMA_FN_HOST_ACC_INLINE constexpr auto arrayDims() const -> ArrayDims
+        {
+            return mapping.arrayDims();
+        }
+
         LLAMA_FN_HOST_ACC_INLINE constexpr auto blobSize(std::size_t i) const -> std::size_t
         {
             LLAMA_FORCE_INLINE_RECURSIVE

--- a/tests/iterator.cpp
+++ b/tests/iterator.cpp
@@ -89,7 +89,7 @@ TEST_CASE("iterator.transform_reduce")
             vd(tag::Y{}) = ++i;
             vd(tag::Z{}) = ++i;
         }
-        // returned type is a llama::One<Particle>
+        // returned type is a llama::One<Position>
         auto [sumX, sumY, sumZ]
             = std::transform_reduce(begin(aosView), end(aosView), begin(soaView), llama::One<Position>{});
 

--- a/tests/proofs.cpp
+++ b/tests/proofs.cpp
@@ -57,6 +57,11 @@ namespace
         {
         }
 
+        LLAMA_FN_HOST_ACC_INLINE constexpr auto arrayDims() const -> ArrayDims
+        {
+            return arrayDimsSize;
+        }
+
         constexpr auto blobSize(std::size_t) const -> std::size_t
         {
             return std::reduce(std::begin(arrayDimsSize), std::end(arrayDimsSize), std::size_t{1}, std::multiplies{})
@@ -69,6 +74,7 @@ namespace
             return {0, 0};
         }
 
+    private:
         ArrayDims arrayDimsSize;
     };
 } // namespace
@@ -100,6 +106,11 @@ namespace
         {
         }
 
+        LLAMA_FN_HOST_ACC_INLINE constexpr auto arrayDims() const -> ArrayDims
+        {
+            return arrayDimsSize;
+        }
+
         constexpr auto blobSize(std::size_t) const -> std::size_t
         {
             return Modulus * llama::sizeOf<RecordDim>;
@@ -114,6 +125,7 @@ namespace
             return {blob, offset};
         }
 
+    private:
         ArrayDims arrayDimsSize;
     };
 } // namespace


### PR DESCRIPTION
This avoids accessing the arrayDimsSize member and thus allows mappings which do not store their size in the mapping object itself.