### PR TITLE
Improvements around the viewcopy example

### DIFF
--- a/examples/viewcopy/viewcopy.cpp
+++ b/examples/viewcopy/viewcopy.cpp
@@ -348,6 +348,7 @@ set style data histograms
 set style fill solid
 set xtics rotate by 45 right
 set key out top center maxrows 3
+set ylabel "runtime [s]"
 plot 'viewcopy.tsv' using 2:xtic(1) ti col, "" using 3 ti col, "" using 4 ti col, "" using 5 ti col, "" using 6 ti col, "" using 7 ti col, "" using 8 ti col, "" using 9 ti col, "" using 10 ti col
 )";
 }

--- a/examples/viewcopy/viewcopy.cpp
+++ b/examples/viewcopy/viewcopy.cpp
@@ -166,6 +166,8 @@ void aosoa_copy(
                     [&](auto coord)
                     {
                         constexpr auto L = std::min(LanesSrc, LanesDst);
+                        static_assert(LanesSrc % L == 0);
+                        static_assert(LanesDst % L == 0);
                         for (std::size_t j = 0; j < LanesSrc; j += L)
                         {
                             constexpr auto bytes = L * sizeof(llama::GetType<RecordDim, decltype(coord)>);

--- a/examples/viewcopy/viewcopy.cpp
+++ b/examples/viewcopy/viewcopy.cpp
@@ -135,8 +135,8 @@ void aosoa_copy(
     const auto arrayDims = dstView.mapping.arrayDims();
     const auto flatSize = std::reduce(std::begin(arrayDims), std::end(arrayDims), std::size_t{1}, std::multiplies<>{});
 
-    const std::byte* src = srcView.storageBlobs[0].data();
-    std::byte* dst = dstView.storageBlobs[0].data();
+    const std::byte* src = &srcView.storageBlobs[0][0];
+    std::byte* dst = &dstView.storageBlobs[0][0];
 
     // the same as AoSoA::blobNrAndOffset but takes a flat array index
     auto map = [](std::size_t flatArrayIndex, auto coord, std::size_t Lanes)

--- a/examples/viewcopy/viewcopy.cpp
+++ b/examples/viewcopy/viewcopy.cpp
@@ -132,11 +132,8 @@ void aosoa_copy(
     if (srcView.mapping.arrayDims() != dstView.mapping.arrayDims())
         throw std::runtime_error{"Array dimensions sizes are different"};
 
-    const auto flatSize = std::reduce(
-        std::begin(dstView.mapping.arrayDims()),
-        std::end(dstView.mapping.arrayDims()),
-        std::size_t{1},
-        std::multiplies<>{});
+    const auto arrayDims = dstView.mapping.arrayDims();
+    const auto flatSize = std::reduce(std::begin(arrayDims), std::end(arrayDims), std::size_t{1}, std::multiplies<>{});
 
     const std::byte* src = srcView.storageBlobs[0].data();
     std::byte* dst = dstView.storageBlobs[0].data();

--- a/include/llama/ArrayDimsIndexRange.hpp
+++ b/include/llama/ArrayDimsIndexRange.hpp
@@ -22,6 +22,7 @@ namespace llama
 
         constexpr ArrayDimsIndexIterator() noexcept = default;
 
+        LLAMA_FN_HOST_ACC_INLINE
         constexpr ArrayDimsIndexIterator(ArrayDims<Dim> size, ArrayDims<Dim> current) noexcept
             : lastIndex(
                 [size]() mutable
@@ -39,16 +40,19 @@ namespace llama
         constexpr auto operator=(const ArrayDimsIndexIterator&) noexcept -> ArrayDimsIndexIterator& = default;
         constexpr auto operator=(ArrayDimsIndexIterator&&) noexcept -> ArrayDimsIndexIterator& = default;
 
+        LLAMA_FN_HOST_ACC_INLINE
         constexpr auto operator*() const noexcept -> value_type
         {
             return current;
         }
 
+        LLAMA_FN_HOST_ACC_INLINE
         constexpr auto operator->() const noexcept -> pointer
         {
             return {**this};
         }
 
+        LLAMA_FN_HOST_ACC_INLINE
         constexpr auto operator++() noexcept -> ArrayDimsIndexIterator&
         {
             for (auto i = (int) Dim - 1; i >= 0; i--)
@@ -64,6 +68,7 @@ namespace llama
             return *this;
         }
 
+        LLAMA_FN_HOST_ACC_INLINE
         constexpr auto operator++(int) noexcept -> ArrayDimsIndexIterator
         {
             auto tmp = *this;
@@ -71,6 +76,7 @@ namespace llama
             return tmp;
         }
 
+        LLAMA_FN_HOST_ACC_INLINE
         constexpr auto operator--() noexcept -> ArrayDimsIndexIterator&
         {
             for (auto i = (int) Dim - 1; i >= 0; i--)
@@ -86,6 +92,7 @@ namespace llama
             return *this;
         }
 
+        LLAMA_FN_HOST_ACC_INLINE
         constexpr auto operator--(int) noexcept -> ArrayDimsIndexIterator
         {
             auto tmp = *this;
@@ -93,11 +100,13 @@ namespace llama
             return tmp;
         }
 
+        LLAMA_FN_HOST_ACC_INLINE
         constexpr auto operator[](difference_type i) const noexcept -> reference
         {
             return *(*this + i);
         }
 
+        LLAMA_FN_HOST_ACC_INLINE
         constexpr auto operator+=(difference_type n) noexcept -> ArrayDimsIndexIterator&
         {
             // add n to all lower dimensions with carry
@@ -127,28 +136,33 @@ namespace llama
             return *this;
         }
 
+        LLAMA_FN_HOST_ACC_INLINE
         friend constexpr auto operator+(ArrayDimsIndexIterator it, difference_type n) noexcept -> ArrayDimsIndexIterator
         {
             it += n;
             return it;
         }
 
+        LLAMA_FN_HOST_ACC_INLINE
         friend constexpr auto operator+(difference_type n, ArrayDimsIndexIterator it) noexcept -> ArrayDimsIndexIterator
         {
             return it + n;
         }
 
+        LLAMA_FN_HOST_ACC_INLINE
         constexpr auto operator-=(difference_type n) noexcept -> ArrayDimsIndexIterator&
         {
             return operator+=(-n);
         }
 
+        LLAMA_FN_HOST_ACC_INLINE
         friend constexpr auto operator-(ArrayDimsIndexIterator it, difference_type n) noexcept -> ArrayDimsIndexIterator
         {
             it -= n;
             return it;
         }
 
+        LLAMA_FN_HOST_ACC_INLINE
         friend constexpr auto operator-(const ArrayDimsIndexIterator& a, const ArrayDimsIndexIterator& b) noexcept
             -> difference_type
         {
@@ -165,6 +179,7 @@ namespace llama
             return n;
         }
 
+        LLAMA_FN_HOST_ACC_INLINE
         friend constexpr auto operator==(
             const ArrayDimsIndexIterator<Dim>& a,
             const ArrayDimsIndexIterator<Dim>& b) noexcept -> bool
@@ -173,6 +188,7 @@ namespace llama
             return a.current == b.current;
         }
 
+        LLAMA_FN_HOST_ACC_INLINE
         friend constexpr auto operator!=(
             const ArrayDimsIndexIterator<Dim>& a,
             const ArrayDimsIndexIterator<Dim>& b) noexcept -> bool
@@ -180,6 +196,7 @@ namespace llama
             return !(a == b);
         }
 
+        LLAMA_FN_HOST_ACC_INLINE
         friend constexpr auto operator<(const ArrayDimsIndexIterator& a, const ArrayDimsIndexIterator& b) noexcept
             -> bool
         {
@@ -191,18 +208,21 @@ namespace llama
                 std::end(b.current));
         }
 
+        LLAMA_FN_HOST_ACC_INLINE
         friend constexpr auto operator>(const ArrayDimsIndexIterator& a, const ArrayDimsIndexIterator& b) noexcept
             -> bool
         {
             return b < a;
         }
 
+        LLAMA_FN_HOST_ACC_INLINE
         friend constexpr auto operator<=(const ArrayDimsIndexIterator& a, const ArrayDimsIndexIterator& b) noexcept
             -> bool
         {
             return !(a > b);
         }
 
+        LLAMA_FN_HOST_ACC_INLINE
         friend constexpr auto operator>=(const ArrayDimsIndexIterator& a, const ArrayDimsIndexIterator& b) noexcept
             -> bool
         {
@@ -223,15 +243,18 @@ namespace llama
     {
         constexpr ArrayDimsIndexRange() noexcept = default;
 
+        LLAMA_FN_HOST_ACC_INLINE
         constexpr ArrayDimsIndexRange(ArrayDims<Dim> size) noexcept : size(size)
         {
         }
 
+        LLAMA_FN_HOST_ACC_INLINE
         constexpr auto begin() const noexcept -> ArrayDimsIndexIterator<Dim>
         {
             return {size, ArrayDims<Dim>{}};
         }
 
+        LLAMA_FN_HOST_ACC_INLINE
         constexpr auto end() const noexcept -> ArrayDimsIndexIterator<Dim>
         {
             auto endPos = ArrayDims<Dim>{};

--- a/include/llama/View.hpp
+++ b/include/llama/View.hpp
@@ -699,7 +699,7 @@ namespace llama
         using ADIterator = ArrayDimsIndexIterator<View::ArrayDims::rank>;
 
         using iterator_category = std::random_access_iterator_tag;
-        using value_type = typename View::VirtualRecordType;
+        using value_type = VirtualRecord<View>;
         using difference_type = typename ADIterator::difference_type;
         using pointer = internal::IndirectValue<value_type>;
         using reference = value_type;
@@ -843,9 +843,10 @@ namespace llama
         using Mapping = T_Mapping;
         using ArrayDims = typename Mapping::ArrayDims;
         using RecordDim = typename Mapping::RecordDim;
-        using VirtualRecordType = VirtualRecord<View<Mapping, BlobType>>;
-        using VirtualRecordTypeConst = VirtualRecord<const View<Mapping, BlobType>>;
+        using VirtualRecordType = VirtualRecord<View>;
+        using VirtualRecordTypeConst = VirtualRecord<const View>;
         using iterator = Iterator<View>;
+        using const_iterator = Iterator<const View>;
 
         View() = default;
 
@@ -941,7 +942,17 @@ namespace llama
             return {ArrayDimsIndexRange<ArrayDims::rank>{mapping.arrayDims()}.begin(), this};
         }
 
+        auto begin() const -> const_iterator
+        {
+            return {ArrayDimsIndexRange<ArrayDims::rank>{mapping.arrayDims()}.begin(), this};
+        }
+
         auto end() -> iterator
+        {
+            return {ArrayDimsIndexRange<ArrayDims::rank>{mapping.arrayDims()}.end(), this};
+        }
+
+        auto end() const -> const_iterator
         {
             return {ArrayDimsIndexRange<ArrayDims::rank>{mapping.arrayDims()}.end(), this};
         }

--- a/include/llama/View.hpp
+++ b/include/llama/View.hpp
@@ -704,11 +704,14 @@ namespace llama
         using pointer = internal::IndirectValue<value_type>;
         using reference = value_type;
 
+        LLAMA_FN_HOST_ACC_INLINE
         constexpr auto operator++() -> Iterator&
         {
             ++adIndex;
             return *this;
         }
+
+        LLAMA_FN_HOST_ACC_INLINE
         constexpr auto operator++(int) -> Iterator
         {
             auto tmp = *this;
@@ -716,12 +719,14 @@ namespace llama
             return tmp;
         }
 
+        LLAMA_FN_HOST_ACC_INLINE
         constexpr auto operator--() -> Iterator&
         {
             --adIndex;
             return *this;
         }
 
+        LLAMA_FN_HOST_ACC_INLINE
         constexpr auto operator--(int) -> Iterator
         {
             auto tmp{*this};
@@ -729,80 +734,95 @@ namespace llama
             return tmp;
         }
 
+        LLAMA_FN_HOST_ACC_INLINE
         constexpr auto operator*() const -> reference
         {
             return (*view)(*adIndex);
         }
 
+        LLAMA_FN_HOST_ACC_INLINE
         constexpr auto operator->() const -> pointer
         {
             return {**this};
         }
 
+        LLAMA_FN_HOST_ACC_INLINE
         constexpr auto operator[](difference_type i) const -> reference
         {
             return *(*this + i);
         }
 
+        LLAMA_FN_HOST_ACC_INLINE
         constexpr auto operator+=(difference_type n) -> Iterator&
         {
             adIndex += n;
             return *this;
         }
 
+        LLAMA_FN_HOST_ACC_INLINE
         friend constexpr auto operator+(Iterator it, difference_type n) -> Iterator
         {
             it += n;
             return it;
         }
 
+        LLAMA_FN_HOST_ACC_INLINE
         friend constexpr auto operator+(difference_type n, Iterator it) -> Iterator
         {
             return it + n;
         }
 
+        LLAMA_FN_HOST_ACC_INLINE
         constexpr auto operator-=(difference_type n) -> Iterator&
         {
             adIndex -= n;
             return *this;
         }
 
+        LLAMA_FN_HOST_ACC_INLINE
         friend constexpr auto operator-(Iterator it, difference_type n) -> Iterator
         {
             it -= n;
             return it;
         }
 
+        LLAMA_FN_HOST_ACC_INLINE
         friend constexpr auto operator-(const Iterator& a, const Iterator& b) -> difference_type
         {
             return static_cast<std::ptrdiff_t>(a.adIndex - b.adIndex);
         }
 
+        LLAMA_FN_HOST_ACC_INLINE
         friend constexpr auto operator==(const Iterator& a, const Iterator& b) -> bool
         {
             return a.adIndex == b.adIndex;
         }
 
+        LLAMA_FN_HOST_ACC_INLINE
         friend constexpr auto operator!=(const Iterator& a, const Iterator& b) -> bool
         {
             return !(a == b);
         }
 
+        LLAMA_FN_HOST_ACC_INLINE
         friend constexpr auto operator<(const Iterator& a, const Iterator& b) -> bool
         {
             return a.adIndex < b.adIndex;
         }
 
+        LLAMA_FN_HOST_ACC_INLINE
         friend constexpr auto operator>(const Iterator& a, const Iterator& b) -> bool
         {
             return b < a;
         }
 
+        LLAMA_FN_HOST_ACC_INLINE
         friend constexpr auto operator<=(const Iterator& a, const Iterator& b) -> bool
         {
             return !(a > b);
         }
 
+        LLAMA_FN_HOST_ACC_INLINE
         friend constexpr auto operator>=(const Iterator& a, const Iterator& b) -> bool
         {
             return !(a < b);
@@ -937,21 +957,25 @@ namespace llama
             return (*this) (index);
         }
 
+        LLAMA_FN_HOST_ACC_INLINE
         auto begin() -> iterator
         {
             return {ArrayDimsIndexRange<ArrayDims::rank>{mapping.arrayDims()}.begin(), this};
         }
 
+        LLAMA_FN_HOST_ACC_INLINE
         auto begin() const -> const_iterator
         {
             return {ArrayDimsIndexRange<ArrayDims::rank>{mapping.arrayDims()}.begin(), this};
         }
 
+        LLAMA_FN_HOST_ACC_INLINE
         auto end() -> iterator
         {
             return {ArrayDimsIndexRange<ArrayDims::rank>{mapping.arrayDims()}.end(), this};
         }
 
+        LLAMA_FN_HOST_ACC_INLINE
         auto end() const -> const_iterator
         {
             return {ArrayDimsIndexRange<ArrayDims::rank>{mapping.arrayDims()}.end(), this};

--- a/tests/iterator.cpp
+++ b/tests/iterator.cpp
@@ -32,8 +32,9 @@ TEST_CASE("iterator")
             vd(tag::Z{}) = 3;
         }
         std::transform(begin(view), end(view), begin(view), [](auto vd) { return vd * 2; });
+        const auto& cview = std::as_const(view);
         const int sumY
-            = std::accumulate(begin(view), end(view), 0, [](int acc, auto vd) { return acc + vd(tag::Y{}); });
+            = std::accumulate(begin(cview), end(cview), 0, [](int acc, auto vd) { return acc + vd(tag::Y{}); });
         CHECK(sumY == 128);
     };
     test(llama::ArrayDims{32});


### PR DESCRIPTION
* make `begin`/`end` work on const views.
* add a copy benchmark using `std::copy`
* fix a bug where we took `begin` of a temporary
* add LLAMA_FN_HOST_ACC_INLINE to `ArrayDimsIndexIterator`, `ArrayDimsIndexRange` and `Iterator`
* refactor viewcopy benchmark driver