### PR TITLE
Fix AlignedAoS not properly aligning after struct

### DIFF
--- a/include/llama/Core.hpp
+++ b/include/llama/Core.hpp
@@ -369,18 +369,20 @@ namespace llama
             using namespace boost::mp11;
 
             std::size_t size = 0;
+            std::size_t maxAlign = 0;
             using FlatRD = FlattenRecordDim<Record<Fields...>>;
             mp_for_each<mp_transform<mp_identity, FlatRD>>([&](auto e) constexpr
                                                            {
                                                                using T = typename decltype(e)::type;
                                                                if constexpr (Align)
                                                                    roundUpToMultiple(size, alignof(T));
+                                                               maxAlign = std::max(maxAlign, alignof(T));
                                                                size += sizeof(T);
                                                            });
 
             // final padding, so next struct can start right away
             if constexpr (Align)
-                roundUpToMultiple(size, alignof(mp_first<FlatRD>));
+                roundUpToMultiple(size, maxAlign);
             return size;
         }
     } // namespace internal

--- a/tests/core.cpp
+++ b/tests/core.cpp
@@ -167,7 +167,7 @@ TEST_CASE("alignment")
     STATIC_REQUIRE(llama::offsetOf<RD, llama::RecordCoord<1>, true> == 8); // aligned
     STATIC_REQUIRE(llama::offsetOf<RD, llama::RecordCoord<2>, true> == 16);
     STATIC_REQUIRE(llama::offsetOf<RD, llama::RecordCoord<3>, true> == 18); // aligned
-    STATIC_REQUIRE(llama::sizeOf<RD, true> == 20);
+    STATIC_REQUIRE(llama::sizeOf<RD, true> == 24);
 }
 
 TEST_CASE("GetCoordFromTags")


### PR DESCRIPTION
Before (notice every second double is missaligned):
![image](https://user-images.githubusercontent.com/1224051/117658388-f21d0480-b19a-11eb-9462-c553f9338bc8.png)
After:
![image](https://user-images.githubusercontent.com/1224051/117658418-fb0dd600-b19a-11eb-8c08-f0b7e8adc0c5.png)
