### PR TITLE
Nbody cleanup and AoS SIMD variant

### DIFF
--- a/examples/nbody/CMakeLists.txt
+++ b/examples/nbody/CMakeLists.txt
@@ -15,7 +15,10 @@ if (Vc_FOUND)
 	target_link_libraries(${PROJECT_NAME} PRIVATE Vc::Vc)
 endif()
 
-if (CMAKE_CXX_COMPILER_ID STREQUAL "GNU" OR CMAKE_CXX_COMPILER_ID STREQUAL "Clang")
+if (CMAKE_CXX_COMPILER_ID STREQUAL "GNU" OR
+	CMAKE_CXX_COMPILER_ID STREQUAL "Clang" OR
+	CMAKE_CXX_COMPILER_ID STREQUAL "IntelLLVM" OR
+	CMAKE_CXX_COMPILER_ID STREQUAL "Intel")
 	target_compile_options(${PROJECT_NAME} PRIVATE
 		-fno-math-errno # sqrt prevents vectorization otherwise
 		-march=native

--- a/examples/nbody/nbody.cpp
+++ b/examples/nbody/nbody.cpp
@@ -1085,6 +1085,107 @@ namespace manualAoSoA_Vc
         return 0;
     }
 } // namespace manualAoSoA_Vc
+
+namespace manualAoS_Vc
+{
+    using manualAoS::Particle;
+    using manualAoSoA_Vc::BLOCKS;
+    using manualAoSoA_Vc::LANES;
+    using manualAoSoA_Vc::pPInteraction;
+    using manualAoSoA_Vc::vec;
+
+    constexpr int offsets[8]
+        = {sizeof(Particle),
+           sizeof(Particle),
+           sizeof(Particle),
+           sizeof(Particle),
+           sizeof(Particle),
+           sizeof(Particle),
+           sizeof(Particle),
+           sizeof(Particle)};
+
+
+    void update(Particle* particles, int threads)
+    {
+#    pragma omp parallel for schedule(static) num_threads(threads)
+        for (std::ptrdiff_t i = 0; i < PROBLEM_SIZE; i += LANES)
+        {
+            // gather
+            auto& pi = particles[i];
+            const vec piposx = vec(&pi.pos.x, offsets);
+            const vec piposy = vec(&pi.pos.y, offsets);
+            const vec piposz = vec(&pi.pos.z, offsets);
+            vec pivelx = vec(&pi.vel.x, offsets);
+            vec pively = vec(&pi.vel.y, offsets);
+            vec pivelz = vec(&pi.vel.z, offsets);
+
+            for (std::size_t j = 0; j < PROBLEM_SIZE; j++)
+            {
+                const auto& pj = particles[j];
+                const vec pjposx = pj.pos.x;
+                const vec pjposy = pj.pos.y;
+                const vec pjposz = pj.pos.z;
+                const vec pjmass = pj.mass;
+
+                pPInteraction(piposx, piposy, piposz, pivelx, pively, pivelz, pjposx, pjposy, pjposz, pjmass);
+            }
+
+            // scatter
+            pivelx.scatter(&pi.vel.x, offsets);
+            pively.scatter(&pi.vel.y, offsets);
+            pivelz.scatter(&pi.vel.z, offsets);
+        }
+    }
+
+    void move(Particle* particles, int threads)
+    {
+#    pragma omp parallel for schedule(static) num_threads(threads)
+        for (std::ptrdiff_t i = 0; i < PROBLEM_SIZE; i += LANES)
+        {
+            auto& pi = particles[i];
+            (vec(&pi.pos.x, offsets) + vec(&pi.vel.x, offsets) * TIMESTEP).scatter(&pi.pos.x, offsets);
+            (vec(&pi.pos.y, offsets) + vec(&pi.vel.y, offsets) * TIMESTEP).scatter(&pi.pos.y, offsets);
+            (vec(&pi.pos.z, offsets) + vec(&pi.vel.z, offsets) * TIMESTEP).scatter(&pi.pos.z, offsets);
+        }
+    }
+
+    auto main(std::ostream& plotFile, int threads) -> int
+    {
+        auto title = "AoS Vc " + std::to_string(LANES) + "L " + std::to_string(threads) + "Th";
+        std::cout << title << '\n';
+        Stopwatch watch;
+
+        std::vector<Particle> particles(PROBLEM_SIZE);
+        watch.printAndReset("alloc");
+
+        std::default_random_engine engine;
+        std::normal_distribution<FP> dist(FP(0), FP(1));
+        for (auto& p : particles)
+        {
+            p.pos.x = dist(engine);
+            p.pos.y = dist(engine);
+            p.pos.z = dist(engine);
+            p.vel.x = dist(engine) / FP(10);
+            p.vel.y = dist(engine) / FP(10);
+            p.vel.z = dist(engine) / FP(10);
+            p.mass = dist(engine) / FP(100);
+        }
+        watch.printAndReset("init");
+
+        double sumUpdate = 0;
+        double sumMove = 0;
+        for (std::size_t s = 0; s < STEPS; ++s)
+        {
+            update(particles.data(), threads);
+            sumUpdate += watch.printAndReset("update", '\t');
+            move(particles.data(), threads);
+            sumMove += watch.printAndReset("move");
+        }
+        plotFile << std::quoted(title) << "\t" << sumUpdate / STEPS << '\t' << sumMove / STEPS << '\n';
+
+        return 0;
+    }
+} // namespace manualAoS_Vc
 #endif
 
 auto main() -> int
@@ -1131,6 +1232,7 @@ try
                 continue;
             r += manualAoSoA_Vc::main(plotFile, threads, useUpdate1, tiled);
         }
+    r += manualAoS_Vc::main(plotFile, threads);
 #endif
 
     std::cout << "Plot with: ./nbody.sh\n";

--- a/examples/nbody/nbody.cpp
+++ b/examples/nbody/nbody.cpp
@@ -1244,6 +1244,7 @@ set style fill solid
 set xtics rotate by 45 right
 set key out top center maxrows 3
 set yrange [0:*]
+set ylabel "runtime [s]"
 plot 'nbody.tsv' using 2:xtic(1) ti col, "" using 4 ti col
 )",
         PROBLEM_SIZE / 1000,


### PR DESCRIPTION
* Remove all non-accumulator versions of the n-body. The variants not using an accumulator variable are slower and issue unnecessary stores to memory.
* Set optimization flags when building with Intel compilers
* Add AoS SIMD version
* Improve the labels of the plot