### PR TITLE
Switch One to have zero dimensions

### DIFF
--- a/include/llama/VirtualRecord.hpp
+++ b/include/llama/VirtualRecord.hpp
@@ -21,7 +21,7 @@ namespace llama
 
     /// A \ref VirtualRecord that owns and holds a single value.
     template <typename RecordDim>
-    using One = VirtualRecord<decltype(allocViewStack<1, RecordDim>()), RecordCoord<>, true>;
+    using One = VirtualRecord<decltype(allocViewStack<0, RecordDim>()), RecordCoord<>, true>;
 
     /// Creates a single \ref VirtualRecord owning a view with stack memory and
     /// copies all values from an existing \ref VirtualRecord.
@@ -301,7 +301,7 @@ namespace llama
         using ArrayDims = typename View::Mapping::ArrayDims;
         using RecordDim = typename View::Mapping::RecordDim;
 
-        const ArrayDims arrayDimsCoord;
+        [[no_unique_address]] const ArrayDims arrayDimsCoord;
         std::conditional_t<OwnView, View, View&> view;
 
     public:
@@ -314,7 +314,7 @@ namespace llama
         LLAMA_FN_HOST_ACC_INLINE VirtualRecord()
             /* requires(OwnView) */
             : arrayDimsCoord({})
-            , view{allocViewStack<1, RecordDim>()}
+            , view{allocViewStack<0, RecordDim>()}
         {
             static_assert(OwnView, "The default constructor of VirtualRecord is only available if it owns the view.");
         }

--- a/tests/arraydomain.cpp
+++ b/tests/arraydomain.cpp
@@ -43,8 +43,8 @@ TEST_CASE("ArrayDims.dim0")
     Mapping mapping{arrayDims};
     auto view = allocView(mapping);
 
-    float& x = view(ArrayDims{})(tag::Pos{}, tag::X{});
-    x = 0;
+    float& x1 = view(ArrayDims{})(tag::Pos{}, tag::X{});
+    float& x2 = view()(tag::Pos{}, tag::X{});
 }
 
 TEST_CASE("ArrayDims.dim1")


### PR DESCRIPTION
Switch `llama::One<RecordDim>` from being backed by a one dimensional view to a zero dimensional view. This is truer to its semantics and also potentially needs to store a `size_t` less.