### PR TITLE
More compile time improvements

### DIFF
--- a/examples/viewcopy/viewcopy.cpp
+++ b/examples/viewcopy/viewcopy.cpp
@@ -394,7 +394,7 @@ auto hash(const llama::View<Mapping, BlobType>& view)
 {
     std::size_t acc = 0;
     for (auto ad : llama::ArrayDimsIndexRange{view.mapping.arrayDims()})
-        llama::forEachLeaf<Particle>([&](auto coord) { boost::hash_combine(acc, view(ad)(coord)); });
+        llama::forEachLeaf<typename Mapping::RecordDim>([&](auto coord) { boost::hash_combine(acc, view(ad)(coord)); });
     return acc;
 }
 template <typename Mapping>

--- a/tests/core.cpp
+++ b/tests/core.cpp
@@ -154,12 +154,12 @@ TEST_CASE("fieldCount")
 
 TEST_CASE("fieldCountBefore")
 {
-    STATIC_REQUIRE(llama::internal::fieldCountBefore<0>(Particle{}) == 0);
-    STATIC_REQUIRE(llama::internal::fieldCountBefore<1>(Particle{}) == 3);
-    STATIC_REQUIRE(llama::internal::fieldCountBefore<2>(Particle{}) == 4);
-    STATIC_REQUIRE(llama::internal::fieldCountBefore<3>(Particle{}) == 5);
-    STATIC_REQUIRE(llama::internal::fieldCountBefore<4>(Particle{}) == 7);
-    STATIC_REQUIRE(llama::internal::fieldCountBefore<5>(Particle{}) == 11);
+    STATIC_REQUIRE(llama::internal::fieldCountBefore<0, Particle> == 0);
+    STATIC_REQUIRE(llama::internal::fieldCountBefore<1, Particle> == 3);
+    STATIC_REQUIRE(llama::internal::fieldCountBefore<2, Particle> == 4);
+    STATIC_REQUIRE(llama::internal::fieldCountBefore<3, Particle> == 5);
+    STATIC_REQUIRE(llama::internal::fieldCountBefore<4, Particle> == 7);
+    STATIC_REQUIRE(llama::internal::fieldCountBefore<5, Particle> == 11);
 }
 
 template <int i>


### PR DESCRIPTION
Addresses #240.

Further improves compile time by using memoizable variable templates instead of repreated constexpr evaluation.
Adds a fast-path for `VirtualRecord` operators when the LHS and RHS record dimension is equal.