### PR TITLE
Improve doxygen output

### DIFF
--- a/docs/Doxyfile
+++ b/docs/Doxyfile
@@ -791,7 +791,6 @@ WARN_LOGFILE           =
 # Note: If this tag is empty the current directory is searched.
 
 INPUT                  = ../include/
-INPUT                 += ../examples/
 
 # This tag can be used to specify the character encoding of the source files
 # that doxygen parses. Internally doxygen uses the UTF-8 encoding. Doxygen uses

--- a/docs/Doxyfile
+++ b/docs/Doxyfile
@@ -816,50 +816,7 @@ INPUT_ENCODING         = UTF-8
 # *.m, *.markdown, *.md, *.mm, *.dox, *.py, *.pyw, *.f90, *.f95, *.f03, *.f08,
 # *.f, *.for, *.tcl, *.vhd, *.vhdl, *.ucf and *.qsf.
 
-FILE_PATTERNS          = *.c \
-                         *.cc \
-                         *.cxx \
-                         *.cpp \
-                         *.c++ \
-                         *.java \
-                         *.ii \
-                         *.ixx \
-                         *.ipp \
-                         *.i++ \
-                         *.inl \
-                         *.idl \
-                         *.ddl \
-                         *.odl \
-                         *.h \
-                         *.hh \
-                         *.hxx \
-                         *.hpp \
-                         *.h++ \
-                         *.cs \
-                         *.d \
-                         *.php \
-                         *.php4 \
-                         *.php5 \
-                         *.phtml \
-                         *.inc \
-                         *.m \
-                         *.markdown \
-                         *.md \
-                         *.mm \
-                         *.dox \
-                         *.py \
-                         *.pyw \
-                         *.f90 \
-                         *.f95 \
-                         *.f03 \
-                         *.f08 \
-                         *.f \
-                         *.for \
-                         *.tcl \
-                         *.vhd \
-                         *.vhdl \
-                         *.ucf \
-                         *.qsf
+FILE_PATTERNS          =
 
 # The RECURSIVE tag can be used to specify whether or not subdirectories should
 # be searched for input files as well.

--- a/include/llama/Core.hpp
+++ b/include/llama/Core.hpp
@@ -56,9 +56,9 @@ namespace llama
     /// Record.
     /// \tparam Tag Name of the node. May be any type (struct, class).
     /// \tparam Type Type of the node. May be one of three cases. 1. another sub tree consisting of a nested \ref
-    /// Record. 2. an array of any type, in which case a Record with as many \ref Field as the array
-    /// size is created, named \ref Index specialized on consecutive numbers. 3. A scalar type different from \ref
-    /// Record, making this node a leaf of this type.
+    /// Record. 2. an array of static size of any type, in which case a Record with as many \ref Field as the array
+    /// size is created, named \ref RecordCoord specialized on consecutive numbers I. 3. A scalar type different from
+    /// \ref Record, making this node a leaf of this type.
     template <typename Tag, typename Type>
     struct Field
     {

--- a/include/llama/mapping/Common.hpp
+++ b/include/llama/mapping/Common.hpp
@@ -91,8 +91,9 @@ namespace llama::mapping
         /// \param size Total size of the array dimensions.
         /// \return Linearized index.
         template <std::size_t Dim>
-        LLAMA_FN_HOST_ACC_INLINE constexpr auto operator()(const ArrayDims<Dim>& coord, const ArrayDims<Dim>&) const
-            -> std::size_t
+        LLAMA_FN_HOST_ACC_INLINE constexpr auto operator()(
+            const ArrayDims<Dim>& coord,
+            [[maybe_unused]] const ArrayDims<Dim>& size) const -> std::size_t
         {
             std::size_t r = 0;
             for (std::size_t bit = 0; bit < (sizeof(std::size_t) * CHAR_BIT) / Dim; bit++)


### PR DESCRIPTION
* cleanup Doxyfile
* fix 2 doxygen warnings
* exclude LLAMA examples from doxygen. They blow up the output a lot by now, making the documentation hard to navigate if you solely work with LLAMA.