### PR TITLE
Various compile time improvements

### DIFF
--- a/docs/pages/api.rst
+++ b/docs/pages/api.rst
@@ -53,6 +53,8 @@ Record dimension
 .. doxygentypedef:: llama::GetCoordFromTags
 .. doxygentypedef:: llama::GetType
 .. doxygentypedef:: llama::GetCoordFromTagsRelative
+.. doxygentypedef:: llama::FlatRecordDim
+.. doxygenvariable:: llama::flatRecordCoord
 
 .. doxygenfunction:: llama::forEachLeaf(Functor &&functor, Tags... baseTags)
 .. doxygenfunction:: llama::forEachLeaf(Functor &&functor, RecordCoord<Coords...> baseCoord)

--- a/include/llama/Core.hpp
+++ b/include/llama/Core.hpp
@@ -444,7 +444,7 @@ namespace llama
     inline constexpr std::size_t flatOffsetOf = internal::offsetOfImpl<Align, TypeList, I>();
 
     template <typename S>
-    auto structName(S) -> std::string
+    auto structName(S = {}) -> std::string
     {
         auto s = boost::core::demangle(typeid(S).name());
         if (const auto pos = s.rfind(':'); pos != std::string::npos)

--- a/include/llama/Core.hpp
+++ b/include/llama/Core.hpp
@@ -363,7 +363,7 @@ namespace llama
     } // namespace internal
 
     template <typename RecordDim>
-    using FlattenRecordDim = typename internal::FlattenRecordDimImpl<RecordDim>::type;
+    using FlatRecordDim = typename internal::FlattenRecordDimImpl<RecordDim>::type;
 
     template <typename RecordDim, typename RecordCoord>
     inline constexpr std::size_t flatRecordCoord
@@ -406,15 +406,15 @@ namespace llama
             using namespace boost::mp11;
 
             std::size_t offset = 0;
-        mp_for_each<mp_transform<mp_identity, mp_take_c<TypeList, I>>>([&](auto t) constexpr
-                                                                             {
-                                                                                 using T = typename decltype(t)::type;
-                                                                                 if constexpr (Align)
-                                                                                     internal::roundUpToMultiple(
-                                                                                         offset,
-                                                                                         alignof(T));
-                                                                                 offset += sizeof(T);
-                                                                             });
+            mp_for_each<mp_transform<mp_identity, mp_take_c<TypeList, I>>>([&](auto t) constexpr
+                                                                           {
+                                                                               using T = typename decltype(t)::type;
+                                                                               if constexpr (Align)
+                                                                                   internal::roundUpToMultiple(
+                                                                                       offset,
+                                                                                       alignof(T));
+                                                                               offset += sizeof(T);
+                                                                           });
             if constexpr (Align)
                 internal::roundUpToMultiple(offset, alignof(mp_at_c<TypeList, I>));
             return offset;
@@ -428,7 +428,7 @@ namespace llama
     /// The size of a record dimension if its fields would be in a normal struct.
     template <typename... Fields, bool Align>
     inline constexpr std::size_t sizeOf<Record<Fields...>, Align> = internal::
-        sizeOfImpl<Align, FlattenRecordDim<Record<Fields...>>>();
+        sizeOfImpl<Align, FlatRecordDim<Record<Fields...>>>();
 
     /// The size of a type list if its elements would be in a normal struct.
     template <typename TypeList, bool Align>
@@ -439,7 +439,7 @@ namespace llama
     /// \tparam RecordCoord Record coordinate of an element inrecord dimension tree.
     template <typename RecordDim, typename RecordCoord, bool Align = false>
     inline constexpr std::size_t offsetOf
-        = internal::offsetOfImpl<Align, FlattenRecordDim<RecordDim>, flatRecordCoord<RecordDim, RecordCoord>>();
+        = internal::offsetOfImpl<Align, FlatRecordDim<RecordDim>, flatRecordCoord<RecordDim, RecordCoord>>();
 
     /// The byte offset of an element in a type list ifs elements would be in a normal struct.
     template <typename TypeList, std::size_t I, bool Align>

--- a/include/llama/Core.hpp
+++ b/include/llama/Core.hpp
@@ -362,9 +362,12 @@ namespace llama
         }
     } // namespace internal
 
+    /// Returns a flat type list containing all leaf field types of the given record dimension.
     template <typename RecordDim>
     using FlatRecordDim = typename internal::FlattenRecordDimImpl<RecordDim>::type;
 
+    /// The equivalent zero based index into a flat record dimension (\ref FlatRecordDim) of the given hierarchical
+    /// record coordinate.
     template <typename RecordDim, typename RecordCoord>
     inline constexpr std::size_t flatRecordCoord
         = internal::flatRecordCoordImpl(static_cast<RecordDim*>(nullptr), RecordCoord{});

--- a/include/llama/Core.hpp
+++ b/include/llama/Core.hpp
@@ -348,6 +348,17 @@ namespace llama
 
     namespace internal
     {
+        // recursive formulation to benefit from template instantiation memoization
+        template <std::size_t I, typename... Children>
+        constexpr auto fieldCountBefore(Record<Children...> r) -> std::size_t
+        {
+            if constexpr (I == 0)
+                return 0;
+            else
+                return fieldCountBefore<I - 1>(r)
+                    + fieldCount<GetFieldType<boost::mp11::mp_at_c<Record<Children...>, I - 1>>>;
+        }
+
         template <typename T>
         constexpr auto flatRecordCoordImpl(T*, RecordCoord<>) -> std::size_t
         {
@@ -357,9 +368,10 @@ namespace llama
         template <typename... Children, std::size_t I, std::size_t... Is>
         constexpr auto flatRecordCoordImpl(Record<Children...>*, RecordCoord<I, Is...>) -> std::size_t
         {
-            return fieldCount<boost::mp11::mp_take_c<
-                       Record<Children...>,
-                       I>> + flatRecordCoordImpl(static_cast<GetFieldType<boost::mp11::mp_at_c<Record<Children...>, I>>*>(nullptr), RecordCoord<Is...>{});
+            return fieldCountBefore<I>(Record<Children...>{})
+                + flatRecordCoordImpl(
+                       static_cast<GetFieldType<boost::mp11::mp_at_c<Record<Children...>, I>>*>(nullptr),
+                       RecordCoord<Is...>{});
         }
     } // namespace internal
 

--- a/include/llama/Core.hpp
+++ b/include/llama/Core.hpp
@@ -406,13 +406,15 @@ namespace llama
             using namespace boost::mp11;
 
             std::size_t offset = 0;
-            mp_for_each<mp_iota_c<I>>([&](auto i) constexpr
-                                      {
-                                          using T = mp_at<TypeList, decltype(i)>;
-                                          if constexpr (Align)
-                                              internal::roundUpToMultiple(offset, alignof(T));
-                                          offset += sizeof(T);
-                                      });
+        mp_for_each<mp_transform<mp_identity, mp_take_c<TypeList, I>>>([&](auto t) constexpr
+                                                                             {
+                                                                                 using T = typename decltype(t)::type;
+                                                                                 if constexpr (Align)
+                                                                                     internal::roundUpToMultiple(
+                                                                                         offset,
+                                                                                         alignof(T));
+                                                                                 offset += sizeof(T);
+                                                                             });
             if constexpr (Align)
                 internal::roundUpToMultiple(offset, alignof(mp_at_c<TypeList, I>));
             return offset;

--- a/include/llama/Core.hpp
+++ b/include/llama/Core.hpp
@@ -406,21 +406,16 @@ namespace llama
         template <bool Align, typename TypeList, std::size_t I>
         constexpr std::size_t offsetOfImpl()
         {
-            using namespace boost::mp11;
-
-            std::size_t offset = 0;
-            mp_for_each<mp_transform<mp_identity, mp_take_c<TypeList, I>>>([&](auto t) constexpr
-                                                                           {
-                                                                               using T = typename decltype(t)::type;
-                                                                               if constexpr (Align)
-                                                                                   roundUpToMultiple(
-                                                                                       offset,
-                                                                                       alignof(T));
-                                                                               offset += sizeof(T);
-                                                                           });
-            if constexpr (Align)
-                roundUpToMultiple(offset, alignof(mp_at_c<TypeList, I>));
-            return offset;
+            if constexpr (I == 0)
+                return 0;
+            else
+            {
+                std::size_t offset
+                    = offsetOfImpl<Align, TypeList, I - 1>() + sizeof(boost::mp11::mp_at_c<TypeList, I - 1>);
+                if constexpr (Align)
+                    roundUpToMultiple(offset, alignof(boost::mp11::mp_at_c<TypeList, I>));
+                return offset;
+            }
         }
     } // namespace internal
 

--- a/include/llama/mapping/SoA.hpp
+++ b/include/llama/mapping/SoA.hpp
@@ -23,7 +23,7 @@ namespace llama::mapping
         using ArrayDims = T_ArrayDims;
         using RecordDim = T_RecordDim;
         static constexpr std::size_t blobCount
-            = SeparateBuffers ? boost::mp11::mp_size<FlattenRecordDim<RecordDim>>::value : 1;
+            = SeparateBuffers ? boost::mp11::mp_size<FlatRecordDim<RecordDim>>::value : 1;
 
         constexpr SoA() = default;
 

--- a/tests/computedprop.cpp
+++ b/tests/computedprop.cpp
@@ -178,7 +178,7 @@ namespace
     {
         using ArrayDims = T_ArrayDims;
         using RecordDim = T_RecordDim;
-        static constexpr std::size_t blobCount = boost::mp11::mp_size<llama::FlattenRecordDim<RecordDim>>::value;
+        static constexpr std::size_t blobCount = boost::mp11::mp_size<llama::FlatRecordDim<RecordDim>>::value;
 
         constexpr CompressedBoolMapping() = default;
 

--- a/tests/core.cpp
+++ b/tests/core.cpp
@@ -152,6 +152,16 @@ TEST_CASE("fieldCount")
     STATIC_REQUIRE(llama::fieldCount<Other> == 2);
 }
 
+TEST_CASE("fieldCountBefore")
+{
+    STATIC_REQUIRE(llama::internal::fieldCountBefore<0>(Particle{}) == 0);
+    STATIC_REQUIRE(llama::internal::fieldCountBefore<1>(Particle{}) == 3);
+    STATIC_REQUIRE(llama::internal::fieldCountBefore<2>(Particle{}) == 4);
+    STATIC_REQUIRE(llama::internal::fieldCountBefore<3>(Particle{}) == 5);
+    STATIC_REQUIRE(llama::internal::fieldCountBefore<4>(Particle{}) == 7);
+    STATIC_REQUIRE(llama::internal::fieldCountBefore<5>(Particle{}) == 11);
+}
+
 template <int i>
 struct S;
 

--- a/tests/core.cpp
+++ b/tests/core.cpp
@@ -257,10 +257,10 @@ TEST_CASE("hasSameTags")
             > == false);
 }
 
-TEST_CASE("FlattenRecordDim")
+TEST_CASE("FlatRecordDim")
 {
     STATIC_REQUIRE(std::is_same_v<
-                   llama::FlattenRecordDim<Particle>,
+                   llama::FlatRecordDim<Particle>,
                    boost::mp11::mp_list<double, double, double, float, int, double, double, bool, bool, bool, bool>>);
 }
 

--- a/tests/core.cpp
+++ b/tests/core.cpp
@@ -144,6 +144,14 @@ TEST_CASE("offsetOf.Align")
     STATIC_REQUIRE(llama::offsetOf<Particle, llama::RecordCoord<4, 3>, true> == 51);
 }
 
+TEST_CASE("fieldCount")
+{
+    STATIC_REQUIRE(llama::fieldCount<int> == 1);
+    STATIC_REQUIRE(llama::fieldCount<XYZ> == 3);
+    STATIC_REQUIRE(llama::fieldCount<Particle> == 11);
+    STATIC_REQUIRE(llama::fieldCount<Other> == 2);
+}
+
 template <int i>
 struct S;
 

--- a/tests/proofs.cpp
+++ b/tests/proofs.cpp
@@ -99,7 +99,7 @@ namespace
     {
         using ArrayDims = T_ArrayDims;
         using RecordDim = T_RecordDim;
-        static constexpr std::size_t blobCount = boost::mp11::mp_size<llama::FlattenRecordDim<RecordDim>>::value;
+        static constexpr std::size_t blobCount = boost::mp11::mp_size<llama::FlatRecordDim<RecordDim>>::value;
 
         LLAMA_FN_HOST_ACC_INLINE
         constexpr explicit ModulusMapping(ArrayDims size, RecordDim = {}) : arrayDimsSize(size)


### PR DESCRIPTION
Partly addresses #240.

* Improves the compilation time of several facilities within LLAMA.
* adds `flatSizeOf` and `flatOffsetOf` working on type lists, which might be faster than their hierarchical versions
* adds `flatRecordCoord` and `FlatRecordDim` to API documentation