### PR TITLE
Allow to use static arrays as record dimension

### DIFF
--- a/include/llama/RecordCoord.hpp
+++ b/include/llama/RecordCoord.hpp
@@ -30,6 +30,12 @@ namespace llama
         static constexpr std::size_t size = 0;
     };
 
+    template <typename T>
+    inline constexpr bool isRecordCoord = false;
+
+    template <std::size_t... Coords>
+    inline constexpr bool isRecordCoord<RecordCoord<Coords...>> = true;
+
     inline namespace literals
     {
         /// Literal operator for converting a numeric literal into a \ref RecordCoord.

--- a/include/llama/View.hpp
+++ b/include/llama/View.hpp
@@ -221,6 +221,17 @@ namespace llama
             : std::bool_constant<Mapping::isComputed(RecordCoord{})>
         {
         };
+
+        // TODO: replace in C++20
+        template <class T>
+        struct is_bounded_array : std::false_type
+        {
+        };
+
+        template <class T, std::size_t N>
+        struct is_bounded_array<T[N]> : std::true_type
+        {
+        };
     } // namespace internal
 
     /// Central LLAMA class holding memory for storage and giving access to
@@ -258,7 +269,7 @@ namespace llama
         /// coordinate.
         LLAMA_FN_HOST_ACC_INLINE auto operator()(ArrayDims arrayDims) const -> decltype(auto)
         {
-            if constexpr (isRecord<RecordDim>)
+            if constexpr (isRecord<RecordDim> || internal::is_bounded_array<RecordDim>::value)
             {
                 LLAMA_FORCE_INLINE_RECURSIVE
                 return VirtualRecordTypeConst{arrayDims, *this};
@@ -272,7 +283,7 @@ namespace llama
 
         LLAMA_FN_HOST_ACC_INLINE auto operator()(ArrayDims arrayDims) -> decltype(auto)
         {
-            if constexpr (isRecord<RecordDim>)
+            if constexpr (isRecord<RecordDim> || internal::is_bounded_array<RecordDim>::value)
             {
                 LLAMA_FORCE_INLINE_RECURSIVE
                 return VirtualRecordType{arrayDims, *this};

--- a/include/llama/View.hpp
+++ b/include/llama/View.hpp
@@ -221,17 +221,6 @@ namespace llama
             : std::bool_constant<Mapping::isComputed(RecordCoord{})>
         {
         };
-
-        // TODO: replace in C++20
-        template <class T>
-        struct is_bounded_array : std::false_type
-        {
-        };
-
-        template <class T, std::size_t N>
-        struct is_bounded_array<T[N]> : std::true_type
-        {
-        };
     } // namespace internal
 
     /// Central LLAMA class holding memory for storage and giving access to

--- a/include/llama/VirtualRecord.hpp
+++ b/include/llama/VirtualRecord.hpp
@@ -351,7 +351,8 @@ namespace llama
         LLAMA_FN_HOST_ACC_INLINE auto operator()(RecordCoord<Coord...> = {}) const -> decltype(auto)
         {
             using AbsolutCoord = Cat<BoundRecordCoord, RecordCoord<Coord...>>;
-            if constexpr (isRecord<GetType<RecordDim, AbsolutCoord>>)
+            using AccessedType = GetType<RecordDim, AbsolutCoord>;
+            if constexpr (isRecord<AccessedType> || internal::is_bounded_array<AccessedType>::value)
             {
                 LLAMA_FORCE_INLINE_RECURSIVE
                 return VirtualRecord<const View, AbsolutCoord>{arrayDimsCoord, this->view};
@@ -368,7 +369,8 @@ namespace llama
         LLAMA_FN_HOST_ACC_INLINE auto operator()(RecordCoord<Coord...> coord = {}) -> decltype(auto)
         {
             using AbsolutCoord = Cat<BoundRecordCoord, RecordCoord<Coord...>>;
-            if constexpr (isRecord<GetType<RecordDim, AbsolutCoord>>)
+            using AccessedType = GetType<RecordDim, AbsolutCoord>;
+            if constexpr (isRecord<AccessedType> || internal::is_bounded_array<AccessedType>::value)
             {
                 LLAMA_FORCE_INLINE_RECURSIVE
                 return VirtualRecord<View, AbsolutCoord>{arrayDimsCoord, this->view};

--- a/include/llama/mapping/tree/TreeFromDimensions.hpp
+++ b/include/llama/mapping/tree/TreeFromDimensions.hpp
@@ -86,6 +86,19 @@ namespace llama::mapping::tree
                 CountType>;
         };
 
+        template <typename Tag, typename ChildType, std::size_t Count, typename CountType>
+        struct CreateTreeElement<Tag, ChildType[Count], CountType>
+        {
+            template <std::size_t... Is>
+            static auto createChildren(std::index_sequence<Is...>)
+            {
+                return Tuple<
+                    typename CreateTreeElement<RecordCoord<Is>, ChildType, boost::mp11::mp_size_t<1>>::type...>{};
+            }
+
+            using type = Node<Tag, decltype(createChildren(std::make_index_sequence<Count>{})), CountType>;
+        };
+
         template <typename Leaf, std::size_t Count>
         struct WrapInNNodes
         {

--- a/tests/core.cpp
+++ b/tests/core.cpp
@@ -300,37 +300,3 @@ TEST_CASE("flatRecordCoord")
     STATIC_REQUIRE(llama::flatRecordCoord<Particle, llama::RecordCoord<4, 2>> == 9);
     STATIC_REQUIRE(llama::flatRecordCoord<Particle, llama::RecordCoord<4, 3>> == 10);
 }
-
-// clang-format off
-namespace tag
-{
-    struct A1{};
-    struct A2{};
-    struct A3{};
-} // namespace tag
-
-using Arrays = llama::Record<
-    llama::Field<tag::A1, int[3]>,
-    llama::Field<tag::A2, llama::Record<
-        llama::Field<tag::X, float>
-    >[3]>,
-    llama::Field<tag::A3, int[2][2]>
->;
-// clang-format on
-
-TEST_CASE("arrays")
-{
-    using namespace llama::literals;
-
-    auto v = llama::allocView(llama::mapping::AoS{llama::ArrayDims{1}, Arrays{}});
-    v(0u)(tag::A1{}, 0_RC);
-    v(0u)(tag::A1{}, 1_RC);
-    v(0u)(tag::A1{}, 2_RC);
-    v(0u)(tag::A2{}, 0_RC, tag::X{});
-    v(0u)(tag::A2{}, 1_RC, tag::X{});
-    v(0u)(tag::A2{}, 2_RC, tag::X{});
-    v(0u)(tag::A3{}, 0_RC, 0_RC);
-    v(0u)(tag::A3{}, 0_RC, 1_RC);
-    v(0u)(tag::A3{}, 1_RC, 0_RC);
-    v(0u)(tag::A3{}, 1_RC, 1_RC);
-}

--- a/tests/recorddimension.cpp
+++ b/tests/recorddimension.cpp
@@ -199,3 +199,71 @@ TEST_CASE("recorddim.int[3]")
     view(0u)(1_RC) = 43;
     view(0u)(2_RC) = 44;
 }
+
+// if we lift the array size higher, we hit the limit on template instantiations
+TEST_CASE("recorddim.int[200]")
+{
+    using namespace llama::literals;
+
+    using RecordDim = int[200];
+    auto view = allocView(llama::mapping::AoS<llama::ArrayDims<1>, RecordDim>{llama::ArrayDims{1}});
+
+    view(0u)(0_RC) = 42;
+    view(0u)(199_RC) = 43;
+}
+
+TEST_CASE("recorddim.int[3][2]")
+{
+    using namespace llama::literals;
+
+    using RecordDim = int[3][2];
+    auto view = allocView(llama::mapping::AoS<llama::ArrayDims<1>, RecordDim>{llama::ArrayDims{1}});
+
+    view(0u)(0_RC)(0_RC) = 42;
+    view(0u)(0_RC)(1_RC) = 43;
+    view(0u)(1_RC)(0_RC) = 44;
+    view(0u)(1_RC)(1_RC) = 45;
+    view(0u)(2_RC)(0_RC) = 46;
+    view(0u)(2_RC)(1_RC) = 47;
+}
+
+TEST_CASE("recorddim.int[1][1][1][1][1][1][1][1][1][1]")
+{
+    using namespace llama::literals;
+
+    using RecordDim = int[1][1][1][1][1][1][1][1][1][1];
+    auto view = allocView(llama::mapping::AoS<llama::ArrayDims<1>, RecordDim>{llama::ArrayDims{1}});
+
+    view(0u)(0_RC)(0_RC) (0_RC) (0_RC) (0_RC) (0_RC) (0_RC) (0_RC) (0_RC) (0_RC) = 42;
+}
+
+// clang-format off
+struct A1{};
+struct A2{};
+struct A3{};
+
+using Arrays = llama::Record<
+    llama::Field<A1, int[3]>,
+    llama::Field<A2, llama::Record<
+        llama::Field<Tag, float>
+    >[3]>,
+    llama::Field<A3, int[2][2]>
+>;
+// clang-format on
+
+TEST_CASE("recorddim.record_with_arrays")
+{
+    using namespace llama::literals;
+
+    auto view = llama::allocView(llama::mapping::AoS{llama::ArrayDims{1}, Arrays{}});
+    view(0u)(A1{}, 0_RC);
+    view(0u)(A1{}, 1_RC);
+    view(0u)(A1{}, 2_RC);
+    view(0u)(A2{}, 0_RC, Tag{});
+    view(0u)(A2{}, 1_RC, Tag{});
+    view(0u)(A2{}, 2_RC, Tag{});
+    view(0u)(A3{}, 0_RC, 0_RC);
+    view(0u)(A3{}, 0_RC, 1_RC);
+    view(0u)(A3{}, 1_RC, 0_RC);
+    view(0u)(A3{}, 1_RC, 1_RC);
+}

--- a/tests/recorddimension.cpp
+++ b/tests/recorddimension.cpp
@@ -187,3 +187,15 @@ TEST_CASE("recorddim.int")
     view[llama::ArrayDims{0}] = 42;
     CHECK(view[llama::ArrayDims{0}] == 42);
 }
+
+TEST_CASE("recorddim.int[3]")
+{
+    using namespace llama::literals;
+
+    using RecordDim = int[3];
+    auto view = allocView(llama::mapping::AoS<llama::ArrayDims<1>, RecordDim>{llama::ArrayDims{1}});
+
+    view(0u)(0_RC) = 42;
+    view(0u)(1_RC) = 43;
+    view(0u)(2_RC) = 44;
+}


### PR DESCRIPTION
This PR adds better static array support to LLAMA and avoids internally expanding static arrays into records. This speeds up compilation and allows LLAMA to handle larger arrays as part of the record domain.

It also fixes #244.