### PR TITLE
One improvements

### DIFF
--- a/examples/alpaka/asyncblur/asyncblur.cpp
+++ b/examples/alpaka/asyncblur/asyncblur.cpp
@@ -128,7 +128,7 @@ struct BlurKernel
             LLAMA_INDEPENDENT_DATA
         for (auto x = start[1]; x < end[1]; ++x)
         {
-            llama::One<PixelOnAcc> sum = 0;
+            llama::One<PixelOnAcc> sum{0};
 
             using ItType = std::int64_t;
             const ItType iBStart = SHARED ? ItType(y) - ItType(bi[0] * ElemsPerBlock) : y;

--- a/include/llama/VirtualRecord.hpp
+++ b/include/llama/VirtualRecord.hpp
@@ -329,10 +329,11 @@ namespace llama
         VirtualRecord(const VirtualRecord&) = default;
         VirtualRecord(VirtualRecord&&) = default;
 
-        /// Create a VirtuaRecord from a single value or a different VirtualRecord. Only available for if the view is
-        /// owned. Used by llama::One.
-        template <typename T>
-        LLAMA_FN_HOST_ACC_INLINE VirtualRecord(const T& other)
+        /// Create a VirtuaRecord from a different VirtualRecord. Only available for if the view is owned. Used by
+        /// llama::One.
+        template <typename OtherView, typename OtherBoundRecordCoord, bool OtherOwnView>
+        LLAMA_FN_HOST_ACC_INLINE VirtualRecord(
+            const VirtualRecord<OtherView, OtherBoundRecordCoord, OtherOwnView>& virtualRecord)
             /* requires(OwnView) */
             : VirtualRecord()
         {
@@ -340,7 +341,20 @@ namespace llama
                 OwnView,
                 "The copy constructor of VirtualRecord from a different VirtualRecord is only available if it owns the "
                 "view.");
-            *this = other;
+            *this = virtualRecord;
+        }
+
+        // TODO: unify with previous in C++20 and use explicit(cond)
+        /// Create a VirtuaRecord from a scalar. Only available for if the view is owned. Used by llama::One.
+        template <typename T, typename = std::enable_if_t<!is_VirtualRecord<T>>>
+        LLAMA_FN_HOST_ACC_INLINE explicit VirtualRecord(const T& scalar)
+            /* requires(OwnView) */
+            : VirtualRecord()
+        {
+            static_assert(
+                OwnView,
+                "The copy constructor of VirtualRecord from a scalar is only available if it owns the view.");
+            *this = scalar;
         }
 
         /// Access a record in the record dimension underneath the current virtual

--- a/tests/virtualrecord.cpp
+++ b/tests/virtualrecord.cpp
@@ -949,6 +949,17 @@ TEST_CASE("VirtualRecord.One_inside_std::vector")
     CHECK(v[2](tag::Weight{}) == 30);
 }
 
+TEST_CASE("VirtualRecord.One_from_scalar")
+{
+    llama::One<Particle> p{42};
+    CHECK(p(tag::Pos{}, tag::A{}) == 42);
+    CHECK(p(tag::Pos{}, tag::Y{}) == 42);
+    CHECK(p(tag::Vel{}, tag::X{}) == 42);
+    CHECK(p(tag::Vel{}, tag::Y{}) == 42);
+    CHECK(p(tag::Vel{}, tag::Z{}) == 42);
+    CHECK(p(tag::Weight{}) == 42);
+}
+
 TEST_CASE("VirtualRecord.operator<<")
 {
     auto p = oneParticle();

--- a/tests/virtualrecord.cpp
+++ b/tests/virtualrecord.cpp
@@ -1,8 +1,10 @@
 #include "common.h"
 
+#include <algorithm>
 #include <catch2/catch.hpp>
 #include <llama/llama.hpp>
 #include <sstream>
+#include <vector>
 
 // clang-format off
 namespace tag {
@@ -921,6 +923,30 @@ TEST_CASE("VirtualRecord.One_range_for")
     for (llama::One<Particle> p : view) // p is a copy
         p = 2;
     CHECK(view(1u) == 1);
+}
+
+TEST_CASE("VirtualRecord.One_concepts")
+{
+#ifdef __cpp_concepts
+    STATIC_REQUIRE(std::regular<llama::One<Particle>>);
+#endif
+}
+
+TEST_CASE("VirtualRecord.One_inside_std::vector")
+{
+    std::vector<llama::One<Particle>> v(2); // create 2 One
+    v.push_back(oneParticle()); // add 1 more
+    v[0](tag::Weight{}) = 20;
+    v[1](tag::Weight{}) = 30;
+    v[2](tag::Weight{}) = 10;
+    std::sort(
+        std::begin(v),
+        std::end(v),
+        [](const llama::One<Particle>& a, const llama::One<Particle>& b)
+        { return a(tag::Weight{}) < b(tag::Weight{}); });
+    CHECK(v[0](tag::Weight{}) == 10);
+    CHECK(v[1](tag::Weight{}) == 20);
+    CHECK(v[2](tag::Weight{}) == 30);
 }
 
 TEST_CASE("VirtualRecord.operator<<")


### PR DESCRIPTION
* add test that One is regular
* check One works inside std::vector
* make constructing VirtualRecords from types other than VirtualRecord is explicit, fixes a bug