### PR TITLE
Showcase and discuss CRP clang-tidy

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -1,10 +1,10 @@
 ---
 # -bugprone-forward-declaration-namespace # too many false positives in LLAMA
+# -cppcoreguidelines-macro-usage # too many macros flagged, which cannot be replaced by constexpr
 # -bugprone-exception-escape # bgruber is fine with exceptions escaping main we cannot add main as an exception
-# -cppcoreguidelines-pro-type-member-init # maybe enable in the future
 # -cppcoreguidelines-pro-type-reinterpret-cast # we need some reinterpret casts in LLAMA
-# -hicpp-member-init # maybe enable in the future
 # -readability-misleading-indentation # many false positives because of constexpr if
+# -readability-static-accessed-through-instance # flags threadIdx/blockIdx in CUDA code
 Checks: >
     *,
     -bugprone-exception-escape,
@@ -17,7 +17,6 @@ Checks: >
     -cppcoreguidelines-non-private-member-variables-in-classes,
     -cppcoreguidelines-pro-bounds-constant-array-index,
     -cppcoreguidelines-pro-bounds-pointer-arithmetic,
-    -cppcoreguidelines-pro-type-member-init,
     -cppcoreguidelines-pro-type-reinterpret-cast,
     -fuchsia-default-arguments-calls,
     -fuchsia-default-arguments-declarations,
@@ -25,11 +24,9 @@ Checks: >
     -fuchsia-trailing-return,
     -google-build-using-namespace,
     -google-readability-braces-around-statements,
-    -google-readability-todo,
     -google-runtime-references,
     -hicpp-avoid-c-arrays,
     -hicpp-braces-around-statements,
-    -hicpp-member-init,
     -hicpp-named-parameter,
     -hicpp-uppercase-literal-suffix,
     -llvmlibc-callee-namespace,
@@ -42,12 +39,14 @@ Checks: >
     -portability-simd-intrinsics,
     -readability-braces-around-statements,
     -readability-magic-numbers,
-    -readability-misleading-indentation,
     -readability-named-parameter,
     -readability-uppercase-literal-suffix,
     -readability-function-cognitive-complexity,
+    -readability-static-accessed-through-instance,
     -altera-struct-pack-align,
-    -misc-no-recursion
+    -misc-no-recursion,
+    -llvm-header-guard,
+    -cppcoreguidelines-macro-usage
 
 WarningsAsErrors: '*'
 HeaderFilterRegex: ''
@@ -55,4 +54,13 @@ AnalyzeTemporaryDtors: false
 FormatStyle: none
 User: ''
 CheckOptions:
-...
+  - { key: readability-identifier-naming.ClassCase, value: CamelCase}
+  - { key: readability-identifier-naming.EnumCase, value: CamelCase}
+  - { key: readability-identifier-naming.StructCase, value: CamelCase}
+  - { key: readability-identifier-naming.MacroDefinitionCase, value: UPPER_CASE}
+  - { key: readability-identifier-naming.TemplateParameterCase, value: CamelCase}
+  - { key: readability-identifier-naming.TemplateTemplateParameterCase, value: CamelCase}
+  - { key: readability-identifier-naming.TypedefCase, value: CamelCase}
+  - { key: readability-identifier-naming.TypeTemplateParameterCase, value: CamelCase}
+  - { key: readability-identifier-naming.UnionCase, value: CamelCase}
+  - { key: readability-identifier-naming.ValueTemplateParameterCase, value: CamelCase}

--- a/.clang-tidy
+++ b/.clang-tidy
@@ -58,9 +58,9 @@ CheckOptions:
   - { key: readability-identifier-naming.EnumCase, value: CamelCase}
   - { key: readability-identifier-naming.StructCase, value: CamelCase}
   - { key: readability-identifier-naming.MacroDefinitionCase, value: UPPER_CASE}
-  - { key: readability-identifier-naming.TemplateParameterCase, value: CamelCase}
-  - { key: readability-identifier-naming.TemplateTemplateParameterCase, value: CamelCase}
+#  - { key: readability-identifier-naming.TemplateParameterCase, value: CamelCase}
+  - { key: readability-identifier-naming.TemplateTemplateParameterCase, value: CamelCase} # bug in C++20: https://bugs.llvm.org/show_bug.cgi?id=46752
   - { key: readability-identifier-naming.TypedefCase, value: CamelCase}
-  - { key: readability-identifier-naming.TypeTemplateParameterCase, value: CamelCase}
+#  - { key: readability-identifier-naming.TypeTemplateParameterCase, value: CamelCase} # bug in C++20: https://bugs.llvm.org/show_bug.cgi?id=46752
   - { key: readability-identifier-naming.UnionCase, value: CamelCase}
   - { key: readability-identifier-naming.ValueTemplateParameterCase, value: CamelCase}

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -42,7 +42,8 @@ jobs:
         mkdir build
         cd build
         cmake .. -DCMAKE_EXPORT_COMPILE_COMMANDS=ON -DCMAKE_BUILD_TYPE=$CONFIG -DALPAKA_ACC_CPU_B_SEQ_T_SEQ_ENABLE=ON -DALPAKA_CXX_STANDARD=17 -DCMAKE_TOOLCHAIN_FILE=/usr/local/share/vcpkg/scripts/buildsystems/vcpkg.cmake
-        run-clang-tidy-12
+        sed -i 's/\(-forward-unknown-to-host-compiler\|--generate-code=arch=[^ ]\+\|--expt-extended-lambda\|--expt-relaxed-constexpr\|--use_fast_math\)//g' compile_commands.json # remove NVCC specific flags which clang cannot handle
+        run-clang-tidy-12 -header-filter='^((?!/thirdparty/).)*$' -extra-arg=--no-cuda-version-check -extra-arg=-nocudalib
 
   amalgamation:
     runs-on: ubuntu-latest

--- a/examples/alpaka/nbody/nbody.cpp
+++ b/examples/alpaka/nbody/nbody.cpp
@@ -105,7 +105,7 @@ LLAMA_FN_HOST_ACC_INLINE auto store(FP& dst, Vec v)
 template<std::size_t Elems>
 struct VecType
 {
-    // TODO: we need a vector type that also works on GPUs
+    // TODO(bgruber): we need a vector type that also works on GPUs
 #ifndef ALPAKA_ACC_GPU_CUDA_ENABLED
     using type = Vc::SimdArray<FP, Elems>;
 #endif
@@ -177,7 +177,7 @@ struct UpdateKernel
         const auto ti = alpaka::getIdx<alpaka::Grid, alpaka::Threads>(acc)[0];
         const auto tbi = alpaka::getIdx<alpaka::Block, alpaka::Threads>(acc)[0];
 
-        // TODO: we could optimize here, because only velocity is ever updated
+        // TODO(bgruber): we could optimize here, because only velocity is ever updated
         auto pi = [&]
         {
             constexpr auto arrayDims = llama::ArrayDims<1>{Elems};
@@ -186,7 +186,7 @@ struct UpdateKernel
             constexpr auto blobAlloc = llama::bloballoc::Stack<llama::sizeOf<typename View::RecordDim> * Elems>{};
             return llama::allocView(mapping, blobAlloc);
         }();
-        // TODO: vector load
+        // TODO(bgruber): vector load
         LLAMA_INDEPENDENT_DATA
         for(auto e = 0u; e < Elems; e++)
             pi(e) = particles(ti * Elems + e);
@@ -204,7 +204,7 @@ struct UpdateKernel
                 pPInteraction<Elems>(pi(0u), sharedView(j));
             alpaka::syncBlockThreads(acc);
         }
-        // TODO: vector store
+        // TODO(bgruber): vector store
         LLAMA_INDEPENDENT_DATA
         for(auto e = 0u; e < Elems; e++)
             particles(ti * Elems + e) = pi(e);

--- a/examples/bufferguard/bufferguard.cpp
+++ b/examples/bufferguard/bufferguard.cpp
@@ -21,13 +21,13 @@ using Vector = llama::Record<
 >;
 // clang-format on
 
-template<template<typename, typename> typename InnerMapping, typename T_ArrayDims, typename T_RecordDim>
+template<template<typename, typename> typename InnerMapping, typename TArrayDims, typename TRecordDim>
 struct GuardMapping2D
 {
-    static_assert(std::is_same_v<T_ArrayDims, llama::ArrayDims<2>>, "Only 2D arrays are implemented");
+    static_assert(std::is_same_v<TArrayDims, llama::ArrayDims<2>>, "Only 2D arrays are implemented");
 
-    using ArrayDims = T_ArrayDims;
-    using RecordDim = T_RecordDim;
+    using ArrayDims = TArrayDims;
+    using RecordDim = TRecordDim;
 
     constexpr GuardMapping2D() = default;
 

--- a/examples/nbody_benchmark/nbody.cpp
+++ b/examples/nbody_benchmark/nbody.cpp
@@ -121,7 +121,7 @@ void run(std::ostream& plotFile)
         std::cout << '\n';
     }
 
-    std::default_random_engine engine;
+    std::default_random_engine engine; // NOLINT(readability-misleading-indentation)
     std::normal_distribution<FP> dist(FP(0), FP(1));
     for(std::size_t i = 0; i < PROBLEM_SIZE; ++i)
     {

--- a/examples/raycast/raycast.cpp
+++ b/examples/raycast/raycast.cpp
@@ -228,7 +228,7 @@ namespace
 
     struct Camera
     {
-        float fovy; // in degree
+        float fovy = 0; // in degree
         VectorF position;
         VectorF view;
         VectorF up;
@@ -237,19 +237,19 @@ namespace
     struct Sphere
     {
         VectorF center;
-        float radius;
+        float radius = 0;
     };
 
     struct Vertex
     {
         VectorF pos;
-        float u;
-        float v;
+        float u = 0;
+        float v = 0;
     };
 
     struct Triangle : std::array<Vertex, 3>
     {
-        int texIndex;
+        int texIndex = 0;
     };
 
     struct AABB
@@ -260,12 +260,6 @@ namespace
         inline auto center() const -> VectorF
         {
             return (lower + upper) * 0.5f;
-        }
-
-        inline auto contains(VectorF v) const -> bool
-        {
-            return lower[0] <= v[0] && v[0] <= upper[0] && lower[1] <= v[1] && v[1] <= upper[1] && lower[2] <= v[2]
-                && v[2] <= upper[2];
         }
     };
 

--- a/include/llama/Array.hpp
+++ b/include/llama/Array.hpp
@@ -25,22 +25,22 @@ namespace llama
             return N;
         }
 
-        LLAMA_FN_HOST_ACC_INLINE constexpr T* begin()
+        LLAMA_FN_HOST_ACC_INLINE constexpr auto begin() -> T*
         {
             return &element[0];
         }
 
-        LLAMA_FN_HOST_ACC_INLINE constexpr const T* begin() const
+        LLAMA_FN_HOST_ACC_INLINE constexpr auto begin() const -> const T*
         {
             return &element[0];
         }
 
-        LLAMA_FN_HOST_ACC_INLINE constexpr T* end()
+        LLAMA_FN_HOST_ACC_INLINE constexpr auto end() -> T*
         {
             return &element[N];
         }
 
-        LLAMA_FN_HOST_ACC_INLINE constexpr const T* end() const
+        LLAMA_FN_HOST_ACC_INLINE constexpr auto end() const -> const T*
         {
             return &element[N];
         }
@@ -102,37 +102,37 @@ namespace llama
             return 0;
         }
 
-        LLAMA_FN_HOST_ACC_INLINE constexpr T* begin()
+        LLAMA_FN_HOST_ACC_INLINE constexpr auto begin() -> T*
         {
             return nullptr;
         }
 
-        LLAMA_FN_HOST_ACC_INLINE constexpr const T* begin() const
+        LLAMA_FN_HOST_ACC_INLINE constexpr auto begin() const -> const T*
         {
             return nullptr;
         }
 
-        LLAMA_FN_HOST_ACC_INLINE constexpr T* end()
+        LLAMA_FN_HOST_ACC_INLINE constexpr auto end() -> T*
         {
             return nullptr;
         }
 
-        LLAMA_FN_HOST_ACC_INLINE constexpr const T* end() const
+        LLAMA_FN_HOST_ACC_INLINE constexpr auto end() const -> const T*
         {
             return nullptr;
         }
 
-        LLAMA_FN_HOST_ACC_INLINE constexpr friend auto operator==(const Array& a, const Array& b) -> bool
+        LLAMA_FN_HOST_ACC_INLINE constexpr friend auto operator==(const Array&, const Array&) -> bool
         {
             return true;
         }
 
-        LLAMA_FN_HOST_ACC_INLINE constexpr friend auto operator!=(const Array& a, const Array& b) -> bool
+        LLAMA_FN_HOST_ACC_INLINE constexpr friend auto operator!=(const Array&, const Array&) -> bool
         {
             return false;
         }
 
-        LLAMA_FN_HOST_ACC_INLINE constexpr friend auto operator+(const Array& a, const Array& b) -> Array
+        LLAMA_FN_HOST_ACC_INLINE constexpr friend auto operator+(const Array&, const Array&) -> Array
         {
             return {};
         }

--- a/include/llama/ArrayDimsIndexRange.hpp
+++ b/include/llama/ArrayDimsIndexRange.hpp
@@ -30,11 +30,6 @@ namespace llama
         {
         }
 
-        constexpr ArrayDimsIndexIterator(const ArrayDimsIndexIterator&) noexcept = default;
-        constexpr ArrayDimsIndexIterator(ArrayDimsIndexIterator&&) noexcept = default;
-        constexpr auto operator=(const ArrayDimsIndexIterator&) noexcept -> ArrayDimsIndexIterator& = default;
-        constexpr auto operator=(ArrayDimsIndexIterator&&) noexcept -> ArrayDimsIndexIterator& = default;
-
         LLAMA_FN_HOST_ACC_INLINE
         constexpr auto operator*() const noexcept -> value_type
         {
@@ -51,7 +46,7 @@ namespace llama
         constexpr auto operator++() noexcept -> ArrayDimsIndexIterator&
         {
             current[Dim - 1]++;
-            for(auto i = (int) Dim - 2; i >= 0; i--)
+            for(auto i = static_cast<int>(Dim) - 2; i >= 0; i--)
             {
                 if(current[i + 1] != size[i + 1])
                     return *this;
@@ -73,7 +68,7 @@ namespace llama
         constexpr auto operator--() noexcept -> ArrayDimsIndexIterator&
         {
             current[Dim - 1]--;
-            for(auto i = (int) Dim - 2; i >= 0; i--)
+            for(auto i = static_cast<int>(Dim) - 2; i >= 0; i--)
             {
                 if(current[i + 1] != std::numeric_limits<std::size_t>::max())
                     return *this;
@@ -102,7 +97,7 @@ namespace llama
         constexpr auto operator+=(difference_type n) noexcept -> ArrayDimsIndexIterator&
         {
             // add n to all lower dimensions with carry
-            for(auto i = (int) Dim - 1; i > 0 && n != 0; i--)
+            for(auto i = static_cast<int>(Dim) - 1; i > 0 && n != 0; i--)
             {
                 n += static_cast<difference_type>(current[i]);
                 const auto s = static_cast<difference_type>(size[i]);
@@ -165,7 +160,7 @@ namespace llama
 
             difference_type n = a.current[Dim - 1] - b.current[Dim - 1];
             difference_type size = a.size[Dim - 1];
-            for(auto i = (int) Dim - 2; i >= 0; i--)
+            for(auto i = static_cast<int>(Dim) - 2; i >= 0; i--)
             {
                 n += (a.current[i] - b.current[i]) * size;
                 size *= a.size[i];
@@ -225,7 +220,7 @@ namespace llama
         }
 
     private:
-        ArrayDims<Dim> size; // TODO: we only need to store Dim - 1 sizes
+        ArrayDims<Dim> size; // TODO(bgruber): we only need to store Dim - 1 sizes
         ArrayDims<Dim> current;
     };
 
@@ -239,7 +234,7 @@ namespace llama
         constexpr ArrayDimsIndexRange() noexcept = default;
 
         LLAMA_FN_HOST_ACC_INLINE
-        constexpr ArrayDimsIndexRange(ArrayDims<Dim> size) noexcept : size(size)
+        constexpr explicit ArrayDimsIndexRange(ArrayDims<Dim> size) noexcept : size(size)
         {
         }
 

--- a/include/llama/BlobAllocators.hpp
+++ b/include/llama/BlobAllocators.hpp
@@ -70,11 +70,9 @@ namespace llama::bloballoc
         inline AlignedAllocator() noexcept = default;
 
         template<typename T2>
-        inline AlignedAllocator(AlignedAllocator<T2, Alignment> const&) noexcept
+        inline explicit AlignedAllocator(AlignedAllocator<T2, Alignment> const&) noexcept
         {
         }
-
-        inline ~AlignedAllocator() noexcept = default;
 
         inline auto allocate(std::size_t n) -> T*
         {
@@ -87,7 +85,7 @@ namespace llama::bloballoc
         }
 
         template<typename T2>
-        struct rebind
+        struct rebind // NOLINT(readability-identifier-naming)
         {
             using other = AlignedAllocator<T2, Alignment>;
         };
@@ -97,7 +95,7 @@ namespace llama::bloballoc
             return !(*this == other);
         }
 
-        auto operator==(const AlignedAllocator<T, Alignment>& other) const -> bool
+        auto operator==(const AlignedAllocator<T, Alignment>&) const -> bool
         {
             return true;
         }

--- a/include/llama/Copy.hpp
+++ b/include/llama/Copy.hpp
@@ -25,13 +25,15 @@ namespace llama
                 });
         }
 
+        using memcopyFunc = void* (*)(void*, const void*, std::size_t);
+
         inline void parallel_memcpy(
             std::byte* dst,
             const std::byte* src,
             std::size_t size,
             std::size_t threadId = 0,
             std::size_t threadCount = 1,
-            decltype(std::memcpy) singleThreadMemcpy = std::memcpy)
+            memcopyFunc singleThreadMemcpy = std::memcpy)
         {
             const auto sizePerThread = size / threadCount;
             const auto sizeLastThread = sizePerThread + size % threadCount;
@@ -53,11 +55,11 @@ namespace llama
     {
         internal::assertTrivialCopyable<typename Mapping::RecordDim>();
 
-        // TODO: we do not verify if the mappings have other runtime state than the array dimensions
+        // TODO(bgruber): we do not verify if the mappings have other runtime state than the array dimensions
         if(srcView.mapping().arrayDims() != dstView.mapping().arrayDims())
             throw std::runtime_error{"Array dimensions sizes are different"};
 
-        // TODO: this is maybe not the best parallel copying strategy
+        // TODO(bgruber): this is maybe not the best parallel copying strategy
         for(std::size_t i = 0; i < Mapping::blobCount; i++)
             internal::parallel_memcpy(
                 &dstView.storageBlobs[i][0],
@@ -77,7 +79,7 @@ namespace llama
         std::size_t threadId = 0,
         std::size_t threadCount = 1)
     {
-        // TODO: think if we can remove this restriction
+        // TODO(bgruber): think if we can remove this restriction
         static_assert(
             std::is_same_v<typename SrcMapping::RecordDim, typename DstMapping::RecordDim>,
             "The source and destination record dimensions must be the same");
@@ -132,7 +134,7 @@ namespace llama
         std::size_t threadId = 0,
         std::size_t threadCount = 1)
     {
-        // TODO: think if we can remove this restriction
+        // TODO(bgruber): think if we can remove this restriction
         static_assert(
             std::is_same_v<typename SrcMapping::RecordDim, typename DstMapping::RecordDim>,
             "The source and destination record dimensions must be the same");
@@ -167,7 +169,7 @@ namespace llama
         const auto flatSize
             = std::reduce(std::begin(arrayDims), std::end(arrayDims), std::size_t{1}, std::multiplies<>{});
 
-        // TODO: implement the following by adding additional copy loops for the remaining elements
+        // TODO(bgruber): implement the following by adding additional copy loops for the remaining elements
         if(!srcIsAoSoA && flatSize % LanesDst != 0)
             throw std::runtime_error{"Source SoA mapping's total array elements must be evenly divisible by the "
                                      "destination AoSoA Lane count."};
@@ -341,7 +343,7 @@ namespace llama
             std::size_t threadId,
             std::size_t threadCount)
         {
-            constexpr auto readOpt = true; // TODO: how to choose?
+            constexpr auto readOpt = true; // TODO(bgruber): how to choose?
             aosoaCommonBlockCopy(srcView, dstView, readOpt, threadId, threadCount);
         }
     };
@@ -363,7 +365,7 @@ namespace llama
             std::size_t threadId,
             std::size_t threadCount)
         {
-            constexpr auto readOpt = true; // TODO: how to choose?
+            constexpr auto readOpt = true; // TODO(bgruber): how to choose?
             aosoaCommonBlockCopy(srcView, dstView, readOpt, threadId, threadCount);
         }
     };
@@ -385,7 +387,7 @@ namespace llama
             std::size_t threadId,
             std::size_t threadCount)
         {
-            constexpr auto readOpt = true; // TODO: how to choose?
+            constexpr auto readOpt = true; // TODO(bgruber): how to choose?
             aosoaCommonBlockCopy(srcView, dstView, readOpt, threadId, threadCount);
         }
     };

--- a/include/llama/Tuple.hpp
+++ b/include/llama/Tuple.hpp
@@ -15,16 +15,16 @@ namespace llama
     };
 
     /// Tuple class like `std::tuple` but suitable for use with offloading devices like GPUs.
-    template<typename T_FirstElement, typename... Elements>
-    struct Tuple<T_FirstElement, Elements...>
+    template<typename TFirstElement, typename... Elements>
+    struct Tuple<TFirstElement, Elements...>
     {
-        using FirstElement = T_FirstElement;
+        using FirstElement = TFirstElement;
         using RestTuple = Tuple<Elements...>;
 
         constexpr Tuple() = default;
 
         /// Construct a tuple from values of the same types as the tuple stores.
-        LLAMA_FN_HOST_ACC_INLINE constexpr Tuple(FirstElement first, Elements... rest)
+        LLAMA_FN_HOST_ACC_INLINE constexpr explicit Tuple(FirstElement first, Elements... rest)
             : first(std::move(first))
             , rest(std::move(rest)...)
         {
@@ -37,9 +37,9 @@ namespace llama
             typename... Ts,
             std::enable_if_t<
                 sizeof...(Elements) == sizeof...(Ts)
-                    && std::is_constructible_v<T_FirstElement, T> && (std::is_constructible_v<Elements, Ts> && ...),
+                    && std::is_constructible_v<TFirstElement, T> && (std::is_constructible_v<Elements, Ts> && ...),
                 int> = 0>
-        LLAMA_FN_HOST_ACC_INLINE constexpr Tuple(T&& firstArg, Ts&&... restArgs)
+        LLAMA_FN_HOST_ACC_INLINE constexpr explicit Tuple(T&& firstArg, Ts&&... restArgs)
             : first(std::forward<T>(firstArg))
             , rest(std::forward<Ts>(restArgs)...)
         {
@@ -200,7 +200,7 @@ namespace llama
 
     /// Applies a functor to every element of a tuple, creating a new tuple with the result of the element
     /// transformations. The functor needs to implement a template `operator()` to which all tuple elements are passed.
-    // TODO: replace by mp11 version in Boost 1.74.
+    // TODO(bgruber): replace by mp11 version in Boost 1.74.
     template<typename... Elements, typename Functor>
     LLAMA_FN_HOST_ACC_INLINE constexpr auto tupleTransform(const Tuple<Elements...>& tuple, const Functor& functor)
     {

--- a/include/llama/Vector.hpp
+++ b/include/llama/Vector.hpp
@@ -11,7 +11,7 @@
 
 namespace llama
 {
-    // TODO: expose blob allocator
+    // TODO(bgruber): expose blob allocator
     /// An equivalent of std::vector<T> backed by a \ref View. Elements are never value initialized though. No strong
     /// exception guarantee.
     /// WARNING: This class is experimental.
@@ -48,23 +48,14 @@ namespace llama
                 push_back(*first);
         }
 
-        LLAMA_FN_HOST_ACC_INLINE Vector(const Vector& other)
-        {
-            m_view = other.m_view; // we depend on the copy semantic of View here
-            m_size = other.m_size;
-        }
+        LLAMA_FN_HOST_ACC_INLINE Vector(const Vector& other) = default;
 
         LLAMA_FN_HOST_ACC_INLINE Vector(Vector&& other) noexcept
         {
             swap(other);
         }
 
-        LLAMA_FN_HOST_ACC_INLINE auto operator=(const Vector& other) -> Vector&
-        {
-            m_view = other.m_view; // we depend on the copy semantic of View here
-            m_size = other.m_size;
-            return *this;
-        }
+        LLAMA_FN_HOST_ACC_INLINE auto operator=(const Vector& other) -> Vector& = default;
 
         LLAMA_FN_HOST_ACC_INLINE auto operator=(Vector&& other) noexcept -> Vector&
         {
@@ -72,9 +63,11 @@ namespace llama
             return *this;
         }
 
-        // TODO: assign
+        ~Vector() = default;
 
-        LLAMA_FN_HOST_ACC_INLINE decltype(auto) at(std::size_t i)
+        // TODO(bgruber): assign
+
+        LLAMA_FN_HOST_ACC_INLINE auto at(std::size_t i) -> decltype(auto)
         {
             if(i >= m_size)
                 throw std::out_of_range{
@@ -82,7 +75,7 @@ namespace llama
             return m_view(i);
         }
 
-        LLAMA_FN_HOST_ACC_INLINE decltype(auto) at(std::size_t i) const
+        LLAMA_FN_HOST_ACC_INLINE auto at(std::size_t i) const -> decltype(auto)
         {
             if(i >= m_size)
                 throw std::out_of_range{
@@ -90,72 +83,72 @@ namespace llama
             return m_view(i);
         }
 
-        LLAMA_FN_HOST_ACC_INLINE decltype(auto) operator[](std::size_t i)
+        LLAMA_FN_HOST_ACC_INLINE auto operator[](std::size_t i) -> decltype(auto)
         {
             return m_view(i);
         }
 
-        LLAMA_FN_HOST_ACC_INLINE decltype(auto) operator[](std::size_t i) const
+        LLAMA_FN_HOST_ACC_INLINE auto operator[](std::size_t i) const -> decltype(auto)
         {
             return m_view(i);
         }
 
-        LLAMA_FN_HOST_ACC_INLINE decltype(auto) front()
+        LLAMA_FN_HOST_ACC_INLINE auto front() -> decltype(auto)
         {
             return m_view(0);
         }
 
-        LLAMA_FN_HOST_ACC_INLINE decltype(auto) front() const
+        LLAMA_FN_HOST_ACC_INLINE auto front() const -> decltype(auto)
         {
             return m_view(0);
         }
 
-        LLAMA_FN_HOST_ACC_INLINE decltype(auto) back()
+        LLAMA_FN_HOST_ACC_INLINE auto back() -> decltype(auto)
         {
             return m_view(m_size - 1);
         }
 
-        LLAMA_FN_HOST_ACC_INLINE decltype(auto) back() const
+        LLAMA_FN_HOST_ACC_INLINE auto back() const -> decltype(auto)
         {
             return m_view(m_size - 1);
         }
 
-        LLAMA_FN_HOST_ACC_INLINE decltype(auto) begin()
+        LLAMA_FN_HOST_ACC_INLINE auto begin() -> decltype(auto)
         {
             return m_view.begin();
         }
 
-        LLAMA_FN_HOST_ACC_INLINE decltype(auto) begin() const
+        LLAMA_FN_HOST_ACC_INLINE auto begin() const -> decltype(auto)
         {
             return m_view.begin();
         }
 
-        LLAMA_FN_HOST_ACC_INLINE decltype(auto) cbegin()
+        LLAMA_FN_HOST_ACC_INLINE auto cbegin() -> decltype(auto)
         {
             return std::as_const(m_view).begin();
         }
 
-        LLAMA_FN_HOST_ACC_INLINE decltype(auto) cbegin() const
+        LLAMA_FN_HOST_ACC_INLINE auto cbegin() const -> decltype(auto)
         {
             return m_view.begin();
         }
 
-        LLAMA_FN_HOST_ACC_INLINE decltype(auto) end()
+        LLAMA_FN_HOST_ACC_INLINE auto end() -> decltype(auto)
         {
             return m_view.begin() + m_size;
         }
 
-        LLAMA_FN_HOST_ACC_INLINE decltype(auto) end() const
+        LLAMA_FN_HOST_ACC_INLINE auto end() const -> decltype(auto)
         {
             return m_view.begin() + m_size;
         }
 
-        LLAMA_FN_HOST_ACC_INLINE decltype(auto) cend()
+        LLAMA_FN_HOST_ACC_INLINE auto cend() -> decltype(auto)
         {
             return std::as_const(m_view).begin() + m_size;
         }
 
-        LLAMA_FN_HOST_ACC_INLINE decltype(auto) cend() const
+        LLAMA_FN_HOST_ACC_INLINE auto cend() const -> decltype(auto)
         {
             return m_view.begin() + m_size;
         }
@@ -203,9 +196,9 @@ namespace llama
             return pos;
         }
 
-        // TODO: more insert overloads
+        // TODO(bgruber): more insert overloads
 
-        // TODO emplace
+        // TODO(bgruber): emplace
 
         LLAMA_FN_HOST_ACC_INLINE auto erase(iterator pos) -> iterator
         {
@@ -214,10 +207,10 @@ namespace llama
             return pos;
         }
 
-        // TODO: more erase overloads
+        // TODO(bgruber): more erase overloads
 
-        // TODO: T here is probably a virtual record. We could also allow any struct that is storable to the view via
-        // VirtualRecord::store().
+        // TODO(bgruber): T here is probably a virtual record. We could also allow any struct that is storable to the
+        // view via VirtualRecord::store().
         template<typename T>
         LLAMA_FN_HOST_ACC_INLINE void push_back(T&& t)
         {
@@ -227,7 +220,7 @@ namespace llama
             m_view[m_size++] = std::forward<T>(t);
         }
 
-        // TODO: emplace_back
+        // TODO(bgruber): emplace_back
 
         LLAMA_FN_HOST_ACC_INLINE void pop_back()
         {
@@ -290,7 +283,7 @@ namespace llama
             swap(m_view, newView); // depends on move semantic of View
         }
 
-        LLAMA_FN_HOST_ACC_INLINE void swap(Vector& other)
+        LLAMA_FN_HOST_ACC_INLINE void swap(Vector& other) noexcept
         {
             using std::swap;
             swap(m_view, other.m_view); // depends on move semantic of View

--- a/include/llama/macros.hpp
+++ b/include/llama/macros.hpp
@@ -93,7 +93,7 @@
 /// Forces a copy of a value. This is useful to prevent ODR usage of constants when compiling for GPU targets.
 #define LLAMA_COPY(x) decltype(x)(x)
 
-// TODO: clang 10 and 11 fail to compile this currently with the issue described here:
+// TODO(bgruber): clang 10 and 11 fail to compile this currently with the issue described here:
 // https://stackoverflow.com/questions/64300832/why-does-clang-think-gccs-subrange-does-not-satisfy-gccs-ranges-begin-functi
 // let's try again with clang 12
 // Intel LLVM compiler is also using the clang frontend

--- a/include/llama/mapping/AoS.hpp
+++ b/include/llama/mapping/AoS.hpp
@@ -15,22 +15,22 @@ namespace llama::mapping
     /// \tparam FlattenRecordDim Defines how the record dimension's fields should be flattened. See \ref
     /// FlattenRecordDimInOrder and \ref FlattenRecordDimMinimizePadding.
     template<
-        typename T_ArrayDims,
-        typename T_RecordDim,
+        typename TArrayDims,
+        typename TRecordDim,
         bool AlignAndPad = true,
-        typename T_LinearizeArrayDimsFunctor = LinearizeArrayDimsCpp,
+        typename TLinearizeArrayDimsFunctor = LinearizeArrayDimsCpp,
         template<typename> typename FlattenRecordDim = FlattenRecordDimInOrder>
     struct AoS
     {
-        using ArrayDims = T_ArrayDims;
-        using RecordDim = T_RecordDim;
-        using LinearizeArrayDimsFunctor = T_LinearizeArrayDimsFunctor;
+        using ArrayDims = TArrayDims;
+        using RecordDim = TRecordDim;
+        using LinearizeArrayDimsFunctor = TLinearizeArrayDimsFunctor;
         static constexpr std::size_t blobCount = 1;
 
         constexpr AoS() = default;
 
         LLAMA_FN_HOST_ACC_INLINE
-        constexpr AoS(ArrayDims size, RecordDim = {}) : arrayDimsSize(size)
+        constexpr explicit AoS(ArrayDims size, RecordDim = {}) : arrayDimsSize(size)
         {
         }
 
@@ -62,7 +62,7 @@ namespace llama::mapping
         }
 
     private:
-        using Flattener = FlattenRecordDim<T_RecordDim>;
+        using Flattener = FlattenRecordDim<TRecordDim>;
         ArrayDims arrayDimsSize;
     };
 

--- a/include/llama/mapping/AoSoA.hpp
+++ b/include/llama/mapping/AoSoA.hpp
@@ -29,20 +29,20 @@ namespace llama::mapping
     /// \tparam T_LinearizeArrayDimsFunctor Defines how the array dimensions should be mapped into linear numbers and
     /// how big the linear domain gets.
     template<
-        typename T_ArrayDims,
-        typename T_RecordDim,
+        typename TArrayDims,
+        typename TRecordDim,
         std::size_t Lanes,
-        typename T_LinearizeArrayDimsFunctor = LinearizeArrayDimsCpp>
+        typename TLinearizeArrayDimsFunctor = LinearizeArrayDimsCpp>
     struct AoSoA
     {
-        using ArrayDims = T_ArrayDims;
-        using RecordDim = T_RecordDim;
-        using LinearizeArrayDimsFunctor = T_LinearizeArrayDimsFunctor;
+        using ArrayDims = TArrayDims;
+        using RecordDim = TRecordDim;
+        using LinearizeArrayDimsFunctor = TLinearizeArrayDimsFunctor;
         static constexpr std::size_t blobCount = 1;
 
         constexpr AoSoA() = default;
 
-        LLAMA_FN_HOST_ACC_INLINE constexpr AoSoA(ArrayDims size, RecordDim = {}) : arrayDimsSize(size)
+        LLAMA_FN_HOST_ACC_INLINE constexpr explicit AoSoA(ArrayDims size, RecordDim = {}) : arrayDimsSize(size)
         {
         }
 

--- a/include/llama/mapping/Common.hpp
+++ b/include/llama/mapping/Common.hpp
@@ -73,7 +73,7 @@ namespace llama::mapping
             else
             {
                 std::size_t address = coord[Dim - 1];
-                for(int i = (int) Dim - 2; i >= 0; i--)
+                for(int i = static_cast<int>(Dim) - 2; i >= 0; i--)
                 {
                     address *= size[i];
                     address += coord[i];
@@ -122,7 +122,7 @@ namespace llama::mapping
         {
             std::size_t r = 1;
             while(r < n)
-                r <<= 1;
+                r <<= 1u;
             return r;
         }
 
@@ -130,7 +130,7 @@ namespace llama::mapping
         {
             e--;
             auto r = b;
-            while(e)
+            while(e != 0u)
             {
                 r *= b;
                 e--;

--- a/include/llama/mapping/Heatmap.hpp
+++ b/include/llama/mapping/Heatmap.hpp
@@ -21,7 +21,7 @@ namespace llama::mapping
         constexpr Heatmap() = default;
 
         LLAMA_FN_HOST_ACC_INLINE
-        Heatmap(Mapping mapping) : mapping(mapping)
+        explicit Heatmap(Mapping mapping) : mapping(mapping)
         {
             for(auto i = 0; i < blobCount; i++)
                 byteHits[i] = std::vector<std::atomic<CountType>>(blobSize(i));
@@ -32,6 +32,8 @@ namespace llama::mapping
 
         Heatmap(Heatmap&&) noexcept = default;
         auto operator=(Heatmap&&) noexcept -> Heatmap& = default;
+
+        ~Heatmap() = default;
 
         LLAMA_FN_HOST_ACC_INLINE constexpr auto arrayDims() const -> ArrayDims
         {

--- a/include/llama/mapping/One.hpp
+++ b/include/llama/mapping/One.hpp
@@ -15,27 +15,27 @@ namespace llama::mapping
     /// \tparam FlattenRecordDim Defines how the record dimension's fields should be flattened. See \ref
     /// FlattenRecordDimInOrder and \ref FlattenRecordDimMinimizePadding.
     template<
-        typename T_ArrayDims,
-        typename T_RecordDim,
+        typename TArrayDims,
+        typename TRecordDim,
         bool AlignAndPad = true,
         template<typename> typename FlattenRecordDim = FlattenRecordDimMinimizePadding>
     struct One
     {
-        using ArrayDims = T_ArrayDims;
-        using RecordDim = T_RecordDim;
+        using ArrayDims = TArrayDims;
+        using RecordDim = TRecordDim;
 
         static constexpr std::size_t blobCount = 1;
 
         constexpr One() = default;
 
         LLAMA_FN_HOST_ACC_INLINE
-        constexpr One(ArrayDims, RecordDim = {})
+        constexpr explicit One(ArrayDims, RecordDim = {})
         {
         }
 
         LLAMA_FN_HOST_ACC_INLINE constexpr auto arrayDims() const -> ArrayDims
         {
-            // TODO: not sure if this is the right approach, since we take any ArrayDims in the ctor
+            // TODO(bgruber): not sure if this is the right approach, since we take any ArrayDims in the ctor
             ArrayDims ad;
             for(auto i = 0; i < ArrayDims::rank; i++)
                 ad[i] = 1;
@@ -60,7 +60,7 @@ namespace llama::mapping
         }
 
     private:
-        using Flattener = FlattenRecordDim<T_RecordDim>;
+        using Flattener = FlattenRecordDim<TRecordDim>;
     };
 
     /// One mapping preserving the alignment of the field types by inserting padding.

--- a/include/llama/mapping/SoA.hpp
+++ b/include/llama/mapping/SoA.hpp
@@ -14,22 +14,22 @@ namespace llama::mapping
     /// \tparam LinearizeArrayDimsFunctor Defines how the array dimensions should be mapped into linear numbers and
     /// how big the linear domain gets.
     template<
-        typename T_ArrayDims,
-        typename T_RecordDim,
+        typename TArrayDims,
+        typename TRecordDim,
         bool SeparateBuffers = true,
-        typename T_LinearizeArrayDimsFunctor = LinearizeArrayDimsCpp>
+        typename TLinearizeArrayDimsFunctor = LinearizeArrayDimsCpp>
     struct SoA
     {
-        using ArrayDims = T_ArrayDims;
-        using RecordDim = T_RecordDim;
-        using LinearizeArrayDimsFunctor = T_LinearizeArrayDimsFunctor;
+        using ArrayDims = TArrayDims;
+        using RecordDim = TRecordDim;
+        using LinearizeArrayDimsFunctor = TLinearizeArrayDimsFunctor;
         static constexpr std::size_t blobCount
             = SeparateBuffers ? boost::mp11::mp_size<FlatRecordDim<RecordDim>>::value : 1;
 
         constexpr SoA() = default;
 
         LLAMA_FN_HOST_ACC_INLINE
-        constexpr SoA(ArrayDims size, RecordDim = {}) : arrayDimsSize(size)
+        constexpr explicit SoA(ArrayDims size, RecordDim = {}) : arrayDimsSize(size)
         {
         }
 

--- a/include/llama/mapping/Split.hpp
+++ b/include/llama/mapping/Split.hpp
@@ -54,8 +54,8 @@ namespace llama::mapping
     /// \tparam MappingTemplate2 The mapping used for the not selected part of the record dimension.
     /// \tparam SeparateBlobs If true, both pieces of the record dimension are mapped to separate blobs.
     template<
-        typename T_ArrayDims,
-        typename T_RecordDim,
+        typename TArrayDims,
+        typename TRecordDim,
         typename RecordCoordForMapping1,
         template<typename...>
         typename MappingTemplate1,
@@ -64,8 +64,8 @@ namespace llama::mapping
         bool SeparateBlobs = false>
     struct Split
     {
-        using ArrayDims = T_ArrayDims;
-        using RecordDim = T_RecordDim;
+        using ArrayDims = TArrayDims;
+        using RecordDim = TRecordDim;
 
         using RecordDimPartitions = decltype(internal::partitionRecordDim(RecordDim{}, RecordCoordForMapping1{}));
         using RecordDim1 = boost::mp11::mp_first<RecordDimPartitions>;
@@ -81,7 +81,7 @@ namespace llama::mapping
         constexpr Split() = default;
 
         LLAMA_FN_HOST_ACC_INLINE
-        constexpr Split(ArrayDims size) : mapping1(size), mapping2(size)
+        constexpr explicit Split(ArrayDims size) : mapping1(size), mapping2(size)
         {
         }
 
@@ -96,8 +96,7 @@ namespace llama::mapping
             {
                 if(i < Mapping1::blobCount)
                     return mapping1.blobSize(i);
-                else
-                    return mapping2.blobSize(i - Mapping1::blobCount);
+                return mapping2.blobSize(i - Mapping1::blobCount);
             }
             else
                 return mapping1.blobSize(0) + mapping2.blobSize(0);

--- a/include/llama/mapping/Trace.hpp
+++ b/include/llama/mapping/Trace.hpp
@@ -43,7 +43,7 @@ namespace llama::mapping
         constexpr Trace() = default;
 
         LLAMA_FN_HOST_ACC_INLINE
-        Trace(Mapping mapping) : mapping(mapping)
+        explicit Trace(Mapping mapping) : mapping(mapping)
         {
             forEachLeaf<RecordDim>([&](auto coord) { fieldHits[internal::coordName<RecordDim>(coord)] = 0; });
         }

--- a/include/llama/mapping/tree/Functors.hpp
+++ b/include/llama/mapping/tree/Functors.hpp
@@ -47,7 +47,7 @@ namespace llama::mapping::tree::functor
         }
 
         template<typename Tree, typename ResultCoord>
-        LLAMA_FN_HOST_ACC_INLINE auto resultCoordToBasicCoord(const ResultCoord& resultCoord, const Tree& tree) const
+        LLAMA_FN_HOST_ACC_INLINE auto resultCoordToBasicCoord(const ResultCoord& resultCoord, const Tree& /*tree*/) const
             -> ResultCoord
         {
             return resultCoord;
@@ -126,7 +126,7 @@ namespace llama::mapping::tree::functor
 
         template<typename TreeCoord, typename Identifier, typename Type, typename CountType>
         LLAMA_FN_HOST_ACC_INLINE auto changeNodeRuntime(
-            const Leaf<Identifier, Type, CountType>& tree,
+            const Leaf<Identifier, Type, CountType>& /*tree*/,
             std::size_t newValue)
         {
             return Leaf<Identifier, Type, std::size_t>{newValue};
@@ -171,7 +171,7 @@ namespace llama::mapping::tree::functor
         template<typename TreeCoord, typename Identifier, typename Type, typename CountType>
         LLAMA_FN_HOST_ACC_INLINE auto changeNodeChildsRuntime(
             const Leaf<Identifier, Type, CountType>& tree,
-            std::size_t newValue)
+            std::size_t /*newValue*/)
         {
             return tree;
         }

--- a/include/llama/mapping/tree/Mapping.hpp
+++ b/include/llama/mapping/tree/Mapping.hpp
@@ -88,15 +88,15 @@ namespace llama::mapping::tree
             }
 
             template<typename TreeCoord>
-            LLAMA_FN_HOST_ACC_INLINE auto basicCoordToResultCoord(TreeCoord const& basicCoord, Tree const& tree) const
-                -> TreeCoord
+            LLAMA_FN_HOST_ACC_INLINE auto basicCoordToResultCoord(TreeCoord const& basicCoord, Tree const& /*tree*/)
+                const -> TreeCoord
             {
                 return basicCoord;
             }
 
             template<typename TreeCoord>
-            LLAMA_FN_HOST_ACC_INLINE auto resultCoordToBasicCoord(TreeCoord const& resultCoord, Tree const& tree) const
-                -> TreeCoord
+            LLAMA_FN_HOST_ACC_INLINE auto resultCoordToBasicCoord(TreeCoord const& resultCoord, Tree const& /*tree*/)
+                const -> TreeCoord
             {
                 return resultCoord;
             }
@@ -111,7 +111,7 @@ namespace llama::mapping::tree
         template<typename... Children, std::size_t... Is, typename Count>
         LLAMA_FN_HOST_ACC_INLINE auto getChildrenBlobSize(
             const Tuple<Children...>& childs,
-            std::index_sequence<Is...> ii,
+            std::index_sequence<Is...> /*ii*/,
             const Count& count) -> std::size_t
         {
             return count * (getTreeBlobSize(get<Is>(childs)) + ...);
@@ -167,13 +167,13 @@ namespace llama::mapping::tree
     /// dimension are represented by a compile time tree data structure. This tree is mapped into memory by means of a
     /// breadth-first tree traversal. By specifying additional tree operations, the tree can be modified at compile
     /// time before being mapped to memory.
-    template<typename T_ArrayDims, typename T_RecordDim, typename TreeOperationList>
+    template<typename TArrayDims, typename TRecordDim, typename TreeOperationList>
     struct Mapping
     {
-        using ArrayDims = T_ArrayDims;
-        using RecordDim = T_RecordDim;
+        using ArrayDims = TArrayDims;
+        using RecordDim = TRecordDim;
         using BasicTree = TreeFromDimensions<ArrayDims, RecordDim>;
-        // TODO, support more than one blob
+        // TODO(bgruber): , support more than one blob
         static constexpr std::size_t blobCount = 1;
 
         using MergedFunctors = internal::MergeFunctors<BasicTree, TreeOperationList>;

--- a/include/llama/mapping/tree/TreeFromDimensions.hpp
+++ b/include/llama/mapping/tree/TreeFromDimensions.hpp
@@ -17,20 +17,20 @@ namespace llama::mapping::tree
     template<>
     inline constexpr auto one<boost::mp11::mp_size_t<1>> = boost::mp11::mp_size_t<1>{};
 
-    template<typename T_Identifier, typename T_Type, typename CountType = std::size_t>
+    template<typename TIdentifier, typename TType, typename CountType = std::size_t>
     struct Leaf
     {
-        using Identifier = T_Identifier;
-        using Type = T_Type;
+        using Identifier = TIdentifier;
+        using Type = TType;
 
         const CountType count = one<CountType>;
     };
 
-    template<typename T_Identifier, typename T_ChildrenTuple, typename CountType = std::size_t>
+    template<typename TIdentifier, typename TChildrenTuple, typename CountType = std::size_t>
     struct Node
     {
-        using Identifier = T_Identifier;
-        using ChildrenTuple = T_ChildrenTuple;
+        using Identifier = TIdentifier;
+        using ChildrenTuple = TChildrenTuple;
 
         const CountType count = one<CountType>;
         const ChildrenTuple childs = {};

--- a/tests/common.hpp
+++ b/tests/common.hpp
@@ -61,11 +61,11 @@ using ParticleUnaligned = llama::Record<
 >;
 // clang-format on
 
-using llama::mapping::tree::internal::replace_all;
-
 template<typename T>
-std::string prettyPrintType(const T& t = {})
+auto prettyPrintType(const T& t = {}) -> std::string
 {
+    using llama::mapping::tree::internal::replace_all;
+
     auto raw = boost::core::demangle(typeid(t).name());
 #ifdef _MSC_VER
     // remove clutter in MSVC

--- a/tests/computedprop.cpp
+++ b/tests/computedprop.cpp
@@ -17,6 +17,8 @@ namespace
     {
         using Base = llama::mapping::PackedAoS<ArrayDims, RecordDim>;
 
+        using Base::Base;
+
         template<std::size_t... RecordCoords>
         static constexpr auto isComputed(llama::RecordCoord<RecordCoords...>)
         {
@@ -109,11 +111,11 @@ TEST_CASE("computedprop")
 namespace
 {
     // Maps accesses to the product of the ArrayDims coord.
-    template<typename T_ArrayDims, typename T_RecordDim>
+    template<typename TArrayDims, typename TRecordDim>
     struct ComputedMapping
     {
-        using ArrayDims = T_ArrayDims;
-        using RecordDim = T_RecordDim;
+        using ArrayDims = TArrayDims;
+        using RecordDim = TRecordDim;
         static constexpr std::size_t blobCount = 0;
 
         constexpr ComputedMapping() = default;
@@ -153,13 +155,13 @@ TEST_CASE("fully_computed_mapping")
 namespace
 {
     template<
-        typename T_ArrayDims,
-        typename T_RecordDim,
+        typename TArrayDims,
+        typename TRecordDim,
         typename LinearizeArrayDimsFunctor = llama::mapping::LinearizeArrayDimsCpp>
     struct CompressedBoolMapping
     {
-        using ArrayDims = T_ArrayDims;
-        using RecordDim = T_RecordDim;
+        using ArrayDims = TArrayDims;
+        using RecordDim = TRecordDim;
         static constexpr std::size_t blobCount = boost::mp11::mp_size<llama::FlatRecordDim<RecordDim>>::value;
 
         constexpr CompressedBoolMapping() = default;

--- a/tests/core.cpp
+++ b/tests/core.cpp
@@ -158,9 +158,6 @@ TEST_CASE("flatFieldCountBefore")
     STATIC_REQUIRE(llama::internal::flatFieldCountBefore<4, Particle> == 11);
 }
 
-template<int i>
-struct S;
-
 TEST_CASE("alignment")
 {
     using RD = llama::Record<

--- a/tests/iterator.cpp
+++ b/tests/iterator.cpp
@@ -218,7 +218,7 @@ TEST_CASE("iterator.different_record_dim")
     }
 }
 
-// TODO: clang 10 and 11 fail to compile this currently with the issue described here:
+// TODO(bgruber): clang 10 and 11 fail to compile this currently with the issue described here:
 // https://stackoverflow.com/questions/64300832/why-does-clang-think-gccs-subrange-does-not-satisfy-gccs-ranges-begin-functi
 // let's try again with clang 12
 // Intel LLVM compiler is also using the clang frontend

--- a/tests/proofs.cpp
+++ b/tests/proofs.cpp
@@ -51,11 +51,11 @@ TEST_CASE("mapsNonOverlappingly.AlignedAoS")
 
 namespace
 {
-    template<typename T_ArrayDims, typename T_RecordDim>
+    template<typename TArrayDims, typename TRecordDim>
     struct MapEverythingToZero
     {
-        using ArrayDims = T_ArrayDims;
-        using RecordDim = T_RecordDim;
+        using ArrayDims = TArrayDims;
+        using RecordDim = TRecordDim;
         static constexpr std::size_t blobCount = 1;
 
         LLAMA_FN_HOST_ACC_INLINE
@@ -102,11 +102,11 @@ namespace
 {
     // maps each element of the record dimension into a separate blobs. Each blob stores Modulus elements. If the array
     // dimensions are larger than Modulus, elements are overwritten.
-    template<typename T_ArrayDims, typename T_RecordDim, std::size_t Modulus>
+    template<typename TArrayDims, typename TRecordDim, std::size_t Modulus>
     struct ModulusMapping
     {
-        using ArrayDims = T_ArrayDims;
-        using RecordDim = T_RecordDim;
+        using ArrayDims = TArrayDims;
+        using RecordDim = TRecordDim;
         static constexpr std::size_t blobCount = boost::mp11::mp_size<llama::FlatRecordDim<RecordDim>>::value;
 
         LLAMA_FN_HOST_ACC_INLINE

--- a/tests/view.cpp
+++ b/tests/view.cpp
@@ -19,13 +19,13 @@ TEST_CASE("view.default-ctor")
     using ArrayDims = llama::ArrayDims<2>;
     constexpr ArrayDims viewSize{16, 16};
 
-    [[maybe_unused]] llama::View<llama::mapping::AlignedAoS<ArrayDims, RecordDim>, std::byte*> view1;
-    [[maybe_unused]] llama::View<llama::mapping::PackedAoS<ArrayDims, RecordDim>, std::byte*> view2;
-    [[maybe_unused]] llama::View<llama::mapping::SingleBlobSoA<ArrayDims, RecordDim>, std::byte*> view3;
-    [[maybe_unused]] llama::View<llama::mapping::MultiBlobSoA<ArrayDims, RecordDim>, std::byte*> view4;
-    [[maybe_unused]] llama::View<llama::mapping::One<ArrayDims, RecordDim>, std::byte*> view5;
+    [[maybe_unused]] llama::View<llama::mapping::AlignedAoS<ArrayDims, RecordDim>, std::byte*> view1{};
+    [[maybe_unused]] llama::View<llama::mapping::PackedAoS<ArrayDims, RecordDim>, std::byte*> view2{};
+    [[maybe_unused]] llama::View<llama::mapping::SingleBlobSoA<ArrayDims, RecordDim>, std::byte*> view3{};
+    [[maybe_unused]] llama::View<llama::mapping::MultiBlobSoA<ArrayDims, RecordDim>, std::byte*> view4{};
+    [[maybe_unused]] llama::View<llama::mapping::One<ArrayDims, RecordDim>, std::byte*> view5{};
     [[maybe_unused]] llama::View<llama::mapping::tree::Mapping<ArrayDims, RecordDim, llama::Tuple<>>, std::byte*>
-        view6;
+        view6{};
 }
 
 TEST_CASE("view.move")


### PR DESCRIPTION
This PR tests the clang-tidy file from https://github.com/ComputationalRadiationPhysics/contributing/blob/master/formatting-tools/.clang-tidy including PR https://github.com/ComputationalRadiationPhysics/contributing/pull/51. It just includes the result of running `run-clang-tidy -fix`, with no additional manual changes.

It includes the following changes to the current state of the CRP `.clang-tidy` file:
* do not prefix public members with `_m`
* ignore prefixing template parameters with 1 or 2 letters