### PR TITLE
Improve SVG output

### DIFF
--- a/include/llama/DumpMapping.hpp
+++ b/include/llama/DumpMapping.hpp
@@ -206,12 +206,24 @@ namespace llama
         for (const auto& info : infos)
         {
             const auto blobY = blobYOffset[info.nrAndOffset.nr];
-            const auto x = (info.nrAndOffset.offset % wrapByteCount) * byteSizeInPixel + blobBlockWidth;
-            const auto y = (info.nrAndOffset.offset / wrapByteCount) * byteSizeInPixel + blobY;
-
+            auto x = (info.nrAndOffset.offset % wrapByteCount) * byteSizeInPixel + blobBlockWidth;
+            auto y = (info.nrAndOffset.offset / wrapByteCount) * byteSizeInPixel + blobY;
             const auto fill = internal::color(info.recordCoord);
-
             const auto width = byteSizeInPixel * info.size;
+
+            constexpr auto cropBoxes = true;
+            if (cropBoxes)
+            {
+                svg += fmt::format(
+                    R"(<svg x="{}" y="{}" width="{}" height="{}">
+)",
+                    x,
+                    y,
+                    width,
+                    byteSizeInPixel);
+                x = 0;
+                y = 0;
+            }
             svg += fmt::format(
                 R"(<rect x="{}" y="{}" width="{}" height="{}" fill="#{:X}" stroke="#000"/>
 )",
@@ -237,6 +249,9 @@ namespace llama
                 y + byteSizeInPixel * 3 / 4,
                 internal::formatUdCoord(info.adCoord),
                 internal::formatDDTags(info.recordTags));
+            if (cropBoxes)
+                svg += R"(</svg>
+)";
         }
         svg += "</svg>";
         return svg;

--- a/include/llama/DumpMapping.hpp
+++ b/include/llama/DumpMapping.hpp
@@ -172,14 +172,6 @@ namespace llama
             infos = internal::breakBoxes(std::move(infos), wrapByteCount);
 
         std::string svg;
-        svg += fmt::format(
-            R"(<?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<svg xmlns="http://www.w3.org/2000/svg">
-    <style>
-        .label {{ font: {}px sans-serif; }}
-    </style>
-)",
-            byteSizeInPixel / 2);
 
         std::array<int, Mapping::blobCount + 1> blobYOffset{};
         for (auto i = 0; i < Mapping::blobCount; i++)
@@ -198,6 +190,18 @@ namespace llama
                 blobYOffset[i] + height / 2,
                 i);
         }
+
+        svg = fmt::format(
+                  R"(<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg width="{}" height="{}" xmlns="http://www.w3.org/2000/svg">
+    <style>
+        .label {{ font: {}px sans-serif; }}
+    </style>
+)",
+                  blobBlockWidth + wrapByteCount * byteSizeInPixel,
+                  blobYOffset.back() - byteSizeInPixel,
+                  byteSizeInPixel / 2)
+            + svg;
 
         for (const auto& info : infos)
         {


### PR DESCRIPTION
This PR improves the SVG renderings of mappings:

* add total width and height to dumped SVG
* add option to crop each field's box in dumped SVGs (turned on)