### PR TITLE
Small improvements

### DIFF
--- a/examples/nbody/nbody.cpp
+++ b/examples/nbody/nbody.cpp
@@ -189,7 +189,7 @@ namespace usellama
         plotFile << std::quoted(title) << "\t" << sumUpdate / STEPS << '\t' << sumMove / STEPS << '\n';
 
         if constexpr (HEATMAP)
-            std::ofstream("nbody_heatmap_" + mappingName(Mapping) + ".dat") << particles.mapping.toGnuplotDatFile();
+            std::ofstream("nbody_heatmap_" + mappingName(Mapping) + ".sh") << particles.mapping.toGnuplotScript();
 
         return 0;
     }

--- a/examples/viewcopy/viewcopy.cpp
+++ b/examples/viewcopy/viewcopy.cpp
@@ -418,7 +418,7 @@ try
     const auto dataSize
         = std::reduce(arrayDims.begin(), arrayDims.end(), std::size_t{1}, std::multiplies{}) * llama::sizeOf<RecordDim>;
     const auto numThreads = static_cast<std::size_t>(omp_get_max_threads());
-    std::cout << "Data size: " << dataSize << "\n";
+    std::cout << "Data size: " << dataSize / 1024 / 1024 << "MiB\n";
     std::cout << "Threads: " << numThreads << "\n";
 
     std::ofstream plotFile{"viewcopy.sh"};

--- a/tests/heatmap.cpp
+++ b/tests/heatmap.cpp
@@ -59,7 +59,7 @@ TEST_CASE("Heatmap.3body")
         for (std::size_t i = 0; i < N; i++)
             particles(i)(tag::Pos{}) += particles(i)(tag::Vel{}) * TIMESTEP;
 
-        std::ofstream{"Heatmap." + name + ".dat"} << particles.mapping.toGnuplotDatFile();
+        std::ofstream{"Heatmap." + name + ".sh"} << particles.mapping.toGnuplotScript();
     };
 
     using ArrayDims = llama::ArrayDims<1>;

--- a/tests/heatmap.cpp
+++ b/tests/heatmap.cpp
@@ -31,7 +31,7 @@ namespace
     // clang-format on
 } // namespace
 
-TEST_CASE("Heatmap.3body")
+TEST_CASE("Heatmap.nbody")
 {
     constexpr auto N = 100;
     auto run = [&](const std::string& name, auto mapping)
@@ -44,9 +44,10 @@ TEST_CASE("Heatmap.3body")
         constexpr float TIMESTEP = 0.0001f;
         constexpr float EPS2 = 0.01f;
         for (std::size_t i = 0; i < N; i++)
+        {
+            llama::One<Particle> pi = particles(i);
             for (std::size_t j = 0; j < N; ++j)
             {
-                auto pi = particles(i);
                 auto pj = particles(j);
                 auto dist = pi(tag::Pos{}) - pj(tag::Pos{});
                 dist *= dist;
@@ -56,6 +57,8 @@ TEST_CASE("Heatmap.3body")
                 const float sts = pj(tag::Mass{}) * invDistCube * TIMESTEP;
                 pi(tag::Vel{}) += dist * sts;
             }
+            particles(i) = pi;
+        }
         for (std::size_t i = 0; i < N; i++)
             particles(i)(tag::Pos{}) += particles(i)(tag::Vel{}) * TIMESTEP;
 


### PR DESCRIPTION
Here are a couple of improvements which were needed for the LLAMA paper:
* report viewcopy data size in MiB
*  more unaligned dump tests
* break SVG boxes at line breaks when dumping mappings
* create heatmap gnuplot script instead of just dat file
* cache pi in heatmap test