### PR TITLE
Fix CUDA CI

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -98,7 +98,12 @@ jobs:
           if [ ${{ matrix.intel }} ]; then source /opt/intel/oneapi/setvars.sh; fi
           mkdir build
           cd build
-          cmake .. -DCMAKE_BUILD_TYPE=$CONFIG -DASAN_FOR_TESTS=ON -DALPAKA_ACC_CPU_B_SEQ_T_SEQ_ENABLE=${{ !matrix.cuda }} -DALPAKA_ACC_GPU_CUDA_ENABLE=${{ matrix.cuda }} -DALPAKA_CXX_STANDARD=17 -DCMAKE_TOOLCHAIN_FILE=/usr/local/share/vcpkg/scripts/buildsystems/vcpkg.cmake
+          CUDACXX=(`echo /usr/local/cuda-*/bin/nvcc`)
+          if [ ! -f $CUDACXX ]; then
+            unset CUDACXX
+          fi
+          echo "nvcc is here: $CUDACXX"
+          cmake .. -DCMAKE_BUILD_TYPE=$CONFIG -DASAN_FOR_TESTS=ON -DALPAKA_ACC_CPU_B_SEQ_T_SEQ_ENABLE=${{ !matrix.cuda }} -DALPAKA_ACC_GPU_CUDA_ENABLE=${{ matrix.cuda }} -DALPAKA_CXX_STANDARD=17 -DCMAKE_CUDA_COMPILER=$CUDACXX -DCMAKE_TOOLCHAIN_FILE=/usr/local/share/vcpkg/scripts/buildsystems/vcpkg.cmake
       - name: build tests + examples
         run: |
           if [ ${{ matrix.intel }} ]; then source /opt/intel/oneapi/setvars.sh; fi


### PR DESCRIPTION
It seems the recent change in alpaka to use native CUDA support https://github.com/alpaka-group/alpaka/pull/1146 caused a CI breakage, because CMake is less capable to find the installed CUDA toolkit. This PR attempts to remedy this by explicitely specifying the path to the installed `nvcc`.