### PR TITLE
Add GPU Gems n-body for reference

### DIFF
--- a/examples/cuda/nbody/CMakeLists.txt
+++ b/examples/cuda/nbody/CMakeLists.txt
@@ -2,6 +2,7 @@ cmake_minimum_required (VERSION 3.18.3)
 project(llama-cuda-nbody CXX CUDA)
 set(CMAKE_CUDA_ARCHITECTURES "35" CACHE STRING "CUDA architectures to compile for")
 
+find_package(CUDAToolkit) # for include directories
 find_package(fmt CONFIG REQUIRED)
 if (NOT TARGET llama::llama)
 	find_package(llama REQUIRED)
@@ -9,4 +10,4 @@ endif()
 add_executable(${PROJECT_NAME} nbody.cu ../../common/Stopwatch.hpp)
 target_compile_features(${PROJECT_NAME} PRIVATE cuda_std_17)
 target_compile_options(${PROJECT_NAME} PUBLIC $<$<COMPILE_LANGUAGE:CUDA>:--expt-extended-lambda --expt-relaxed-constexpr>)
-target_link_libraries(${PROJECT_NAME} PRIVATE llama::llama fmt::fmt)
+target_link_libraries(${PROJECT_NAME} PRIVATE llama::llama CUDA::cudart fmt::fmt)

--- a/examples/cuda/nbody/nbody.cu
+++ b/examples/cuda/nbody/nbody.cu
@@ -169,6 +169,9 @@ try
             return "AoSoA" + std::to_string(AOSOA_LANES);
         if (m == 4)
             return "Split SoA";
+        if (m == 5)
+            return "Split AoS";
+        std::abort();
     };
     auto title = "GM " + mappingName(Mapping);
     if (useSharedMemory)
@@ -193,6 +196,14 @@ try
                 llama::RecordCoord<1>,
                 llama::mapping::PreconfiguredSoA<>::type,
                 llama::mapping::PreconfiguredSoA<>::type,
+                true>{arrayDims};
+        if constexpr (Mapping == 5)
+            return llama::mapping::Split<
+                decltype(arrayDims),
+                Particle,
+                llama::RecordCoord<1>,
+                llama::mapping::PreconfiguredAoS<>::type,
+                llama::mapping::PreconfiguredAoS<>::type,
                 true>{arrayDims};
     }();
 
@@ -473,8 +484,8 @@ try
     plotFile << "\"\"\t\"update\"\t\"move\"\n";
 
     using namespace boost::mp11;
-    mp_for_each<mp_iota_c<5>>([&](auto i) { run<decltype(i)::value, 0>(plotFile, false); });
-    mp_for_each<mp_iota_c<5>>(
+    mp_for_each<mp_iota_c<6>>([&](auto i) { run<decltype(i)::value, 0>(plotFile, false); });
+    mp_for_each<mp_iota_c<6>>(
         [&](auto i)
         { mp_for_each<mp_iota_c<4>>([&](auto j) { run<decltype(i)::value, decltype(j)::value>(plotFile, true); }); });
     manual::run(plotFile);


### PR DESCRIPTION
Adds the GPU Gems n-body example for comparison with the following adaptation:
* Allow multiple particles loaded per thread.
* Add timestep multiplication and use rsqrt.
* Allow compilation with double.

Also adds a Split AoS mapping variant with LLAMA, which has a similar memory layout than the GPU gems version.