### PR TITLE
Refactoring, rewording, plot improvements

### DIFF
--- a/docs/pages/copying.rst
+++ b/docs/pages/copying.rst
@@ -5,46 +5,36 @@
 Copying between views
 =====================
 
-Especially when working with hardware accelerators such as GPUs or offloading to many core procressors,
-explicit copy operations call for memory chunks as big as possible to reach good throughput.
+Especially when working with hardware accelerators such as GPUs or offloading to many-core processors, explicit copy operations call for memory chunks as big as possible to reach good throughput.
 
-It is trivial to copy a view from one memory region to another if mapping and size are identical.
+Copying the contents of a view from one memory region to another if mapping and size are identical is trivial.
 However, if the mapping differs, a direct copy of the underlying memory is wrong.
-In most cases only elementwise copy operations will be possible as the memory patterns are not compatible.
-There is a small class of remaining use cases where the mapping is the same, but the size of the view is different or mappings are
-very related to each other. E.g. when both mappings use struct of array, but one time with, one time without padding.
-In those cases an optimized copy operation would in *theory* be possible .
-However *practically* it is very hard to figure out the biggest possible memory chunks to copy at compile time,
-since the mappings can always depend on run time parameters.
-E.g. a mapping could implement struct of array if the view is bigger than :math:`255` elements, but use array of struct for a smaller amount.
+In most cases only field-wise copy operations are possible.
 
-Three solutions exist for this challenge. One is to implement specializations
-for specific combinations of mappings, which reflect the properties of those
-mappings. This **can** be the way to go if the application shows significantly
-better run times for slightly different mappings and the copy operation is the bottle neck.
-However this would be the very last optimization step as for every new mapping a new specialization would be needed.
+There is a small class of remaining cases where the mapping is the same, but the size or shape of the view is different, or the record dimension differ slightly, or the mappings are very related to each other.
+E.g. when both mappings use SoA, but one time with, one time without padding, or a specific field is missing on one side.
+Or two AoSoA mappings with a different inner array length.
+In those cases an optimized copy procedure is possible, copying larger chunks than mere fields.
 
-Another solution would be a run time analysis of the two views to find
-contiguous memory chunks, but the overhead would probably be too big, especially
-if no contiguous memory chunks could be found. At least in that case it may make
-sense to use a (maybe smaller) intermediate view which connects the two worlds.
+Practically, it is hard to figure out the biggest possible memory chunks to copy at compile time, since the mappings can always depend on run time parameters.
+E.g. a mapping could implement SoA if the view is bigger than 255 records, but use AoS for a smaller size.
 
-This last solution is that we have e.g. a view in memory region :math:`A`
-with mapping :math:`A` and another view of the same size in memory region
-:math:`B` with mapping :math:`B`. A third view in memory region :math:`A` but
-with mapping :math:`B` could be used to reindex in region :math:`A` and then to
-copy it as one big chunk to region :math:`B`.
+Three solutions exist for this problem:
 
-When using two intermediate views in region :math:`A` and :math:`B` with the
-same mapping but possibly different than in :math:`A` **and** :math:`B` the copy
-problem can be split to smaller chunks of memory. It makes also sense to combine
-this approach with an asynchronous workflow where reindexing, copying and
-computation are overloayed as e.g. seen in the
-`async copy example <https://github.com/alpaka-group/llama/blob/master/examples/asynccopy/asynccopy.cpp>`_.
+1. Implement specializations for specific combinations of mappings, which reflect the properties of these.
+This is relevant if an application uses a set of similar mappings and the copy operation between them is the bottle neck.
+However, for every new mapping a new specialization is needed.
 
-Another benefit is, that the creation and copying of the intermediate view can
-be analyzed and optimized by the compiler (e.g. with vector operations).
-Furthermore different (sub) record dimensions may be used. The above mentioned async copy
-example e.g. applies a bluring kernel to an RGB-image, but may work only on
-two or one channel instead of all three. Not used channels are not allocated and
-especially not copied at all.
+2. A run time analysis of the two views to find contiguous memory chunks.
+The overhead is probably big, especially if no contiguous memory chunks are identified.
+
+3. A compile time analysis of the mapping function.
+This requires the mapping to be formulated in a way which is fully consumable via constexpr and template meta programming, probably at the cost of read- and maintainability.
+
+An additional challenge comes from copies between different address spaces where elementary copy operations require calls to external APIs which profit especially from large chunk sizes.
+In that case it may make sense to use a smaller intermediate view to shuffle a chunk from one mapping to the other inside the same address space and then perform a copy of that chunk into the other address space.
+This shuffle could be performed in the source or destination address space and potentially overlap with shuffles and copies of other chunks in an asynchronous workflow.
+
+The `async copy example <https://github.com/alpaka-group/llama/blob/master/examples/asynccopy/asynccopy.cpp>`_ tries to show an asynchronous copy/shuffle/compute workflow.
+This example applies a bluring kernel to an RGB-image, but also may work only on two or one channel instead of all three.
+Not used channels are not allocated and especially not copied.

--- a/docs/pages/iteration.rst
+++ b/docs/pages/iteration.rst
@@ -105,12 +105,11 @@ A more detailed example can be found in the
 View iterators
 --------------
 
-Iterators on views are useful but pose a couple of difficulties.
-Therefore, only 1D iterators are supported currently.
-Higher dimensional iterators are difficult to get right if we also want to preserve good codegen.
-Multiple nested loops seem to be superior to a single iterator over multiple dimensions.
+Iterators on views of any dimension are supported.
+Higher than 1D iterators however are difficult to get right if we also want to achieve well optimized assembly.
+Multiple nested loops seem to be optimized better than a single loop using iterators over multiple dimensions.
 
-Having an iterator to a view opens up the standard library for use in conjunction with LLAMA:
+Nevertheless, having an iterator to a view opens up the standard library for use in conjunction with LLAMA:
 
 .. code-block:: C++
 

--- a/include/llama/mapping/SoA.hpp
+++ b/include/llama/mapping/SoA.hpp
@@ -23,7 +23,7 @@ namespace llama::mapping
         using ArrayDims = T_ArrayDims;
         using RecordDim = T_RecordDim;
         static constexpr std::size_t blobCount
-            = SeparateBuffers ? boost::mp11::mp_size<llama::FlattenRecordDim<RecordDim>>::value : 1;
+            = SeparateBuffers ? boost::mp11::mp_size<FlattenRecordDim<RecordDim>>::value : 1;
 
         constexpr SoA() = default;
 
@@ -42,11 +42,10 @@ namespace llama::mapping
         {
             if constexpr (SeparateBuffers)
             {
-                constexpr llama::Array<std::size_t, blobCount> typeSizes = []() constexpr
+                constexpr Array<std::size_t, blobCount> typeSizes = []() constexpr
                 {
-                    llama::Array<std::size_t, blobCount> r{};
-                    std::size_t i = 0;
-                    forEachLeaf<RecordDim>([&](auto coord) constexpr
+                    Array<std::size_t, blobCount> r{};
+                    forEachLeaf<RecordDim>([&r, i = 0](auto coord) mutable constexpr
                                            { r[i++] = sizeof(GetType<RecordDim, decltype(coord)>); });
                     return r;
                 }
@@ -54,9 +53,7 @@ namespace llama::mapping
                 return LinearizeArrayDimsFunctor{}.size(arrayDimsSize) * typeSizes[blobIndex];
             }
             else
-            {
                 return LinearizeArrayDimsFunctor{}.size(arrayDimsSize) * sizeOf<RecordDim>;
-            }
         }
 
         template <std::size_t... RecordCoords>
@@ -64,27 +61,7 @@ namespace llama::mapping
         {
             if constexpr (SeparateBuffers)
             {
-                using TargetRecordCoord = RecordCoord<RecordCoords...>;
-                constexpr auto blob = [&]() constexpr
-                {
-                    std::size_t index = 0;
-                    bool found = false;
-                    forEachLeaf<RecordDim>([&](auto c) constexpr
-                                           {
-                                               if constexpr (std::is_same_v<decltype(c), TargetRecordCoord>)
-                                                   found = true;
-                                               else if (!found)
-                                                   index++;
-                                           });
-                    if (!found)
-                        return std::numeric_limits<std::size_t>::max();
-                    return index;
-                }
-                ();
-                static_assert(
-                    blob != std::numeric_limits<std::size_t>::max(),
-                    "Passed TargetRecordCoord must be in record dimension");
-
+                constexpr auto blob = flatRecordCoord<RecordDim, RecordCoord<RecordCoords...>>;
                 const auto offset = LinearizeArrayDimsFunctor{}(coord, arrayDimsSize)
                     * sizeof(GetType<RecordDim, RecordCoord<RecordCoords...>>);
                 return {blob, offset};


### PR DESCRIPTION
* separate viewcopy memcopy runs form the rest
* simplify SoA blob selection
* reword copying.rst and iteration intro
* add a test case for std::transform between different record dimensions
* rename template parameters in viewcopy example