### PR TITLE
Add SoA <-> AoSoA viewcopy and improve plot

### DIFF
--- a/examples/viewcopy/CMakeLists.txt
+++ b/examples/viewcopy/CMakeLists.txt
@@ -9,3 +9,16 @@ if (NOT TARGET llama::llama)
 endif()
 add_executable(${PROJECT_NAME} viewcopy.cpp ../common/Stopwatch.hpp)
 target_link_libraries(${PROJECT_NAME} PRIVATE llama::llama OpenMP::OpenMP_CXX)
+
+if (CMAKE_CXX_COMPILER_ID STREQUAL "GNU" OR
+	CMAKE_CXX_COMPILER_ID STREQUAL "Clang" OR
+	CMAKE_CXX_COMPILER_ID STREQUAL "IntelLLVM" OR
+	CMAKE_CXX_COMPILER_ID STREQUAL "Intel")
+	target_compile_options(${PROJECT_NAME} PRIVATE
+		-march=native
+	)
+elseif(MSVC)
+	target_compile_options(${PROJECT_NAME} PRIVATE
+		/arch:AVX2
+	)
+endif()

--- a/examples/viewcopy/viewcopy.cpp
+++ b/examples/viewcopy/viewcopy.cpp
@@ -380,7 +380,7 @@ inline constexpr auto is_AoSoA<llama::mapping::AoSoA<AD, RD, L>> = true;
 auto main() -> int
 try
 {
-    const auto numThreads = static_cast<std::size_t>(omp_get_num_threads());
+    const auto numThreads = static_cast<std::size_t>(omp_get_max_threads());
     std::cout << "Threads: " << numThreads << "\n";
 
     const auto arrayDims = llama::ArrayDims{1024, 1024, 16};

--- a/examples/viewcopy/viewcopy.cpp
+++ b/examples/viewcopy/viewcopy.cpp
@@ -10,6 +10,8 @@
 #include <omp.h>
 #include <string_view>
 
+constexpr auto REPETITIONS = 5;
+
 // clang-format off
 namespace tag
 {
@@ -402,8 +404,9 @@ try
         {
             auto dstView = llama::allocView(dstMapping);
             Stopwatch watch;
-            copy(srcView, dstView);
-            const auto seconds = watch.printAndReset(name, '\t');
+            for (auto i = 0; i < REPETITIONS; i++)
+                copy(srcView, dstView);
+            const auto seconds = watch.printAndReset(name, '\t') / REPETITIONS;
             const auto gbs = (dataSize / seconds) / (1024.0 * 1024.0 * 1024.0);
             const auto dstHash = hash(dstView);
             std::cout << gbs << "GiB/s\t" << (srcHash == dstHash ? "" : "\thash BAD ") << "\n";

--- a/examples/viewcopy/viewcopy.cpp
+++ b/examples/viewcopy/viewcopy.cpp
@@ -251,6 +251,7 @@ try
     std::cout << "Threads: " << numThreads << "\n";
 
     const auto arrayDims = llama::ArrayDims{1024, 1024, 16};
+    const auto dataSize = std::reduce(arrayDims.begin(), arrayDims.end(), std::size_t{1}, std::multiplies{}) * llama::sizeOf<Particle>;
 
     std::ofstream plotFile{"viewcopy.tsv"};
     plotFile.exceptions(std::ios::badbit | std::ios::failbit);
@@ -271,9 +272,10 @@ try
             Stopwatch watch;
             copy(srcView, dstView);
             const auto seconds = watch.printAndReset(name, '\t');
+            const auto gbs = (dataSize / seconds) / (1024.0 * 1024.0 * 1024.0);
             const auto dstHash = hash(dstView);
-            std::cout << (srcHash == dstHash ? "" : "\thash BAD ") << "\n";
-            plotFile << seconds << "\t";
+            std::cout << gbs << "GiB/s\t" << (srcHash == dstHash ? "" : "\thash BAD ") << "\n";
+            plotFile << gbs << "\t";
         };
 
         benchmarkCopy("naive copy", [](const auto& srcView, auto& dstView) { naive_copy(srcView, dstView); });
@@ -348,7 +350,7 @@ set style data histograms
 set style fill solid
 set xtics rotate by 45 right
 set key out top center maxrows 3
-set ylabel "runtime [s]"
+set ylabel "throughput [GiB/s]"
 plot 'viewcopy.tsv' using 2:xtic(1) ti col, "" using 3 ti col, "" using 4 ti col, "" using 5 ti col, "" using 6 ti col, "" using 7 ti col, "" using 8 ti col, "" using 9 ti col, "" using 10 ti col
 )";
 }

--- a/examples/viewcopy/viewcopy.cpp
+++ b/examples/viewcopy/viewcopy.cpp
@@ -1,8 +1,10 @@
 #include "../common/Stopwatch.hpp"
 
+#include <boost/asio/ip/host_name.hpp>
 #include <boost/functional/hash.hpp>
 #include <boost/mp11.hpp>
 #include <chrono>
+#include <fmt/format.h>
 #include <fstream>
 #include <iomanip>
 #include <llama/llama.hpp>
@@ -482,14 +484,18 @@ try
     benchmarkAllCopies("AoSoA64", "AoSoA8", aosoa64Mapping, aosoa8Mapping);
 
     std::cout << "Plot with: ./viewcopy.sh\n";
-    std::ofstream{"viewcopy.sh"} << R"(#!/usr/bin/gnuplot -p
+    std::ofstream{"viewcopy.sh"} << fmt::format(
+        R"(#!/usr/bin/gnuplot -p
+set title "viewcopy CPU {}MiB particles on {}"
 set style data histograms
 set style fill solid
 set xtics rotate by 45 right
 set key out top center maxrows 3
 set ylabel "throughput [GiB/s]"
 plot 'viewcopy.tsv' using 2:xtic(1) ti col, "" using 3 ti col, "" using 4 ti col, "" using 5 ti col, "" using 6 ti col, "" using 7 ti col, "" using 8 ti col, "" using 9 ti col, "" using 10 ti col
-)";
+)",
+        dataSize / 1024 / 1024,
+        boost::asio::ip::host_name());
 }
 catch (const std::exception& e)
 {

--- a/examples/viewcopy/viewcopy.cpp
+++ b/examples/viewcopy/viewcopy.cpp
@@ -13,6 +13,7 @@
 #include <string_view>
 
 constexpr auto REPETITIONS = 5;
+constexpr auto arrayDims = llama::ArrayDims{1024, 1024, 16};
 
 // clang-format off
 namespace tag
@@ -385,7 +386,6 @@ try
     const auto numThreads = static_cast<std::size_t>(omp_get_max_threads());
     std::cout << "Threads: " << numThreads << "\n";
 
-    const auto arrayDims = llama::ArrayDims{1024, 1024, 16};
     const auto dataSize
         = std::reduce(arrayDims.begin(), arrayDims.end(), std::size_t{1}, std::multiplies{}) * llama::sizeOf<Particle>;
 


### PR DESCRIPTION
* plot throughput instead of runtime
* extend `aosoa_copy` to also support SoA
* repeat copy a few times to reduce noise
* fix using the wrong OpenMP API to retrieve the thread count
* add title to plot with hostname and total copied size