### PR TITLE
Improve forEachLeaf compilation time

### DIFF
--- a/include/llama/RecordCoord.hpp
+++ b/include/llama/RecordCoord.hpp
@@ -78,7 +78,7 @@ namespace llama
 
     /// Concatenate two \ref RecordCoord instances.
     template <typename RecordCoord1, typename RecordCoord2>
-    auto cat(RecordCoord1, RecordCoord2)
+    constexpr auto cat(RecordCoord1, RecordCoord2)
     {
         return Cat<RecordCoord1, RecordCoord2>{};
     }


### PR DESCRIPTION
Instead of an hierarchical iteration on the record domain, we now precompute a flat list of leaf record coords, which is memoized and can be reused in multiple `forEachLeaf` instantiations.

Before (60s):
![image](https://user-images.githubusercontent.com/1224051/118851375-f6030200-b8d1-11eb-9251-576765e00b68.png)
After (45s):
![image](https://user-images.githubusercontent.com/1224051/118851748-627e0100-b8d2-11eb-9b4a-8ea3459afa0e.png)
Notice the reduction of the green bars, which are the template instantiations.