### PR TITLE
Drop boost asio and fix boost hash

### DIFF
--- a/examples/common/hostname.hpp
+++ b/examples/common/hostname.hpp
@@ -1,0 +1,25 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#pragma once
+
+#include <string>
+#ifdef _WIN32
+#    define NOMINMAX
+#    define WIN32_LEAN_AND_MEAN
+#    include <winsock2.h>
+#    pragma comment(lib, "ws2_32")
+#else
+#    include <unistd.h>
+#endif
+
+namespace common
+{
+    // We used boost::asio::ip::host_name() originally, but it complicated the disassembly and requires asio as
+    // additional dependency.
+    inline auto hostname() -> std::string
+    {
+        std::string name(256, '\0');
+        ::gethostname(name.data(), 256);
+        return name;
+    }
+} // namespace common

--- a/examples/cuda/nbody/nbody.cu
+++ b/examples/cuda/nbody/nbody.cu
@@ -1,6 +1,6 @@
 #include "../../common/Stopwatch.hpp"
+#include "../../common/hostname.hpp"
 
-#include <boost/asio/ip/host_name.hpp>
 #include <cuda_runtime.h>
 #include <fmt/format.h>
 #include <fstream>
@@ -494,7 +494,7 @@ set y2tics auto
 $data << EOD
 )",
         PROBLEM_SIZE / 1024,
-        boost::asio::ip::host_name());
+        common::hostname());
     plotFile << "\"\"\t\"update\"\t\"move\"\n";
 
     using namespace boost::mp11;

--- a/examples/nbody/nbody.cpp
+++ b/examples/nbody/nbody.cpp
@@ -1,6 +1,6 @@
 #include "../common/Stopwatch.hpp"
+#include "../common/hostname.hpp"
 
-#include <boost/asio/ip/host_name.hpp>
 #include <fmt/format.h>
 #include <fstream>
 #include <iomanip>
@@ -1357,7 +1357,7 @@ set y2tics auto
 $data << EOD
 )",
         PROBLEM_SIZE / 1024,
-        boost::asio::ip::host_name());
+        common::hostname());
     plotFile << "\"\"\t\"update\"\t\"move\"\n";
 
     // Note:

--- a/examples/nbody_benchmark/nbody.cpp
+++ b/examples/nbody_benchmark/nbody.cpp
@@ -1,6 +1,6 @@
 #include "../common/Stopwatch.hpp"
+#include "../common/hostname.hpp"
 
-#include <boost/asio/ip/host_name.hpp>
 #include <chrono>
 #include <fmt/format.h>
 #include <fstream>
@@ -165,7 +165,7 @@ set yrange [0:*]
 $data << EOD
 )",
         PROBLEM_SIZE / 1000,
-        boost::asio::ip::host_name());
+        common::hostname());
 
     mp_for_each<mp_iota_c<28>>(
         [&](auto ae)

--- a/examples/vectoradd/vectoradd.cpp
+++ b/examples/vectoradd/vectoradd.cpp
@@ -1,6 +1,6 @@
 #include "../common/Stopwatch.hpp"
+#include "../common/hostname.hpp"
 
-#include <boost/asio/ip/host_name.hpp>
 #include <fmt/format.h>
 #include <fstream>
 #include <iostream>
@@ -298,7 +298,7 @@ set ylabel "update runtime [s]"
 $data << EOD
 )",
         PROBLEM_SIZE / 1024 / 1024,
-        boost::asio::ip::host_name());
+        common::hostname());
 
     int r = 0;
     r += usellama::main(plotFile);

--- a/examples/viewcopy/viewcopy.cpp
+++ b/examples/viewcopy/viewcopy.cpp
@@ -1,7 +1,7 @@
 #include "../common/Stopwatch.hpp"
+#include "../common/hostname.hpp"
 #include "../common/ttjet_13tev_june2019.hpp"
 
-#include <boost/asio/ip/host_name.hpp>
 #include <boost/functional/hash.hpp>
 #include <boost/mp11.hpp>
 #include <fmt/format.h>
@@ -435,7 +435,7 @@ set ylabel "throughput [GiB/s]"
 $data << EOD
 )",
         dataSize / 1024 / 1024,
-        boost::asio::ip::host_name());
+        common::hostname());
 
     plotFile << "\"\"\t\"memcpy\"\t\"memcpy\\\\\\_avx2\"\t\"memcpy(p)\"\t\"memcpy\\\\\\_avx2(p)\"\t\"naive "
                 "copy\"\t\"std::copy\"\t\"aosoa copy(r)\"\t\"aosoa copy(w)\"\t\"naive copy(p)\"\t\"aosoa "

--- a/include/llama/DumpMapping.hpp
+++ b/include/llama/DumpMapping.hpp
@@ -5,7 +5,7 @@
 #include "ArrayDimsIndexRange.hpp"
 #include "Core.hpp"
 
-#include <boost/container_hash/hash.hpp>
+#include <boost/functional/hash.hpp>
 #include <fmt/format.h>
 #include <string>
 #include <vector>
@@ -64,7 +64,7 @@ namespace llama
 
         inline auto color(const std::vector<std::size_t>& recordCoord) -> std::size_t
         {
-            auto c = (boost::hash_value(recordCoord) & 0xFFFFFF);
+            auto c = boost::hash<std::vector<std::size_t>>{}(recordCoord) &0xFFFFFF;
             const auto channelSum = ((c & 0xFF0000) >> 4) + ((c & 0xFF00) >> 2) + c & 0xFF;
             if (channelSum < 200)
                 c |= 0x404040; // ensure color per channel is at least 0x40.


### PR DESCRIPTION
This PR replaced boost asio for getting the hostname by calling the platforms `::gethostname` directly. Furthermore, `boost::hash` is now used via an older header, to support older boost versions.

Related: #159.