### PR TITLE
Minimize padding for aligned AoS

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -30,7 +30,7 @@ if (BUILD_TESTING)
 	source_group(TREE "${CMAKE_CURRENT_LIST_DIR}/tests" FILES ${testSources})
 	target_compile_features(tests PRIVATE cxx_std_20)
 	if (MSVC)
-		target_compile_options(tests PRIVATE /permissive- /constexpr:steps10000000)
+		target_compile_options(tests PRIVATE /permissive- /constexpr:steps10000000 /diagnostics:caret)
 	endif()
 	target_link_libraries(tests PRIVATE Catch2::Catch2 llama::llama)
 

--- a/include/llama/mapping/AoS.hpp
+++ b/include/llama/mapping/AoS.hpp
@@ -9,14 +9,17 @@ namespace llama::mapping
 {
     /// Array of struct mapping. Used to create a \ref View via \ref allocView.
     /// \tparam AlignAndPad If true, padding bytes are inserted to guarantee that struct members are properly aligned.
-    /// If false, struct members are tighly packed.
+    /// If false, struct members are tightly packed.
     /// \tparam LinearizeArrayDimsFunctor Defines how the array dimensions should be mapped into linear numbers and
     /// how big the linear domain gets.
+    /// \tparam FlattenRecordDim Defines how the record dimension's fields should be flattended. See \ref
+    /// FlattenRecordDimInOrder and \ref FlattenRecordDimMinimizePadding.
     template <
         typename T_ArrayDims,
         typename T_RecordDim,
         bool AlignAndPad = true,
-        typename LinearizeArrayDimsFunctor = LinearizeArrayDimsCpp>
+        typename LinearizeArrayDimsFunctor = LinearizeArrayDimsCpp,
+        template <typename> typename FlattenRecordDim = FlattenRecordDimInOrder>
     struct AoS
     {
         using ArrayDims = T_ArrayDims;
@@ -37,27 +40,41 @@ namespace llama::mapping
 
         LLAMA_FN_HOST_ACC_INLINE constexpr auto blobSize(std::size_t) const -> std::size_t
         {
-            return LinearizeArrayDimsFunctor{}.size(arrayDimsSize) * sizeOf<RecordDim, AlignAndPad>;
+            return LinearizeArrayDimsFunctor{}.size(arrayDimsSize)
+                * flatSizeOf<typename Flattener::FlatRecordDim, AlignAndPad>;
         }
 
         template <std::size_t... RecordCoords>
         LLAMA_FN_HOST_ACC_INLINE constexpr auto blobNrAndOffset(ArrayDims coord) const -> NrAndOffset
         {
+            constexpr std::size_t flatIndex =
+#ifdef __NVCC__
+                Flattener{}.template flatIndex<RecordCoords...>;
+#else
+                Flattener::template flatIndex<RecordCoords...>;
+#endif
             const auto offset = LinearizeArrayDimsFunctor{}(coord, arrayDimsSize)
-                    * sizeOf<RecordDim, AlignAndPad> + offsetOf<RecordDim, RecordCoord<RecordCoords...>, AlignAndPad>;
+                    * flatSizeOf<typename Flattener::FlatRecordDim,
+                                 AlignAndPad> + flatOffsetOf<typename Flattener::FlatRecordDim, flatIndex, AlignAndPad>;
             return {0, offset};
         }
 
     private:
+        using Flattener = FlattenRecordDim<T_RecordDim>;
         ArrayDims arrayDimsSize;
     };
 
-    /// Array of struct mapping preserving the alignment of the element types by inserting padding.
+    /// Array of struct mapping preserving the alignment of the field types by inserting padding.
     /// \see AoS
     template <typename ArrayDims, typename RecordDim, typename LinearizeArrayDimsFunctor = LinearizeArrayDimsCpp>
     using AlignedAoS = AoS<ArrayDims, RecordDim, true, LinearizeArrayDimsFunctor>;
 
-    /// Array of struct mapping packing the element types tighly, violating the types alignment requirements.
+    /// Array of struct mapping preserving the alignment of the field types by inserting padding and permuting the field
+    /// order to minimize this padding. \see AoS
+    template <typename ArrayDims, typename RecordDim, typename LinearizeArrayDimsFunctor = LinearizeArrayDimsCpp>
+    using MinAlignedAoS = AoS<ArrayDims, RecordDim, true, LinearizeArrayDimsFunctor, FlattenRecordDimMinimizePadding>;
+
+    /// Array of struct mapping packing the field types tightly, violating the types alignment requirements.
     /// \see AoS
     template <typename ArrayDims, typename RecordDim, typename LinearizeArrayDimsFunctor = LinearizeArrayDimsCpp>
     using PackedAoS = AoS<ArrayDims, RecordDim, false, LinearizeArrayDimsFunctor>;

--- a/tests/dump.cpp
+++ b/tests/dump.cpp
@@ -117,6 +117,11 @@ TEST_CASE("dump.ParticleUnaligned.AoS_Aligned")
     dump(llama::mapping::AlignedAoS<ArrayDims, ParticleUnaligned>{arrayDims});
 }
 
+TEST_CASE("dump.ParticleUnaligned.AoS_Aligned_Min")
+{
+    dump(llama::mapping::MinAlignedAoS<ArrayDims, ParticleUnaligned>{arrayDims});
+}
+
 TEST_CASE("dump.ParticleUnaligned.SoA_SB")
 {
     dump(llama::mapping::SingleBlobSoA<ArrayDims, ParticleUnaligned>{arrayDims});

--- a/tests/mapping.cpp
+++ b/tests/mapping.cpp
@@ -223,6 +223,58 @@ TEST_CASE("address.AoS.Aligned")
     }
 }
 
+TEST_CASE("address.AoS.aligned_min")
+{
+    using ArrayDims = llama::ArrayDims<2>;
+    auto arrayDims = ArrayDims{16, 16};
+    auto mapping = llama::mapping::MinAlignedAoS<ArrayDims, Particle>{arrayDims};
+
+    {
+        const auto coord = ArrayDims{0, 0};
+        CHECK(mapping.blobNrAndOffset<0, 0>(coord).offset == 8);
+        CHECK(mapping.blobNrAndOffset<0, 1>(coord).offset == 16);
+        CHECK(mapping.blobNrAndOffset<0, 2>(coord).offset == 24);
+        CHECK(mapping.blobNrAndOffset<1>(coord).offset == 4);
+        CHECK(mapping.blobNrAndOffset<2, 0>(coord).offset == 32);
+        CHECK(mapping.blobNrAndOffset<2, 1>(coord).offset == 40);
+        CHECK(mapping.blobNrAndOffset<2, 2>(coord).offset == 48);
+        CHECK(mapping.blobNrAndOffset<3, 0>(coord).offset == 0);
+        CHECK(mapping.blobNrAndOffset<3, 1>(coord).offset == 1);
+        CHECK(mapping.blobNrAndOffset<3, 2>(coord).offset == 2);
+        CHECK(mapping.blobNrAndOffset<3, 3>(coord).offset == 3);
+    }
+
+    {
+        const auto coord = ArrayDims{0, 1};
+        CHECK(mapping.blobNrAndOffset<0, 0>(coord).offset == 64);
+        CHECK(mapping.blobNrAndOffset<0, 1>(coord).offset == 72);
+        CHECK(mapping.blobNrAndOffset<0, 2>(coord).offset == 80);
+        CHECK(mapping.blobNrAndOffset<1>(coord).offset == 60);
+        CHECK(mapping.blobNrAndOffset<2, 0>(coord).offset == 88);
+        CHECK(mapping.blobNrAndOffset<2, 1>(coord).offset == 96);
+        CHECK(mapping.blobNrAndOffset<2, 2>(coord).offset == 104);
+        CHECK(mapping.blobNrAndOffset<3, 0>(coord).offset == 56);
+        CHECK(mapping.blobNrAndOffset<3, 1>(coord).offset == 57);
+        CHECK(mapping.blobNrAndOffset<3, 2>(coord).offset == 58);
+        CHECK(mapping.blobNrAndOffset<3, 3>(coord).offset == 59);
+    }
+
+    {
+        const auto coord = ArrayDims{1, 0};
+        CHECK(mapping.blobNrAndOffset<0, 0>(coord).offset == 904);
+        CHECK(mapping.blobNrAndOffset<0, 1>(coord).offset == 912);
+        CHECK(mapping.blobNrAndOffset<0, 2>(coord).offset == 920);
+        CHECK(mapping.blobNrAndOffset<1>(coord).offset == 900);
+        CHECK(mapping.blobNrAndOffset<2, 0>(coord).offset == 928);
+        CHECK(mapping.blobNrAndOffset<2, 1>(coord).offset == 936);
+        CHECK(mapping.blobNrAndOffset<2, 2>(coord).offset == 944);
+        CHECK(mapping.blobNrAndOffset<3, 0>(coord).offset == 896);
+        CHECK(mapping.blobNrAndOffset<3, 1>(coord).offset == 897);
+        CHECK(mapping.blobNrAndOffset<3, 2>(coord).offset == 898);
+        CHECK(mapping.blobNrAndOffset<3, 3>(coord).offset == 899);
+    }
+}
+
 TEST_CASE("address.SoA.SingleBlob")
 {
     using ArrayDims = llama::ArrayDims<2>;


### PR DESCRIPTION
This PR adds the ability to the AoS mapping to arbitrarily permute the record dimension via an additional template argument. This mechanism is generic and supports future LLAMA and user side extensions.

Two such permutations are provided:
* `FlattenRecordDimInorder`: an identity permutation flattening a record in the order of field declaration.
* `FlattenRecordDimMinimizePadding`: reorders fields to minimize padding caused by alignment.

Aligned AoS with `FlattenRecordDimInorder`:
![image](https://user-images.githubusercontent.com/1224051/117700008-c82d0780-b1c5-11eb-8ca4-31e8e6714dc0.png)

Aligned AoS with `FlattenRecordDimMinimizePadding`:
![image](https://user-images.githubusercontent.com/1224051/117699826-8ef49780-b1c5-11eb-86af-2fa6b9148174.png)