### PR TITLE
n-body benchmark improvements

### DIFF
--- a/examples/nbody/nbody.cpp
+++ b/examples/nbody/nbody.cpp
@@ -1342,7 +1342,7 @@ try
     using vec = Vc::Vector<FP>;
     // using vec = Vc::SimdArray<FP, 16>;
 
-    std::cout << PROBLEM_SIZE / 1000 << "k particles "
+    std::cout << PROBLEM_SIZE / 1024 << "ki particles "
               << "(" << PROBLEM_SIZE * sizeof(FP) * 7 / 1024 << "kiB)\n"
               << "Threads: " << std::thread::hardware_concurrency() << "\n"
               << "SIMD lanes: " << vec::size() << "\n";
@@ -1407,7 +1407,7 @@ try
     std::cout << "Plot with: ./nbody.sh\n";
     std::ofstream{"nbody.sh"} << fmt::format(
         R"(#!/usr/bin/gnuplot -p
-set title "nbody CPU {0}k particles on {1}"
+set title "nbody CPU {}ki particles on {}"
 set style data histograms
 set style fill solid
 set xtics rotate by 45 right
@@ -1419,7 +1419,7 @@ set y2label "move runtime [s]"
 set y2tics auto
 plot 'nbody.tsv' using 2:xtic(1) ti col axis x1y1, "" using 3 ti col axis x1y2
 )",
-        PROBLEM_SIZE / 1000,
+        PROBLEM_SIZE / 1024,
         boost::asio::ip::host_name());
 
     return r;

--- a/examples/nbody/nbody.cpp
+++ b/examples/nbody/nbody.cpp
@@ -1052,7 +1052,8 @@ namespace manualAoSoA_Vc
         auto title = "AoSoA" + std::to_string(LANES) + " Vc" + (useUpdate1 ? " w1r8" : " w8r1"); // NOLINT
         if (tiled)
             title += " tiled";
-        title += " " + std::to_string(threads) + "Thrds";
+        if (threads > 1)
+            title += " " + std::to_string(threads) + "Thrds";
 
         std::cout << title << '\n';
         Stopwatch watch;
@@ -1181,7 +1182,9 @@ namespace manualAoS_Vc
     template <std::size_t LANES>
     auto main(std::ostream& plotFile, int threads) -> int
     {
-        auto title = "AoS Vc " + std::to_string(LANES) + "Lns " + std::to_string(threads) + "Thrds";
+        auto title = "AoS Vc " + std::to_string(LANES) + "Lns";
+        if (threads > 1)
+            title += " " + std::to_string(threads) + "Thrds";
         std::cout << title << '\n';
         Stopwatch watch;
 
@@ -1269,7 +1272,9 @@ namespace manualSoA_Vc
 
     auto main(std::ostream& plotFile, int threads) -> int
     {
-        auto title = "SoA Vc " + std::to_string(threads) + "Thrds";
+        auto title = "SoA Vc"s;
+        if (threads > 1)
+            title += " " + std::to_string(threads) + "Thrds";
         std::cout << title << '\n';
         Stopwatch watch;
 


### PR DESCRIPTION
* add a manually vectorized SoA variant
* allow to disable `update()` to benchmark `move()` on large particle counts
* plot `move()` together with `update()` on second ordinate
* centralizing choice of Vc vector type (allows switching to SIMD arrays in one place)
* minor changes to text and plot outputs (printing SIMD lanes, using kibi instead of kilo particles)