### PR TITLE
Partially unify record dimension in unit tests

### DIFF
--- a/include/llama/Core.hpp
+++ b/include/llama/Core.hpp
@@ -384,29 +384,30 @@ namespace llama
 
     /// The total number of fields in the recursively expanded record dimension.
     template <typename RecordDim>
-    inline constexpr std::size_t fieldCount = 1;
+    inline constexpr std::size_t flatFieldCount = 1;
 
     template <typename... Children>
-    inline constexpr std::size_t fieldCount<Record<Children...>> = (fieldCount<GetFieldType<Children>> + ... + 0);
+    inline constexpr std::size_t flatFieldCount<
+        Record<Children...>> = (flatFieldCount<GetFieldType<Children>> + ... + 0);
 
     template <typename Child, std::size_t N>
-    inline constexpr std::size_t fieldCount<Child[N]> = fieldCount<Child>* N;
+    inline constexpr std::size_t flatFieldCount<Child[N]> = flatFieldCount<Child>* N;
 
     namespace internal
     {
         template <std::size_t I, typename RecordDim>
-        inline constexpr std::size_t fieldCountBefore = 0;
+        inline constexpr std::size_t flatFieldCountBefore = 0;
 
         template <typename... Children>
-        inline constexpr std::size_t fieldCountBefore<0, Record<Children...>> = 0;
+        inline constexpr std::size_t flatFieldCountBefore<0, Record<Children...>> = 0;
 
         // recursive formulation to benefit from template instantiation memoization
         // this massively improves compilation time when this template is instantiated with a lot of different I
         template <std::size_t I, typename... Children>
-        inline constexpr std::size_t fieldCountBefore<
+        inline constexpr std::size_t flatFieldCountBefore<
             I,
             Record<
-                Children...>> = fieldCountBefore<I - 1, Record<Children...>> + fieldCount<GetFieldType<boost::mp11::mp_at_c<Record<Children...>, I - 1>>>;
+                Children...>> = flatFieldCountBefore<I - 1, Record<Children...>> + flatFieldCount<GetFieldType<boost::mp11::mp_at_c<Record<Children...>, I - 1>>>;
     } // namespace internal
 
     /// The equivalent zero based index into a flat record dimension (\ref FlatRecordDim) of the given hierarchical
@@ -423,13 +424,13 @@ namespace llama
         RecordCoord<
             I,
             Is...>> = internal::
-                          fieldCountBefore<
+                          flatFieldCountBefore<
                               I,
                               Record<
                                   Children...>> + flatRecordCoord<GetFieldType<boost::mp11::mp_at_c<Record<Children...>, I>>, RecordCoord<Is...>>;
 
     template <typename Child, std::size_t N, std::size_t I, std::size_t... Is>
-    inline constexpr std::size_t flatRecordCoord<Child[N], RecordCoord<I, Is...>> = fieldCount<Child>* I
+    inline constexpr std::size_t flatRecordCoord<Child[N], RecordCoord<I, Is...>> = flatFieldCount<Child>* I
         + flatRecordCoord<Child, RecordCoord<Is...>>;
 
     namespace internal

--- a/include/llama/Core.hpp
+++ b/include/llama/Core.hpp
@@ -190,7 +190,7 @@ namespace llama
             static constexpr auto tagIndex = boost::mp11::mp_find_if<boost::mp11::mp_list<Fields...>, HasTag>::value;
             static_assert(
                 tagIndex < sizeof...(Fields),
-                "FirstTag was not found inside this DatumStruct. Does your datum domain contain the tag you access "
+                "FirstTag was not found inside this Record. Does your record dimension contain the tag you access "
                 "with?");
 
             using ChildType = GetFieldType<boost::mp11::mp_at_c<Record<Fields...>, tagIndex>>;

--- a/tests/arraydomain.cpp
+++ b/tests/arraydomain.cpp
@@ -3,24 +3,6 @@
 #include <catch2/catch.hpp>
 #include <llama/llama.hpp>
 
-// clang-format off
-namespace tag
-{
-    struct Pos {};
-    struct X {};
-    struct Y {};
-    struct Z {};
-} // namespace tag
-
-using Name = llama::Record<
-    llama::Field<tag::Pos, llama::Record<
-        llama::Field<tag::X, float>,
-        llama::Field<tag::Y, float>,
-        llama::Field<tag::Z, float>
-    >>
->;
-// clang-format on
-
 TEST_CASE("ArrayDims.CTAD")
 {
     llama::ArrayDims ad0{};
@@ -39,12 +21,12 @@ TEST_CASE("ArrayDims.dim0")
     using ArrayDims = llama::ArrayDims<0>;
     ArrayDims arrayDims{};
 
-    using Mapping = llama::mapping::SoA<ArrayDims, Name>;
+    using Mapping = llama::mapping::SoA<ArrayDims, Particle>;
     Mapping mapping{arrayDims};
     auto view = allocView(mapping);
 
-    float& x1 = view(ArrayDims{})(tag::Pos{}, tag::X{});
-    float& x2 = view()(tag::Pos{}, tag::X{});
+    double& x1 = view(ArrayDims{})(tag::Pos{}, tag::X{});
+    double& x2 = view()(tag::Pos{}, tag::X{});
 }
 
 TEST_CASE("ArrayDims.dim1")
@@ -52,11 +34,11 @@ TEST_CASE("ArrayDims.dim1")
     using ArrayDims = llama::ArrayDims<1>;
     ArrayDims arrayDims{16};
 
-    using Mapping = llama::mapping::SoA<ArrayDims, Name>;
+    using Mapping = llama::mapping::SoA<ArrayDims, Particle>;
     Mapping mapping{arrayDims};
     auto view = allocView(mapping);
 
-    float& x = view(ArrayDims{0})(tag::Pos{}, tag::X{});
+    double& x = view(ArrayDims{0})(tag::Pos{}, tag::X{});
     x = 0;
 }
 
@@ -65,11 +47,11 @@ TEST_CASE("ArrayDims.dim2")
     using ArrayDims = llama::ArrayDims<2>;
     ArrayDims arrayDims{16, 16};
 
-    using Mapping = llama::mapping::SoA<ArrayDims, Name>;
+    using Mapping = llama::mapping::SoA<ArrayDims, Particle>;
     Mapping mapping{arrayDims};
     auto view = allocView(mapping);
 
-    float& x = view(ArrayDims{0, 0})(tag::Pos{}, tag::X{});
+    double& x = view(ArrayDims{0, 0})(tag::Pos{}, tag::X{});
     x = 0;
 }
 
@@ -78,11 +60,11 @@ TEST_CASE("ArrayDims.dim3")
     using ArrayDims = llama::ArrayDims<3>;
     ArrayDims arrayDims{16, 16, 16};
 
-    using Mapping = llama::mapping::SoA<ArrayDims, Name>;
+    using Mapping = llama::mapping::SoA<ArrayDims, Particle>;
     Mapping mapping{arrayDims};
     auto view = allocView(mapping);
 
-    float& x = view(ArrayDims{0, 0, 0})(tag::Pos{}, tag::X{});
+    double& x = view(ArrayDims{0, 0, 0})(tag::Pos{}, tag::X{});
     x = 0;
 }
 
@@ -91,11 +73,11 @@ TEST_CASE("ArrayDims.dim10")
     using ArrayDims = llama::ArrayDims<10>;
     ArrayDims arrayDims{2, 2, 2, 2, 2, 2, 2, 2, 2, 2};
 
-    using Mapping = llama::mapping::SoA<ArrayDims, Name>;
+    using Mapping = llama::mapping::SoA<ArrayDims, Particle>;
     Mapping mapping{arrayDims};
     auto view = allocView(mapping);
 
-    float& x = view(ArrayDims{0, 0, 0, 0, 0, 0, 0, 0, 0, 0})(tag::Pos{}, tag::X{});
+    double& x = view(ArrayDims{0, 0, 0, 0, 0, 0, 0, 0, 0, 0})(tag::Pos{}, tag::X{});
     x = 0;
 }
 

--- a/tests/common.h
+++ b/tests/common.h
@@ -11,7 +11,7 @@
 using llama::mapping::tree::internal::replace_all;
 
 template <typename T>
-std::string prettyPrintType(const T& t)
+std::string prettyPrintType(const T& t = {})
 {
     auto raw = boost::core::demangle(typeid(t).name());
 #ifdef _MSC_VER

--- a/tests/common.h
+++ b/tests/common.h
@@ -8,6 +8,58 @@
 #include <string>
 #include <typeinfo>
 
+// clang-format off
+namespace tag
+{
+    struct Pos {};
+    struct Vel {};
+    struct X {};
+    struct Y {};
+    struct Z {};
+    struct Mass {};
+    struct Flags {};
+    struct Id {};
+    struct A {};
+    struct B {};
+    struct C {};
+    struct Normal {};
+    struct Part1 {};
+    struct Part2 {};
+} // namespace tag
+
+using Vec2F = llama::Record<
+    llama::Field<tag::X, float>,
+    llama::Field<tag::Y, float>
+>;
+using Vec3D = llama::Record<
+    llama::Field<tag::X, double>,
+    llama::Field<tag::Y, double>,
+    llama::Field<tag::Z, double>
+>;
+using Vec3I = llama::Record<
+    llama::Field<tag::X, int>,
+    llama::Field<tag::Y, int>,
+    llama::Field<tag::Z, int>
+>;
+using Particle = llama::Record<
+    llama::Field<tag::Pos, Vec3D>,
+    llama::Field<tag::Mass, float>,
+    llama::Field<tag::Vel, Vec3D>,
+    llama::Field<tag::Flags, bool[4]>
+>;
+using ParticleHeatmap = llama::Record<
+    llama::Field<tag::Pos, Vec3D>,
+    llama::Field<tag::Vel, Vec3D>,
+    llama::Field<tag::Mass, float>
+>;
+using ParticleUnaligned = llama::Record<
+    llama::Field<tag::Id, std::uint16_t>,
+    llama::Field<tag::Pos, Vec2F>,
+    llama::Field<tag::Mass, double>,
+    llama::Field<tag::Flags, bool[3]>
+>;
+// clang-format on
+
 using llama::mapping::tree::internal::replace_all;
 
 template <typename T>

--- a/tests/computedprop.cpp
+++ b/tests/computedprop.cpp
@@ -4,32 +4,14 @@
 #include <llama/llama.hpp>
 #include <numeric>
 
-// clang-format off
-namespace tag {
-    struct X {};
-    struct Y {};
-    struct Z {};
-    struct A {};
-    struct B {};
-    struct C {};
-    struct Normal {};
-}
-
-using Vec3 = llama::Record<
-    llama::Field<tag::X, double>,
-    llama::Field<tag::Y, double>,
-    llama::Field<tag::Z, double>
->;
-using Triangle = llama::Record<
-    llama::Field<tag::A, Vec3>,
-    llama::Field<tag::B, Vec3>,
-    llama::Field<tag::C, Vec3>,
-    llama::Field<tag::Normal, Vec3>
->;
-// clang-format on
-
 namespace
 {
+    using Triangle = llama::Record<
+        llama::Field<tag::A, Vec3D>,
+        llama::Field<tag::B, Vec3D>,
+        llama::Field<tag::C, Vec3D>,
+        llama::Field<tag::Normal, Vec3D>>;
+
     template <typename ArrayDims, typename RecordDim>
     struct AoSWithComputedNormal : llama::mapping::PackedAoS<ArrayDims, RecordDim>
     {

--- a/tests/core.cpp
+++ b/tests/core.cpp
@@ -144,22 +144,22 @@ TEST_CASE("offsetOf.Align")
     STATIC_REQUIRE(llama::offsetOf<Particle, llama::RecordCoord<4, 3>, true> == 51);
 }
 
-TEST_CASE("fieldCount")
+TEST_CASE("flatFieldCount")
 {
-    STATIC_REQUIRE(llama::fieldCount<int> == 1);
-    STATIC_REQUIRE(llama::fieldCount<XYZ> == 3);
-    STATIC_REQUIRE(llama::fieldCount<Particle> == 11);
-    STATIC_REQUIRE(llama::fieldCount<Other> == 2);
+    STATIC_REQUIRE(llama::flatFieldCount<int> == 1);
+    STATIC_REQUIRE(llama::flatFieldCount<XYZ> == 3);
+    STATIC_REQUIRE(llama::flatFieldCount<Particle> == 11);
+    STATIC_REQUIRE(llama::flatFieldCount<Other> == 2);
 }
 
-TEST_CASE("fieldCountBefore")
+TEST_CASE("flatFieldCountBefore")
 {
-    STATIC_REQUIRE(llama::internal::fieldCountBefore<0, Particle> == 0);
-    STATIC_REQUIRE(llama::internal::fieldCountBefore<1, Particle> == 3);
-    STATIC_REQUIRE(llama::internal::fieldCountBefore<2, Particle> == 4);
-    STATIC_REQUIRE(llama::internal::fieldCountBefore<3, Particle> == 5);
-    STATIC_REQUIRE(llama::internal::fieldCountBefore<4, Particle> == 7);
-    STATIC_REQUIRE(llama::internal::fieldCountBefore<5, Particle> == 11);
+    STATIC_REQUIRE(llama::internal::flatFieldCountBefore<0, Particle> == 0);
+    STATIC_REQUIRE(llama::internal::flatFieldCountBefore<1, Particle> == 3);
+    STATIC_REQUIRE(llama::internal::flatFieldCountBefore<2, Particle> == 4);
+    STATIC_REQUIRE(llama::internal::flatFieldCountBefore<3, Particle> == 5);
+    STATIC_REQUIRE(llama::internal::flatFieldCountBefore<4, Particle> == 7);
+    STATIC_REQUIRE(llama::internal::flatFieldCountBefore<5, Particle> == 11);
 }
 
 template <int i>

--- a/tests/core.cpp
+++ b/tests/core.cpp
@@ -3,45 +3,9 @@
 #include <catch2/catch.hpp>
 #include <llama/llama.hpp>
 
-// clang-format off
-namespace tag
-{
-    struct Pos {};
-    struct Vel {};
-    struct X {};
-    struct Y {};
-    struct Z {};
-    struct Flags {};
-    struct Weight {};
-} // namespace tag
-
-using XYZ = llama::Record<
-    llama::Field<tag::X, double>,
-    llama::Field<tag::Y, double>,
-    llama::Field<tag::Z, double>
->;
-using Particle = llama::Record<
-    llama::Field<tag::Pos, XYZ>,
-    llama::Field<tag::Weight, float>,
-    llama::Field<llama::NoName, int>,
-    llama::Field<tag::Vel,llama::Record<
-        llama::Field<tag::Z, double>,
-        llama::Field<tag::X, double>
-    >>,
-    llama::Field<tag::Flags, bool[4]>
->;
-
-using Other = llama::Record<
-    llama::Field<tag::Pos, llama::Record<
-        llama::Field<tag::Z, float>,
-        llama::Field<tag::Y, float>
-    >>
->;
-// clang-format on
-
 TEST_CASE("prettyPrintType")
 {
-    auto str = prettyPrintType(Particle());
+    auto str = prettyPrintType<Particle>();
 #ifdef _WIN32
     replace_all(str, "__int64", "long");
 #endif
@@ -64,22 +28,22 @@ TEST_CASE("prettyPrintType")
         >
     >,
     llama::Field<
-        tag::Weight,
+        tag::Mass,
         float
-    >,
-    llama::Field<
-        llama::NoName,
-        int
     >,
     llama::Field<
         tag::Vel,
         llama::Record<
             llama::Field<
-                tag::Z,
+                tag::X,
                 double
             >,
             llama::Field<
-                tag::X,
+                tag::Y,
+                double
+            >,
+            llama::Field<
+                tag::Z,
                 double
             >
         >
@@ -95,15 +59,17 @@ TEST_CASE("prettyPrintType")
 TEST_CASE("sizeOf")
 {
     STATIC_REQUIRE(llama::sizeOf<float> == 4);
-    STATIC_REQUIRE(llama::sizeOf<XYZ> == 24);
-    STATIC_REQUIRE(llama::sizeOf<Particle> == 52);
+    STATIC_REQUIRE(llama::sizeOf<Vec3D> == 24);
+    STATIC_REQUIRE(llama::sizeOf<Vec2F> == 8);
+    STATIC_REQUIRE(llama::sizeOf<Particle> == 56);
 }
 
 TEST_CASE("sizeOf.Align")
 {
     STATIC_REQUIRE(llama::sizeOf<float, true> == 4);
-    STATIC_REQUIRE(llama::sizeOf<XYZ, true> == 24);
-    STATIC_REQUIRE(llama::sizeOf<Particle, true> == 56);
+    STATIC_REQUIRE(llama::sizeOf<Vec3D, true> == 24);
+    STATIC_REQUIRE(llama::sizeOf<Vec2F, true> == 8);
+    STATIC_REQUIRE(llama::sizeOf<Particle, true> == 64);
 }
 
 TEST_CASE("offsetOf")
@@ -115,14 +81,14 @@ TEST_CASE("offsetOf")
     STATIC_REQUIRE(llama::offsetOf<Particle, llama::RecordCoord<0, 2>> == 16);
     STATIC_REQUIRE(llama::offsetOf<Particle, llama::RecordCoord<1>> == 24);
     STATIC_REQUIRE(llama::offsetOf<Particle, llama::RecordCoord<2>> == 28);
-    STATIC_REQUIRE(llama::offsetOf<Particle, llama::RecordCoord<3>> == 32);
-    STATIC_REQUIRE(llama::offsetOf<Particle, llama::RecordCoord<3, 0>> == 32);
-    STATIC_REQUIRE(llama::offsetOf<Particle, llama::RecordCoord<3, 1>> == 40);
-    STATIC_REQUIRE(llama::offsetOf<Particle, llama::RecordCoord<4>> == 48);
-    STATIC_REQUIRE(llama::offsetOf<Particle, llama::RecordCoord<4, 0>> == 48);
-    STATIC_REQUIRE(llama::offsetOf<Particle, llama::RecordCoord<4, 1>> == 49);
-    STATIC_REQUIRE(llama::offsetOf<Particle, llama::RecordCoord<4, 2>> == 50);
-    STATIC_REQUIRE(llama::offsetOf<Particle, llama::RecordCoord<4, 3>> == 51);
+    STATIC_REQUIRE(llama::offsetOf<Particle, llama::RecordCoord<2, 0>> == 28);
+    STATIC_REQUIRE(llama::offsetOf<Particle, llama::RecordCoord<2, 1>> == 36);
+    STATIC_REQUIRE(llama::offsetOf<Particle, llama::RecordCoord<2, 2>> == 44);
+    STATIC_REQUIRE(llama::offsetOf<Particle, llama::RecordCoord<3>> == 52);
+    STATIC_REQUIRE(llama::offsetOf<Particle, llama::RecordCoord<3, 0>> == 52);
+    STATIC_REQUIRE(llama::offsetOf<Particle, llama::RecordCoord<3, 1>> == 53);
+    STATIC_REQUIRE(llama::offsetOf<Particle, llama::RecordCoord<3, 2>> == 54);
+    STATIC_REQUIRE(llama::offsetOf<Particle, llama::RecordCoord<3, 3>> == 55);
 }
 
 TEST_CASE("offsetOf.Align")
@@ -133,21 +99,33 @@ TEST_CASE("offsetOf.Align")
     STATIC_REQUIRE(llama::offsetOf<Particle, llama::RecordCoord<0, 1>, true> == 8);
     STATIC_REQUIRE(llama::offsetOf<Particle, llama::RecordCoord<0, 2>, true> == 16);
     STATIC_REQUIRE(llama::offsetOf<Particle, llama::RecordCoord<1>, true> == 24);
-    STATIC_REQUIRE(llama::offsetOf<Particle, llama::RecordCoord<2>, true> == 28);
-    STATIC_REQUIRE(llama::offsetOf<Particle, llama::RecordCoord<3>, true> == 32);
-    STATIC_REQUIRE(llama::offsetOf<Particle, llama::RecordCoord<3, 0>, true> == 32);
-    STATIC_REQUIRE(llama::offsetOf<Particle, llama::RecordCoord<3, 1>, true> == 40);
-    STATIC_REQUIRE(llama::offsetOf<Particle, llama::RecordCoord<4>, true> == 48);
-    STATIC_REQUIRE(llama::offsetOf<Particle, llama::RecordCoord<4, 0>, true> == 48);
-    STATIC_REQUIRE(llama::offsetOf<Particle, llama::RecordCoord<4, 1>, true> == 49);
-    STATIC_REQUIRE(llama::offsetOf<Particle, llama::RecordCoord<4, 2>, true> == 50);
-    STATIC_REQUIRE(llama::offsetOf<Particle, llama::RecordCoord<4, 3>, true> == 51);
+    STATIC_REQUIRE(llama::offsetOf<Particle, llama::RecordCoord<2>, true> == 32);
+    STATIC_REQUIRE(llama::offsetOf<Particle, llama::RecordCoord<2, 0>, true> == 32);
+    STATIC_REQUIRE(llama::offsetOf<Particle, llama::RecordCoord<2, 1>, true> == 40);
+    STATIC_REQUIRE(llama::offsetOf<Particle, llama::RecordCoord<2, 2>, true> == 48);
+    STATIC_REQUIRE(llama::offsetOf<Particle, llama::RecordCoord<3>, true> == 56);
+    STATIC_REQUIRE(llama::offsetOf<Particle, llama::RecordCoord<3, 0>, true> == 56);
+    STATIC_REQUIRE(llama::offsetOf<Particle, llama::RecordCoord<3, 1>, true> == 57);
+    STATIC_REQUIRE(llama::offsetOf<Particle, llama::RecordCoord<3, 2>, true> == 58);
+    STATIC_REQUIRE(llama::offsetOf<Particle, llama::RecordCoord<3, 3>, true> == 59);
 }
 
-TEST_CASE("flatFieldCount")
+namespace
+{
+    // clang-format off
+    using Other = llama::Record<
+        llama::Field<tag::Pos, llama::Record<
+            llama::Field<tag::Z, float>,
+            llama::Field<tag::Y, float>
+        >>
+    >;
+    // clang-format on
+} // namespace
+
+TEST_CASE("fieldCount")
 {
     STATIC_REQUIRE(llama::flatFieldCount<int> == 1);
-    STATIC_REQUIRE(llama::flatFieldCount<XYZ> == 3);
+    STATIC_REQUIRE(llama::flatFieldCount<Vec3D> == 3);
     STATIC_REQUIRE(llama::flatFieldCount<Particle> == 11);
     STATIC_REQUIRE(llama::flatFieldCount<Other> == 2);
 }
@@ -157,9 +135,8 @@ TEST_CASE("flatFieldCountBefore")
     STATIC_REQUIRE(llama::internal::flatFieldCountBefore<0, Particle> == 0);
     STATIC_REQUIRE(llama::internal::flatFieldCountBefore<1, Particle> == 3);
     STATIC_REQUIRE(llama::internal::flatFieldCountBefore<2, Particle> == 4);
-    STATIC_REQUIRE(llama::internal::flatFieldCountBefore<3, Particle> == 5);
-    STATIC_REQUIRE(llama::internal::flatFieldCountBefore<4, Particle> == 7);
-    STATIC_REQUIRE(llama::internal::flatFieldCountBefore<5, Particle> == 11);
+    STATIC_REQUIRE(llama::internal::flatFieldCountBefore<3, Particle> == 7);
+    STATIC_REQUIRE(llama::internal::flatFieldCountBefore<4, Particle> == 11);
 }
 
 template <int i>
@@ -171,7 +148,7 @@ TEST_CASE("alignment")
         llama::Field<tag::X, float>,
         llama::Field<tag::Y, double>,
         llama::Field<tag::Z, bool>,
-        llama::Field<tag::Weight, std::uint16_t>>;
+        llama::Field<tag::Mass, std::uint16_t>>;
 
     STATIC_REQUIRE(llama::offsetOf<RD, llama::RecordCoord<>, false> == 0);
     STATIC_REQUIRE(llama::offsetOf<RD, llama::RecordCoord<0>, false> == 0);
@@ -192,20 +169,20 @@ TEST_CASE("GetCoordFromTags")
 {
     using namespace llama::literals;
     // clang-format off
-    STATIC_REQUIRE(std::is_same_v<llama::GetCoordFromTags<Particle                                  >, llama::RecordCoord<    >>);
-    STATIC_REQUIRE(std::is_same_v<llama::GetCoordFromTags<Particle, tag::Pos                        >, llama::RecordCoord<0   >>);
-    STATIC_REQUIRE(std::is_same_v<llama::GetCoordFromTags<Particle, tag::Pos, tag::X                >, llama::RecordCoord<0, 0>>);
-    STATIC_REQUIRE(std::is_same_v<llama::GetCoordFromTags<Particle, tag::Pos, tag::Y                >, llama::RecordCoord<0, 1>>);
-    STATIC_REQUIRE(std::is_same_v<llama::GetCoordFromTags<Particle, tag::Pos, tag::Z                >, llama::RecordCoord<0, 2>>);
-    STATIC_REQUIRE(std::is_same_v<llama::GetCoordFromTags<Particle, tag::Weight                     >, llama::RecordCoord<1   >>);
-    STATIC_REQUIRE(std::is_same_v<llama::GetCoordFromTags<Particle, llama::NoName                   >, llama::RecordCoord<2   >>);
-    STATIC_REQUIRE(std::is_same_v<llama::GetCoordFromTags<Particle, tag::Vel, tag::Z                >, llama::RecordCoord<3, 0>>);
-    STATIC_REQUIRE(std::is_same_v<llama::GetCoordFromTags<Particle, tag::Vel, tag::X                >, llama::RecordCoord<3, 1>>);
-    STATIC_REQUIRE(std::is_same_v<llama::GetCoordFromTags<Particle, tag::Flags                      >, llama::RecordCoord<4   >>);
-    STATIC_REQUIRE(std::is_same_v<llama::GetCoordFromTags<Particle, tag::Flags, llama::RecordCoord<0>>, llama::RecordCoord<4, 0>>);
-    STATIC_REQUIRE(std::is_same_v<llama::GetCoordFromTags<Particle, tag::Flags, llama::RecordCoord<1>>, llama::RecordCoord<4, 1>>);
-    STATIC_REQUIRE(std::is_same_v<llama::GetCoordFromTags<Particle, tag::Flags, llama::RecordCoord<2>>, llama::RecordCoord<4, 2>>);
-    STATIC_REQUIRE(std::is_same_v<llama::GetCoordFromTags<Particle, tag::Flags, llama::RecordCoord<3>>, llama::RecordCoord<4, 3>>);
+    STATIC_REQUIRE(std::is_same_v<llama::GetCoordFromTags<Particle                                   >, llama::RecordCoord<    >>);
+    STATIC_REQUIRE(std::is_same_v<llama::GetCoordFromTags<Particle, tag::Pos                         >, llama::RecordCoord<0   >>);
+    STATIC_REQUIRE(std::is_same_v<llama::GetCoordFromTags<Particle, tag::Pos, tag::X                 >, llama::RecordCoord<0, 0>>);
+    STATIC_REQUIRE(std::is_same_v<llama::GetCoordFromTags<Particle, tag::Pos, tag::Y                 >, llama::RecordCoord<0, 1>>);
+    STATIC_REQUIRE(std::is_same_v<llama::GetCoordFromTags<Particle, tag::Pos, tag::Z                 >, llama::RecordCoord<0, 2>>);
+    STATIC_REQUIRE(std::is_same_v<llama::GetCoordFromTags<Particle, tag::Mass                        >, llama::RecordCoord<1   >>);
+    STATIC_REQUIRE(std::is_same_v<llama::GetCoordFromTags<Particle, tag::Vel, tag::X                 >, llama::RecordCoord<2, 0>>);
+    STATIC_REQUIRE(std::is_same_v<llama::GetCoordFromTags<Particle, tag::Vel, tag::Y                 >, llama::RecordCoord<2, 1>>);
+    STATIC_REQUIRE(std::is_same_v<llama::GetCoordFromTags<Particle, tag::Vel, tag::Z                 >, llama::RecordCoord<2, 2>>);
+    STATIC_REQUIRE(std::is_same_v<llama::GetCoordFromTags<Particle, tag::Flags                       >, llama::RecordCoord<3   >>);
+    STATIC_REQUIRE(std::is_same_v<llama::GetCoordFromTags<Particle, tag::Flags, llama::RecordCoord<0>>, llama::RecordCoord<3, 0>>);
+    STATIC_REQUIRE(std::is_same_v<llama::GetCoordFromTags<Particle, tag::Flags, llama::RecordCoord<1>>, llama::RecordCoord<3, 1>>);
+    STATIC_REQUIRE(std::is_same_v<llama::GetCoordFromTags<Particle, tag::Flags, llama::RecordCoord<2>>, llama::RecordCoord<3, 2>>);
+    STATIC_REQUIRE(std::is_same_v<llama::GetCoordFromTags<Particle, tag::Flags, llama::RecordCoord<3>>, llama::RecordCoord<3, 3>>);
     // clang-format on
 }
 
@@ -215,7 +192,7 @@ TEST_CASE("GetTags")
     STATIC_REQUIRE(std::is_same_v<llama::GetTags<Particle, llama::RecordCoord<0, 0>>, boost::mp11::mp_list<llama::NoName, tag::Pos, tag::X >>);
     STATIC_REQUIRE(std::is_same_v<llama::GetTags<Particle, llama::RecordCoord<0   >>, boost::mp11::mp_list<llama::NoName, tag::Pos         >>);
     STATIC_REQUIRE(std::is_same_v<llama::GetTags<Particle, llama::RecordCoord<    >>, boost::mp11::mp_list<llama::NoName                   >>);
-    STATIC_REQUIRE(std::is_same_v<llama::GetTags<Particle, llama::RecordCoord<3, 1>>, boost::mp11::mp_list<llama::NoName, tag::Vel, tag::X >>);
+    STATIC_REQUIRE(std::is_same_v<llama::GetTags<Particle, llama::RecordCoord<2, 1>>, boost::mp11::mp_list<llama::NoName, tag::Vel, tag::Y >>);
     // clang-format on
 }
 
@@ -225,7 +202,7 @@ TEST_CASE("GetTag")
     STATIC_REQUIRE(std::is_same_v<llama::GetTag<Particle, llama::RecordCoord<0, 0>>, tag::X       >);
     STATIC_REQUIRE(std::is_same_v<llama::GetTag<Particle, llama::RecordCoord<0   >>, tag::Pos     >);
     STATIC_REQUIRE(std::is_same_v<llama::GetTag<Particle, llama::RecordCoord<    >>, llama::NoName>);
-    STATIC_REQUIRE(std::is_same_v<llama::GetTag<Particle, llama::RecordCoord<3, 1>>, tag::X       >);
+    STATIC_REQUIRE(std::is_same_v<llama::GetTag<Particle, llama::RecordCoord<2, 1>>, tag::Y       >);
     // clang-format on
 }
 
@@ -239,7 +216,7 @@ TEST_CASE("hasSameTags")
             PosRecord, // RD A
             llama::RecordCoord<0>, // Local A
             VelRecord, // RD B
-            llama::RecordCoord<0> // Local B
+            llama::RecordCoord<1> // Local B
             > == false);
 
     STATIC_REQUIRE(
@@ -247,7 +224,7 @@ TEST_CASE("hasSameTags")
             PosRecord, // RD A
             llama::RecordCoord<0>, // Local A
             VelRecord, // RD B
-            llama::RecordCoord<1> // Local B
+            llama::RecordCoord<0> // Local B
             > == true);
 
     STATIC_REQUIRE(
@@ -277,9 +254,10 @@ TEST_CASE("hasSameTags")
 
 TEST_CASE("FlatRecordDim")
 {
-    STATIC_REQUIRE(std::is_same_v<
-                   llama::FlatRecordDim<Particle>,
-                   boost::mp11::mp_list<double, double, double, float, int, double, double, bool, bool, bool, bool>>);
+    STATIC_REQUIRE(
+        std::is_same_v<
+            llama::FlatRecordDim<Particle>,
+            boost::mp11::mp_list<double, double, double, float, double, double, double, bool, bool, bool, bool>>);
 }
 
 TEST_CASE("flatRecordCoord")
@@ -291,12 +269,12 @@ TEST_CASE("flatRecordCoord")
     STATIC_REQUIRE(llama::flatRecordCoord<Particle, llama::RecordCoord<0, 2>> == 2);
     STATIC_REQUIRE(llama::flatRecordCoord<Particle, llama::RecordCoord<1>> == 3);
     STATIC_REQUIRE(llama::flatRecordCoord<Particle, llama::RecordCoord<2>> == 4);
-    STATIC_REQUIRE(llama::flatRecordCoord<Particle, llama::RecordCoord<3>> == 5);
-    STATIC_REQUIRE(llama::flatRecordCoord<Particle, llama::RecordCoord<3, 0>> == 5);
-    STATIC_REQUIRE(llama::flatRecordCoord<Particle, llama::RecordCoord<3, 1>> == 6);
-    STATIC_REQUIRE(llama::flatRecordCoord<Particle, llama::RecordCoord<4>> == 7);
-    STATIC_REQUIRE(llama::flatRecordCoord<Particle, llama::RecordCoord<4, 0>> == 7);
-    STATIC_REQUIRE(llama::flatRecordCoord<Particle, llama::RecordCoord<4, 1>> == 8);
-    STATIC_REQUIRE(llama::flatRecordCoord<Particle, llama::RecordCoord<4, 2>> == 9);
-    STATIC_REQUIRE(llama::flatRecordCoord<Particle, llama::RecordCoord<4, 3>> == 10);
+    STATIC_REQUIRE(llama::flatRecordCoord<Particle, llama::RecordCoord<2, 0>> == 4);
+    STATIC_REQUIRE(llama::flatRecordCoord<Particle, llama::RecordCoord<2, 1>> == 5);
+    STATIC_REQUIRE(llama::flatRecordCoord<Particle, llama::RecordCoord<2, 2>> == 6);
+    STATIC_REQUIRE(llama::flatRecordCoord<Particle, llama::RecordCoord<3>> == 7);
+    STATIC_REQUIRE(llama::flatRecordCoord<Particle, llama::RecordCoord<3, 0>> == 7);
+    STATIC_REQUIRE(llama::flatRecordCoord<Particle, llama::RecordCoord<3, 1>> == 8);
+    STATIC_REQUIRE(llama::flatRecordCoord<Particle, llama::RecordCoord<3, 2>> == 9);
+    STATIC_REQUIRE(llama::flatRecordCoord<Particle, llama::RecordCoord<3, 3>> == 10);
 }

--- a/tests/heatmap.cpp
+++ b/tests/heatmap.cpp
@@ -1,35 +1,8 @@
+#include "common.h"
+
 #include <catch2/catch.hpp>
 #include <fstream>
 #include <llama/llama.hpp>
-
-namespace
-{
-    // clang-format off
-    namespace tag
-    {
-        struct Pos{};
-        struct Vel{};
-        struct X{};
-        struct Y{};
-        struct Z{};
-        struct Mass{};
-    } // namespace tag
-
-    using Particle = llama::Record<
-        llama::Field<tag::Pos, llama::Record<
-            llama::Field<tag::X, float>,
-            llama::Field<tag::Y, float>,
-            llama::Field<tag::Z, float>
-        >>,
-        llama::Field<tag::Vel, llama::Record<
-            llama::Field<tag::X, float>,
-            llama::Field<tag::Y, float>,
-            llama::Field<tag::Z, float>
-        >>,
-        llama::Field<tag::Mass, float>
-    >;
-    // clang-format on
-} // namespace
 
 TEST_CASE("Heatmap.nbody")
 {
@@ -45,7 +18,7 @@ TEST_CASE("Heatmap.nbody")
         constexpr float EPS2 = 0.01f;
         for (std::size_t i = 0; i < N; i++)
         {
-            llama::One<Particle> pi = particles(i);
+            llama::One<ParticleHeatmap> pi = particles(i);
             for (std::size_t j = 0; j < N; ++j)
             {
                 auto pj = particles(j);
@@ -67,6 +40,6 @@ TEST_CASE("Heatmap.nbody")
 
     using ArrayDims = llama::ArrayDims<1>;
     auto arrayDims = ArrayDims{N};
-    run("AlignedAoS", llama::mapping::AlignedAoS<ArrayDims, Particle>{arrayDims});
-    run("SingleBlobSoA", llama::mapping::SingleBlobSoA<ArrayDims, Particle>{arrayDims});
+    run("AlignedAoS", llama::mapping::AlignedAoS<ArrayDims, ParticleHeatmap>{arrayDims});
+    run("SingleBlobSoA", llama::mapping::SingleBlobSoA<ArrayDims, ParticleHeatmap>{arrayDims});
 }

--- a/tests/mapping.cpp
+++ b/tests/mapping.cpp
@@ -4,35 +4,6 @@
 #include <llama/Concepts.hpp>
 #include <llama/llama.hpp>
 
-// clang-format off
-namespace tag {
-    struct Pos {};
-    struct X {};
-    struct Y {};
-    struct Z {};
-    struct Momentum {};
-    struct Weight {};
-    struct Flags {};
-} // namespace tag
-
-// clang-format off
-using Particle = llama::Record<
-    llama::Field<tag::Pos, llama::Record<
-        llama::Field<tag::X, double>,
-        llama::Field<tag::Y, double>,
-        llama::Field<tag::Z, double>
-    >>,
-    llama::Field<tag::Weight, float>,
-    llama::Field<tag::Momentum, llama::Record<
-        llama::Field<tag::X, double>,
-        llama::Field<tag::Y, double>,
-        llama::Field<tag::Z, double>
-    >>,
-    llama::Field<tag::Flags, bool[4]>
->;
-// clang-format on
-
-
 #ifdef __cpp_concepts
 TEST_CASE("mapping.concepts")
 {

--- a/tests/splitmapping.cpp
+++ b/tests/splitmapping.cpp
@@ -5,34 +5,6 @@
 #include <llama/DumpMapping.hpp>
 #include <llama/llama.hpp>
 
-// clang-format off
-namespace tag {
-    struct Pos {};
-    struct X {};
-    struct Y {};
-    struct Z {};
-    struct Momentum {};
-    struct Weight {};
-    struct Flags {};
-} // namespace tag
-
-// clang-format off
-using Particle = llama::Record<
-    llama::Field<tag::Pos, llama::Record<
-        llama::Field<tag::X, double>,
-        llama::Field<tag::Y, double>,
-        llama::Field<tag::Z, double>
-    >>,
-    llama::Field<tag::Weight, float>,
-    llama::Field<tag::Momentum, llama::Record<
-        llama::Field<tag::X, double>,
-        llama::Field<tag::Y, double>,
-        llama::Field<tag::Z, double>
-    >>,
-    llama::Field<tag::Flags, bool[4]>
->;
-// clang-format on
-
 TEST_CASE("Split.SoA.AoS.1Buffer")
 {
     using ArrayDims = llama::ArrayDims<2>;

--- a/tests/treemap.cpp
+++ b/tests/treemap.cpp
@@ -7,16 +7,6 @@ namespace tree = llama::mapping::tree;
 
 namespace tag
 {
-    // clang-format off
-    struct Pos {};
-    struct X {};
-    struct Y {};
-    struct Z {};
-    struct Momentum {};
-    struct Weight {};
-    struct Flags {};
-    // clang-format on
-
     auto toString(Pos)
     {
         return "Pos";
@@ -33,13 +23,13 @@ namespace tag
     {
         return "Z";
     }
-    auto toString(Momentum)
+    auto toString(Vel)
     {
-        return "Momentum";
+        return "Vel";
     }
-    auto toString(Weight)
+    auto toString(Mass)
     {
-        return "Weight";
+        return "Mass";
     }
     auto toString(Flags)
     {
@@ -47,42 +37,25 @@ namespace tag
     }
 } // namespace tag
 
-// clang-format off
-using Name = llama::Record<
-    llama::Field<tag::Pos, llama::Record<
-        llama::Field<tag::X, double>,
-        llama::Field<tag::Y, double>,
-        llama::Field<tag::Z, double>
-    >>,
-    llama::Field<tag::Weight, float>,
-    llama::Field<tag::Momentum, llama::Record<
-        llama::Field<tag::Z, double>,
-        llama::Field<tag::Y, double>,
-        llama::Field<tag::X, double>
-    >>,
-    llama::Field<tag::Flags, bool[4]>
->;
-// clang-format on
-
 TEST_CASE("treemapping.empty")
 {
     using ArrayDims = llama::ArrayDims<2>;
     const ArrayDims arrayDims{16, 16};
 
     auto treeOperationList = llama::Tuple{};
-    using Mapping = tree::Mapping<ArrayDims, Name, decltype(treeOperationList)>;
+    using Mapping = tree::Mapping<ArrayDims, Particle, decltype(treeOperationList)>;
     const Mapping mapping(arrayDims, treeOperationList);
 
     CHECK(
         tree::toString(mapping.basicTree)
-        == "16R * [ 16R * [ 1C * Pos[ 1C * X(double) , 1C * Y(double) , 1C * Z(double) ] , 1C * Weight(float) , 1C * "
-           "Momentum[ 1C * Z(double) , 1C * Y(double) , 1C * "
-           "X(double) ] , 1C * Flags[ 1C * (bool) , 1C * (bool) , 1C * (bool) , 1C * (bool) ] ] ]");
+        == "16R * [ 16R * [ 1C * Pos[ 1C * X(double) , 1C * Y(double) , 1C * Z(double) ] , 1C * Mass(float) , 1C * "
+           "Vel[ 1C * X(double) , 1C * Y(double) , 1C * "
+           "Z(double) ] , 1C * Flags[ 1C * (bool) , 1C * (bool) , 1C * (bool) , 1C * (bool) ] ] ]");
     CHECK(
         tree::toString(mapping.resultTree)
-        == "16R * [ 16R * [ 1C * Pos[ 1C * X(double) , 1C * Y(double) , 1C * Z(double) ] , 1C * Weight(float) , 1C * "
-           "Momentum[ 1C * Z(double) , 1C * Y(double) , 1C * "
-           "X(double) ] , 1C * Flags[ 1C * (bool) , 1C * (bool) , 1C * (bool) , 1C * (bool) ] ] ]");
+        == "16R * [ 16R * [ 1C * Pos[ 1C * X(double) , 1C * Y(double) , 1C * Z(double) ] , 1C * Mass(float) , 1C * "
+           "Vel[ 1C * X(double) , 1C * Y(double) , 1C * "
+           "Z(double) ] , 1C * Flags[ 1C * (bool) , 1C * (bool) , 1C * (bool) , 1C * (bool) ] ] ]");
 
     CHECK(mapping.blobSize(0) == 14336);
 
@@ -138,19 +111,19 @@ TEST_CASE("treemapping.Idem")
     const ArrayDims arrayDims{16, 16};
 
     auto treeOperationList = llama::Tuple{tree::functor::Idem()};
-    using Mapping = tree::Mapping<ArrayDims, Name, decltype(treeOperationList)>;
+    using Mapping = tree::Mapping<ArrayDims, Particle, decltype(treeOperationList)>;
     const Mapping mapping(arrayDims, treeOperationList);
 
     CHECK(
         tree::toString(mapping.basicTree)
-        == "16R * [ 16R * [ 1C * Pos[ 1C * X(double) , 1C * Y(double) , 1C * Z(double) ] , 1C * Weight(float) , 1C * "
-           "Momentum[ 1C * Z(double) , 1C * Y(double) , 1C * "
-           "X(double) ] , 1C * Flags[ 1C * (bool) , 1C * (bool) , 1C * (bool) , 1C * (bool) ] ] ]");
+        == "16R * [ 16R * [ 1C * Pos[ 1C * X(double) , 1C * Y(double) , 1C * Z(double) ] , 1C * Mass(float) , 1C * "
+           "Vel[ 1C * X(double) , 1C * Y(double) , 1C * "
+           "Z(double) ] , 1C * Flags[ 1C * (bool) , 1C * (bool) , 1C * (bool) , 1C * (bool) ] ] ]");
     CHECK(
         tree::toString(mapping.resultTree)
-        == "16R * [ 16R * [ 1C * Pos[ 1C * X(double) , 1C * Y(double) , 1C * Z(double) ] , 1C * Weight(float) , 1C * "
-           "Momentum[ 1C * Z(double) , 1C * Y(double) , 1C * "
-           "X(double) ] , 1C * Flags[ 1C * (bool) , 1C * (bool) , 1C * (bool) , 1C * (bool) ] ] ]");
+        == "16R * [ 16R * [ 1C * Pos[ 1C * X(double) , 1C * Y(double) , 1C * Z(double) ] , 1C * Mass(float) , 1C * "
+           "Vel[ 1C * X(double) , 1C * Y(double) , 1C * "
+           "Z(double) ] , 1C * Flags[ 1C * (bool) , 1C * (bool) , 1C * (bool) , 1C * (bool) ] ] ]");
 
     CHECK(mapping.blobSize(0) == 14336);
 
@@ -206,19 +179,19 @@ TEST_CASE("treemapping.LeafOnlyRT")
     const ArrayDims arrayDims{16, 16};
 
     auto treeOperationList = llama::Tuple{tree::functor::LeafOnlyRT()};
-    using Mapping = tree::Mapping<ArrayDims, Name, decltype(treeOperationList)>;
+    using Mapping = tree::Mapping<ArrayDims, Particle, decltype(treeOperationList)>;
     const Mapping mapping(arrayDims, treeOperationList);
 
     CHECK(
         tree::toString(mapping.basicTree)
-        == "16R * [ 16R * [ 1C * Pos[ 1C * X(double) , 1C * Y(double) , 1C * Z(double) ] , 1C * Weight(float) , 1C * "
-           "Momentum[ 1C * Z(double) , 1C * Y(double) , 1C * "
-           "X(double) ] , 1C * Flags[ 1C * (bool) , 1C * (bool) , 1C * (bool) , 1C * (bool) ] ] ]");
+        == "16R * [ 16R * [ 1C * Pos[ 1C * X(double) , 1C * Y(double) , 1C * Z(double) ] , 1C * Mass(float) , 1C * "
+           "Vel[ 1C * X(double) , 1C * Y(double) , 1C * "
+           "Z(double) ] , 1C * Flags[ 1C * (bool) , 1C * (bool) , 1C * (bool) , 1C * (bool) ] ] ]");
     CHECK(
         tree::toString(mapping.resultTree)
-        == "1C * [ 1C * [ 1C * Pos[ 256R * X(double) , 256R * Y(double) , 256R * Z(double) ] , 256R * Weight(float) , "
-           "1C * Momentum[ 256R * Z(double) , 256R * Y(double) "
-           ", 256R * X(double) ] , 1C * Flags[ 256R * (bool) , 256R * (bool) , 256R * (bool) , 256R * (bool) ] ] ]");
+        == "1C * [ 1C * [ 1C * Pos[ 256R * X(double) , 256R * Y(double) , 256R * Z(double) ] , 256R * Mass(float) , "
+           "1C * Vel[ 256R * X(double) , 256R * Y(double) "
+           ", 256R * Z(double) ] , 1C * Flags[ 256R * (bool) , 256R * (bool) , 256R * (bool) , 256R * (bool) ] ] ]");
 
     CHECK(mapping.blobSize(0) == 14336);
 
@@ -274,19 +247,19 @@ TEST_CASE("treemapping.MoveRTDown<>")
     const ArrayDims arrayDims{16, 16};
 
     auto treeOperationList = llama::Tuple{tree::functor::MoveRTDown<tree::TreeCoord<>>{4}};
-    using Mapping = tree::Mapping<ArrayDims, Name, decltype(treeOperationList)>;
+    using Mapping = tree::Mapping<ArrayDims, Particle, decltype(treeOperationList)>;
     const Mapping mapping(arrayDims, treeOperationList);
 
     CHECK(
         tree::toString(mapping.basicTree)
-        == "16R * [ 16R * [ 1C * Pos[ 1C * X(double) , 1C * Y(double) , 1C * Z(double) ] , 1C * Weight(float) , 1C * "
-           "Momentum[ 1C * Z(double) , 1C * Y(double) , 1C * "
-           "X(double) ] , 1C * Flags[ 1C * (bool) , 1C * (bool) , 1C * (bool) , 1C * (bool) ] ] ]");
+        == "16R * [ 16R * [ 1C * Pos[ 1C * X(double) , 1C * Y(double) , 1C * Z(double) ] , 1C * Mass(float) , 1C * "
+           "Vel[ 1C * X(double) , 1C * Y(double) , 1C * "
+           "Z(double) ] , 1C * Flags[ 1C * (bool) , 1C * (bool) , 1C * (bool) , 1C * (bool) ] ] ]");
     CHECK(
         tree::toString(mapping.resultTree)
-        == "4R * [ 64R * [ 1C * Pos[ 1C * X(double) , 1C * Y(double) , 1C * Z(double) ] , 1C * Weight(float) , 1C * "
-           "Momentum[ 1C * Z(double) , 1C * Y(double) , 1C * "
-           "X(double) ] , 1C * Flags[ 1C * (bool) , 1C * (bool) , 1C * (bool) , 1C * (bool) ] ] ]");
+        == "4R * [ 64R * [ 1C * Pos[ 1C * X(double) , 1C * Y(double) , 1C * Z(double) ] , 1C * Mass(float) , 1C * "
+           "Vel[ 1C * X(double) , 1C * Y(double) , 1C * "
+           "Z(double) ] , 1C * Flags[ 1C * (bool) , 1C * (bool) , 1C * (bool) , 1C * (bool) ] ] ]");
 
     CHECK(mapping.blobSize(0) == 14336);
 
@@ -330,19 +303,19 @@ TEST_CASE("treemapping.MoveRTDown<0>")
     const ArrayDims arrayDims{16, 16};
 
     auto treeOperationList = llama::Tuple{tree::functor::MoveRTDown<tree::TreeCoord<0>>{4}};
-    using Mapping = tree::Mapping<ArrayDims, Name, decltype(treeOperationList)>;
+    using Mapping = tree::Mapping<ArrayDims, Particle, decltype(treeOperationList)>;
     const Mapping mapping(arrayDims, treeOperationList);
 
     CHECK(
         tree::toString(mapping.basicTree)
-        == "16R * [ 16R * [ 1C * Pos[ 1C * X(double) , 1C * Y(double) , 1C * Z(double) ] , 1C * Weight(float) , 1C * "
-           "Momentum[ 1C * Z(double) , 1C * Y(double) , 1C * "
-           "X(double) ] , 1C * Flags[ 1C * (bool) , 1C * (bool) , 1C * (bool) , 1C * (bool) ] ] ]");
+        == "16R * [ 16R * [ 1C * Pos[ 1C * X(double) , 1C * Y(double) , 1C * Z(double) ] , 1C * Mass(float) , 1C * "
+           "Vel[ 1C * X(double) , 1C * Y(double) , 1C * "
+           "Z(double) ] , 1C * Flags[ 1C * (bool) , 1C * (bool) , 1C * (bool) , 1C * (bool) ] ] ]");
     CHECK(
         tree::toString(mapping.resultTree)
-        == "16R * [ 4R * [ 4R * Pos[ 1C * X(double) , 1C * Y(double) , 1C * Z(double) ] , 4R * Weight(float) , 4R * "
-           "Momentum[ 1C * Z(double) , 1C * Y(double) , 1C * "
-           "X(double) ] , 4R * Flags[ 1C * (bool) , 1C * (bool) , 1C * (bool) , 1C * (bool) ] ] ]");
+        == "16R * [ 4R * [ 4R * Pos[ 1C * X(double) , 1C * Y(double) , 1C * Z(double) ] , 4R * Mass(float) , 4R * "
+           "Vel[ 1C * X(double) , 1C * Y(double) , 1C * "
+           "Z(double) ] , 4R * Flags[ 1C * (bool) , 1C * (bool) , 1C * (bool) , 1C * (bool) ] ] ]");
 
     CHECK(mapping.blobSize(0) == 14336);
 
@@ -386,19 +359,19 @@ TEST_CASE("treemapping.MoveRTDown<0,0>")
     const ArrayDims arrayDims{16, 16};
 
     auto treeOperationList = llama::Tuple{tree::functor::MoveRTDown<tree::TreeCoord<0, 0>>{4}};
-    using Mapping = tree::Mapping<ArrayDims, Name, decltype(treeOperationList)>;
+    using Mapping = tree::Mapping<ArrayDims, Particle, decltype(treeOperationList)>;
     const Mapping mapping(arrayDims, treeOperationList);
 
     CHECK(
         tree::toString(mapping.basicTree)
-        == "16R * [ 16R * [ 1C * Pos[ 1C * X(double) , 1C * Y(double) , 1C * Z(double) ] , 1C * Weight(float) , 1C * "
-           "Momentum[ 1C * Z(double) , 1C * Y(double) , 1C * "
-           "X(double) ] , 1C * Flags[ 1C * (bool) , 1C * (bool) , 1C * (bool) , 1C * (bool) ] ] ]");
+        == "16R * [ 16R * [ 1C * Pos[ 1C * X(double) , 1C * Y(double) , 1C * Z(double) ] , 1C * Mass(float) , 1C * "
+           "Vel[ 1C * X(double) , 1C * Y(double) , 1C * "
+           "Z(double) ] , 1C * Flags[ 1C * (bool) , 1C * (bool) , 1C * (bool) , 1C * (bool) ] ] ]");
     CHECK(
         tree::toString(mapping.resultTree)
-        == "16R * [ 16R * [ 1R * Pos[ 4R * X(double) , 4R * Y(double) , 4R * Z(double) ] , 1C * Weight(float) , 1C * "
-           "Momentum[ 1C * Z(double) , 1C * Y(double) , 1C * "
-           "X(double) ] , 1C * Flags[ 1C * (bool) , 1C * (bool) , 1C * (bool) , 1C * (bool) ] ] ]");
+        == "16R * [ 16R * [ 1R * Pos[ 4R * X(double) , 4R * Y(double) , 4R * Z(double) ] , 1C * Mass(float) , 1C * "
+           "Vel[ 1C * X(double) , 1C * Y(double) , 1C * "
+           "Z(double) ] , 1C * Flags[ 1C * (bool) , 1C * (bool) , 1C * (bool) , 1C * (bool) ] ] ]");
 
     CHECK(mapping.blobSize(0) == 32768);
 
@@ -442,19 +415,19 @@ TEST_CASE("treemapping.MoveRTDownFixed<>")
     const ArrayDims arrayDims{16, 16};
 
     auto treeOperationList = llama::Tuple{tree::functor::MoveRTDownFixed<tree::TreeCoord<>, 4>{}};
-    using Mapping = tree::Mapping<ArrayDims, Name, decltype(treeOperationList)>;
+    using Mapping = tree::Mapping<ArrayDims, Particle, decltype(treeOperationList)>;
     const Mapping mapping(arrayDims, treeOperationList);
 
     CHECK(
         tree::toString(mapping.basicTree)
-        == "16R * [ 16R * [ 1C * Pos[ 1C * X(double) , 1C * Y(double) , 1C * Z(double) ] , 1C * Weight(float) , 1C * "
-           "Momentum[ 1C * Z(double) , 1C * Y(double) , 1C * "
-           "X(double) ] , 1C * Flags[ 1C * (bool) , 1C * (bool) , 1C * (bool) , 1C * (bool) ] ] ]");
+        == "16R * [ 16R * [ 1C * Pos[ 1C * X(double) , 1C * Y(double) , 1C * Z(double) ] , 1C * Mass(float) , 1C * "
+           "Vel[ 1C * X(double) , 1C * Y(double) , 1C * "
+           "Z(double) ] , 1C * Flags[ 1C * (bool) , 1C * (bool) , 1C * (bool) , 1C * (bool) ] ] ]");
     CHECK(
         tree::toString(mapping.resultTree)
-        == "4R * [ 64R * [ 1C * Pos[ 1C * X(double) , 1C * Y(double) , 1C * Z(double) ] , 1C * Weight(float) , 1C * "
-           "Momentum[ 1C * Z(double) , 1C * Y(double) , 1C * "
-           "X(double) ] , 1C * Flags[ 1C * (bool) , 1C * (bool) , 1C * (bool) , 1C * (bool) ] ] ]");
+        == "4R * [ 64R * [ 1C * Pos[ 1C * X(double) , 1C * Y(double) , 1C * Z(double) ] , 1C * Mass(float) , 1C * "
+           "Vel[ 1C * X(double) , 1C * Y(double) , 1C * "
+           "Z(double) ] , 1C * Flags[ 1C * (bool) , 1C * (bool) , 1C * (bool) , 1C * (bool) ] ] ]");
 
     CHECK(mapping.blobSize(0) == 14336);
 
@@ -498,19 +471,19 @@ TEST_CASE("treemapping.MoveRTDownFixed<0>")
     const ArrayDims arrayDims{16, 16};
 
     auto treeOperationList = llama::Tuple{tree::functor::MoveRTDownFixed<tree::TreeCoord<0>, 4>{}};
-    using Mapping = tree::Mapping<ArrayDims, Name, decltype(treeOperationList)>;
+    using Mapping = tree::Mapping<ArrayDims, Particle, decltype(treeOperationList)>;
     const Mapping mapping(arrayDims, treeOperationList);
 
     CHECK(
         tree::toString(mapping.basicTree)
-        == "16R * [ 16R * [ 1C * Pos[ 1C * X(double) , 1C * Y(double) , 1C * Z(double) ] , 1C * Weight(float) , 1C * "
-           "Momentum[ 1C * Z(double) , 1C * Y(double) , 1C * "
-           "X(double) ] , 1C * Flags[ 1C * (bool) , 1C * (bool) , 1C * (bool) , 1C * (bool) ] ] ]");
+        == "16R * [ 16R * [ 1C * Pos[ 1C * X(double) , 1C * Y(double) , 1C * Z(double) ] , 1C * Mass(float) , 1C * "
+           "Vel[ 1C * X(double) , 1C * Y(double) , 1C * "
+           "Z(double) ] , 1C * Flags[ 1C * (bool) , 1C * (bool) , 1C * (bool) , 1C * (bool) ] ] ]");
     CHECK(
         tree::toString(mapping.resultTree)
-        == "16R * [ 4R * [ 4R * Pos[ 1C * X(double) , 1C * Y(double) , 1C * Z(double) ] , 4R * Weight(float) , 4R * "
-           "Momentum[ 1C * Z(double) , 1C * Y(double) , 1C * "
-           "X(double) ] , 4R * Flags[ 1C * (bool) , 1C * (bool) , 1C * (bool) , 1C * (bool) ] ] ]");
+        == "16R * [ 4R * [ 4R * Pos[ 1C * X(double) , 1C * Y(double) , 1C * Z(double) ] , 4R * Mass(float) , 4R * "
+           "Vel[ 1C * X(double) , 1C * Y(double) , 1C * "
+           "Z(double) ] , 4R * Flags[ 1C * (bool) , 1C * (bool) , 1C * (bool) , 1C * (bool) ] ] ]");
 
     CHECK(mapping.blobSize(0) == 14336);
 
@@ -554,19 +527,19 @@ TEST_CASE("treemapping.MoveRTDownFixed<0,0>")
     const ArrayDims arrayDims{16, 16};
 
     auto treeOperationList = llama::Tuple{tree::functor::MoveRTDownFixed<tree::TreeCoord<0, 0>, 4>{}};
-    using Mapping = tree::Mapping<ArrayDims, Name, decltype(treeOperationList)>;
+    using Mapping = tree::Mapping<ArrayDims, Particle, decltype(treeOperationList)>;
     const Mapping mapping(arrayDims, treeOperationList);
 
     CHECK(
         tree::toString(mapping.basicTree)
-        == "16R * [ 16R * [ 1C * Pos[ 1C * X(double) , 1C * Y(double) , 1C * Z(double) ] , 1C * Weight(float) , 1C * "
-           "Momentum[ 1C * Z(double) , 1C * Y(double) , 1C * "
-           "X(double) ] , 1C * Flags[ 1C * (bool) , 1C * (bool) , 1C * (bool) , 1C * (bool) ] ] ]");
+        == "16R * [ 16R * [ 1C * Pos[ 1C * X(double) , 1C * Y(double) , 1C * Z(double) ] , 1C * Mass(float) , 1C * "
+           "Vel[ 1C * X(double) , 1C * Y(double) , 1C * "
+           "Z(double) ] , 1C * Flags[ 1C * (bool) , 1C * (bool) , 1C * (bool) , 1C * (bool) ] ] ]");
     CHECK(
         tree::toString(mapping.resultTree)
-        == "16R * [ 16R * [ 1R * Pos[ 4R * X(double) , 4R * Y(double) , 4R * Z(double) ] , 1C * Weight(float) , 1C * "
-           "Momentum[ 1C * Z(double) , 1C * Y(double) , 1C * "
-           "X(double) ] , 1C * Flags[ 1C * (bool) , 1C * (bool) , 1C * (bool) , 1C * (bool) ] ] ]");
+        == "16R * [ 16R * [ 1R * Pos[ 4R * X(double) , 4R * Y(double) , 4R * Z(double) ] , 1C * Mass(float) , 1C * "
+           "Vel[ 1C * X(double) , 1C * Y(double) , 1C * "
+           "Z(double) ] , 1C * Flags[ 1C * (bool) , 1C * (bool) , 1C * (bool) , 1C * (bool) ] ] ]");
 
     CHECK(mapping.blobSize(0) == 32768);
 
@@ -613,22 +586,22 @@ TEST_CASE("treemapping.vectorblocks.runtime")
 
     auto treeOperationList = llama::Tuple{
         tree::functor::MoveRTDown<tree::TreeCoord<0>>{vectorWidth}, // move 8 down from ArrayDims (to
-                                                                    // Position/Weight/Momentum)
+                                                                    // Position/Mass/Vel)
         tree::functor::MoveRTDown<tree::TreeCoord<0, 0>>{vectorWidth}, // move 8 down from Position (to X/Y/Z)
-        tree::functor::MoveRTDown<tree::TreeCoord<0, 2>>{vectorWidth}, // move 8 down from Momentum (to X/Y/Z)
+        tree::functor::MoveRTDown<tree::TreeCoord<0, 2>>{vectorWidth}, // move 8 down from Vel (to X/Y/Z)
     };
-    using Mapping = tree::Mapping<ArrayDims, Name, decltype(treeOperationList)>;
+    using Mapping = tree::Mapping<ArrayDims, Particle, decltype(treeOperationList)>;
     const Mapping mapping(arrayDims, treeOperationList);
 
     CHECK(
         tree::toString(mapping.basicTree)
-        == "16R * [ 16R * [ 1C * Pos[ 1C * X(double) , 1C * Y(double) , 1C * Z(double) ] , 1C * Weight(float) , 1C * "
-           "Momentum[ 1C * Z(double) , 1C * Y(double) , 1C * "
-           "X(double) ] , 1C * Flags[ 1C * (bool) , 1C * (bool) , 1C * (bool) , 1C * (bool) ] ] ]");
+        == "16R * [ 16R * [ 1C * Pos[ 1C * X(double) , 1C * Y(double) , 1C * Z(double) ] , 1C * Mass(float) , 1C * "
+           "Vel[ 1C * X(double) , 1C * Y(double) , 1C * "
+           "Z(double) ] , 1C * Flags[ 1C * (bool) , 1C * (bool) , 1C * (bool) , 1C * (bool) ] ] ]");
     CHECK(
         tree::toString(mapping.resultTree)
-        == "16R * [ 2R * [ 1R * Pos[ 8R * X(double) , 8R * Y(double) , 8R * Z(double) ] , 8R * Weight(float) , "
-           "1R * Momentum[ 8R * Z(double) , 8R * Y(double) , 8R * X(double) ] , 8R * Flags[ 1C * (bool) , 1C * (bool) "
+        == "16R * [ 2R * [ 1R * Pos[ 8R * X(double) , 8R * Y(double) , 8R * Z(double) ] , 8R * Mass(float) , "
+           "1R * Vel[ 8R * X(double) , 8R * Y(double) , 8R * Z(double) ] , 8R * Flags[ 1C * (bool) , 1C * (bool) "
            ", 1C * (bool) , 1C * (bool) ] ] ]");
 
     CHECK(mapping.blobSize(0) == 14336);
@@ -676,22 +649,22 @@ TEST_CASE("treemapping.vectorblocks.compiletime")
 
     auto treeOperationList = llama::Tuple{
         tree::functor::MoveRTDownFixed<tree::TreeCoord<0>, vectorWidth>{}, // move 8 down from ArrayDims (to
-                                                                           // Position/Weight/Momentum)
+                                                                           // Position/Mass/Vel)
         tree::functor::MoveRTDownFixed<tree::TreeCoord<0, 0>, vectorWidth>{}, // move 8 down from Position (to X/Y/Z)
-        tree::functor::MoveRTDownFixed<tree::TreeCoord<0, 2>, vectorWidth>{}, // move 8 down from Momentum (to X/Y/Z)
+        tree::functor::MoveRTDownFixed<tree::TreeCoord<0, 2>, vectorWidth>{}, // move 8 down from Vel (to X/Y/Z)
     };
-    using Mapping = tree::Mapping<ArrayDims, Name, decltype(treeOperationList)>;
+    using Mapping = tree::Mapping<ArrayDims, Particle, decltype(treeOperationList)>;
     const Mapping mapping(arrayDims, treeOperationList);
 
     CHECK(
         tree::toString(mapping.basicTree)
-        == "16R * [ 16R * [ 1C * Pos[ 1C * X(double) , 1C * Y(double) , 1C * Z(double) ] , 1C * Weight(float) , 1C * "
-           "Momentum[ 1C * Z(double) , 1C * Y(double) , 1C * "
-           "X(double) ] , 1C * Flags[ 1C * (bool) , 1C * (bool) , 1C * (bool) , 1C * (bool) ] ] ]");
+        == "16R * [ 16R * [ 1C * Pos[ 1C * X(double) , 1C * Y(double) , 1C * Z(double) ] , 1C * Mass(float) , 1C * "
+           "Vel[ 1C * X(double) , 1C * Y(double) , 1C * "
+           "Z(double) ] , 1C * Flags[ 1C * (bool) , 1C * (bool) , 1C * (bool) , 1C * (bool) ] ] ]");
     CHECK(
         tree::toString(mapping.resultTree)
-        == "16R * [ 2R * [ 1R * Pos[ 8R * X(double) , 8R * Y(double) , 8R * Z(double) ] , 8R * Weight(float) , "
-           "1R * Momentum[ 8R * Z(double) , 8R * Y(double) , 8R * X(double) ] , 8R * Flags[ 1C * (bool) , 1C * (bool) "
+        == "16R * [ 2R * [ 1R * Pos[ 8R * X(double) , 8R * Y(double) , 8R * Z(double) ] , 8R * Mass(float) , "
+           "1R * Vel[ 8R * X(double) , 8R * Y(double) , 8R * Z(double) ] , 8R * Flags[ 1C * (bool) , 1C * (bool) "
            ", 1C * (bool) , 1C * (bool) ] ] ]");
 
     CHECK(mapping.blobSize(0) == 14336);
@@ -736,7 +709,7 @@ TEST_CASE("treemapping.getNode")
     const ArrayDims arrayDims{16, 16};
 
     auto treeOperationList = llama::Tuple{};
-    using Mapping = tree::Mapping<ArrayDims, Name, decltype(treeOperationList)>;
+    using Mapping = tree::Mapping<ArrayDims, Particle, decltype(treeOperationList)>;
     const Mapping mapping(arrayDims, treeOperationList);
 
     using namespace tree;
@@ -744,13 +717,13 @@ TEST_CASE("treemapping.getNode")
 
     CHECK(
         toString(getNode<TreeCoord<>>(mapping.resultTree))
-        == "16R * [ 16R * [ 1C * Pos[ 1C * X(double) , 1C * Y(double) , 1C * Z(double) ] , 1C * Weight(float) "
-           ", 1C * Momentum[ 1C * Z(double) , 1C * Y(double) , 1C * X(double) ] , 1C * Flags[ 1C * (bool) , 1C * "
+        == "16R * [ 16R * [ 1C * Pos[ 1C * X(double) , 1C * Y(double) , 1C * Z(double) ] , 1C * Mass(float) "
+           ", 1C * Vel[ 1C * X(double) , 1C * Y(double) , 1C * Z(double) ] , 1C * Flags[ 1C * (bool) , 1C * "
            "(bool) , 1C * (bool) , 1C * (bool) ] ] ]");
     CHECK(
         toString(getNode<TreeCoord<0>>(mapping.resultTree))
-        == "16R * [ 1C * Pos[ 1C * X(double) , 1C * Y(double) , 1C * Z(double) ] , 1C * Weight(float) , 1C * "
-           "Momentum[ 1C * Z(double) , 1C * Y(double) , 1C * X(double) ] , 1C * Flags[ 1C * (bool) , 1C * (bool) , 1C "
+        == "16R * [ 1C * Pos[ 1C * X(double) , 1C * Y(double) , 1C * Z(double) ] , 1C * Mass(float) , 1C * "
+           "Vel[ 1C * X(double) , 1C * Y(double) , 1C * Z(double) ] , 1C * Flags[ 1C * (bool) , 1C * (bool) , 1C "
            "* (bool) , 1C * (bool) ] ]");
     CHECK(
         toString(getNode<TreeCoord<0, 0>>(mapping.resultTree))
@@ -758,13 +731,13 @@ TEST_CASE("treemapping.getNode")
     CHECK(toString(getNode<TreeCoord<0, 0, 0>>(mapping.resultTree)) == "1C * X(double)");
     CHECK(toString(getNode<TreeCoord<0, 0, 1>>(mapping.resultTree)) == "1C * Y(double)");
     CHECK(toString(getNode<TreeCoord<0, 0, 2>>(mapping.resultTree)) == "1C * Z(double)");
-    CHECK(toString(getNode<TreeCoord<0, 1>>(mapping.resultTree)) == "1C * Weight(float)");
+    CHECK(toString(getNode<TreeCoord<0, 1>>(mapping.resultTree)) == "1C * Mass(float)");
     CHECK(
         toString(getNode<TreeCoord<0, 2>>(mapping.resultTree))
-        == "1C * Momentum[ 1C * Z(double) , 1C * Y(double) , 1C * X(double) ]");
-    CHECK(toString(getNode<TreeCoord<0, 2, 0>>(mapping.resultTree)) == "1C * Z(double)");
+        == "1C * Vel[ 1C * X(double) , 1C * Y(double) , 1C * Z(double) ]");
+    CHECK(toString(getNode<TreeCoord<0, 2, 0>>(mapping.resultTree)) == "1C * X(double)");
     CHECK(toString(getNode<TreeCoord<0, 2, 1>>(mapping.resultTree)) == "1C * Y(double)");
-    CHECK(toString(getNode<TreeCoord<0, 2, 2>>(mapping.resultTree)) == "1C * X(double)");
+    CHECK(toString(getNode<TreeCoord<0, 2, 2>>(mapping.resultTree)) == "1C * Z(double)");
     CHECK(
         toString(getNode<TreeCoord<0, 3>>(mapping.resultTree))
         == "1C * Flags[ 1C * (bool) , 1C * (bool) , 1C * (bool) , 1C * (bool) ]");
@@ -783,7 +756,7 @@ TEST_CASE("treemapping")
 
     auto treeOperationList = llama::Tuple{tree::functor::Idem(), tree::functor::LeafOnlyRT{}, tree::functor::Idem{}};
 
-    using Mapping = tree::Mapping<ArrayDims, Name, decltype(treeOperationList)>;
+    using Mapping = tree::Mapping<ArrayDims, Particle, decltype(treeOperationList)>;
     const Mapping mapping(arrayDims, treeOperationList);
 
     auto raw = prettyPrintType(mapping.basicTree);
@@ -830,7 +803,7 @@ TEST_CASE("treemapping")
                     >
                 >,
                 llama::mapping::tree::Leaf<
-                    tag::Weight,
+                    tag::Mass,
                     float,
                     std::integral_constant<
                         unsigned long,
@@ -838,10 +811,10 @@ TEST_CASE("treemapping")
                     >
                 >,
                 llama::mapping::tree::Node<
-                    tag::Momentum,
+                    tag::Vel,
                     llama::Tuple<
                         llama::mapping::tree::Leaf<
-                            tag::Z,
+                            tag::X,
                             double,
                             std::integral_constant<
                                 unsigned long,
@@ -857,7 +830,7 @@ TEST_CASE("treemapping")
                             >
                         >,
                         llama::mapping::tree::Leaf<
-                            tag::X,
+                            tag::Z,
                             double,
                             std::integral_constant<
                                 unsigned long,
@@ -962,15 +935,15 @@ TEST_CASE("treemapping")
                     >
                 >,
                 llama::mapping::tree::Leaf<
-                    tag::Weight,
+                    tag::Mass,
                     float,
                     unsigned long
                 >,
                 llama::mapping::tree::Node<
-                    tag::Momentum,
+                    tag::Vel,
                     llama::Tuple<
                         llama::mapping::tree::Leaf<
-                            tag::Z,
+                            tag::X,
                             double,
                             unsigned long
                         >,
@@ -980,7 +953,7 @@ TEST_CASE("treemapping")
                             unsigned long
                         >,
                         llama::mapping::tree::Leaf<
-                            tag::X,
+                            tag::Z,
                             double,
                             unsigned long
                         >
@@ -1043,13 +1016,13 @@ TEST_CASE("treemapping")
 
     CHECK(
         tree::toString(mapping.basicTree)
-        == "12R * [ 12R * [ 1C * Pos[ 1C * X(double) , 1C * Y(double) , 1C * Z(double) ] , 1C * Weight(float) , 1C * "
-           "Momentum[ 1C * Z(double) , 1C * Y(double) , 1C * "
-           "X(double) ] , 1C * Flags[ 1C * (bool) , 1C * (bool) , 1C * (bool) , 1C * (bool) ] ] ]");
+        == "12R * [ 12R * [ 1C * Pos[ 1C * X(double) , 1C * Y(double) , 1C * Z(double) ] , 1C * Mass(float) , 1C * "
+           "Vel[ 1C * X(double) , 1C * Y(double) , 1C * "
+           "Z(double) ] , 1C * Flags[ 1C * (bool) , 1C * (bool) , 1C * (bool) , 1C * (bool) ] ] ]");
     CHECK(
         tree::toString(mapping.resultTree)
-        == "1C * [ 1C * [ 1C * Pos[ 144R * X(double) , 144R * Y(double) , 144R * Z(double) ] , 144R * Weight(float) , "
-           "1C * Momentum[ 144R * Z(double) , 144R * Y(double) , 144R * X(double) ] , 1C * Flags[ 144R * (bool) , 144R "
+        == "1C * [ 1C * [ 1C * Pos[ 144R * X(double) , 144R * Y(double) , 144R * Z(double) ] , 144R * Mass(float) , "
+           "1C * Vel[ 144R * X(double) , 144R * Y(double) , 144R * Z(double) ] , 1C * Flags[ 144R * (bool) , 144R "
            "* (bool) , 144R * (bool) , 144R * (bool) ] ] ]");
 
     CHECK(mapping.blobSize(0) == 8064);
@@ -1063,7 +1036,7 @@ TEST_CASE("treemapping")
         for (size_t y = 0; y < arrayDims[1]; ++y)
         {
             auto record = view(x, y);
-            llama::forEachLeaf<Name>([&](auto coord) { record(coord) = 0; }, tag::Momentum{});
+            llama::forEachLeaf<Particle>([&](auto coord) { record(coord) = 0; }, tag::Vel{});
         }
     double sum = 0.0;
     for (size_t x = 0; x < arrayDims[0]; ++x)

--- a/tests/virtualrecord.cpp
+++ b/tests/virtualrecord.cpp
@@ -6,33 +6,35 @@
 #include <sstream>
 #include <vector>
 
-// clang-format off
-namespace tag {
-    struct Pos {};
-    struct Vel {};
-    struct A {};
-    struct X {};
-    struct Y {};
-    struct Z {};
-    struct Weight {};
-    struct Part1 {};
-    struct Part2 {};
-} // namespace tag
+namespace
+{
+    // clang-format off
+    using ParticleInt = llama::Record<
+        llama::Field<tag::Pos, llama::Record<
+            llama::Field<tag::A, int>,
+            llama::Field<tag::Y, int>
+        >>,
+        llama::Field<tag::Vel, Vec3I>,
+        llama::Field<tag::Mass, int>
+    >;
+    // clang-format on
 
-using Particle = llama::Record<
-    llama::Field<tag::Pos, llama::Record<
-        llama::Field<tag::A, int>,
-        llama::Field<tag::Y, int>>>,
-    llama::Field<tag::Vel, llama::Record<
-        llama::Field<tag::X, int>,
-        llama::Field<tag::Y, int>,
-        llama::Field<tag::Z, int>>>,
-    llama::Field<tag::Weight, int>>;
-// clang-format on
+    auto oneParticleInt()
+    {
+        llama::One<ParticleInt> record;
+        record(tag::Pos{}, tag::A{}) = 1;
+        record(tag::Pos{}, tag::Y{}) = 2;
+        record(tag::Vel{}, tag::X{}) = 3;
+        record(tag::Vel{}, tag::Y{}) = 4;
+        record(tag::Vel{}, tag::Z{}) = 5;
+        record(tag::Mass{}) = 6;
+        return record;
+    }
+} // namespace
 
 TEST_CASE("VirtualRecord.operator=")
 {
-    llama::One<Particle> record;
+    llama::One<ParticleInt> record;
 
     // scalar to multiple elements in virtual record
     record(tag::Pos{}) = 1;
@@ -41,7 +43,7 @@ TEST_CASE("VirtualRecord.operator=")
     CHECK(record(tag::Vel{}, tag::X{}) == 0);
     CHECK(record(tag::Vel{}, tag::Y{}) == 0);
     CHECK(record(tag::Vel{}, tag::Z{}) == 0);
-    CHECK(record(tag::Weight{}) == 0);
+    CHECK(record(tag::Mass{}) == 0);
 
     // scalar to multiple elements in virtual record
     record = 2;
@@ -50,7 +52,7 @@ TEST_CASE("VirtualRecord.operator=")
     CHECK(record(tag::Vel{}, tag::X{}) == 2);
     CHECK(record(tag::Vel{}, tag::Y{}) == 2);
     CHECK(record(tag::Vel{}, tag::Z{}) == 2);
-    CHECK(record(tag::Weight{}) == 2);
+    CHECK(record(tag::Mass{}) == 2);
 
     // smaller virtual record to larger virtual record
     record(tag::Pos{}) = 3;
@@ -60,7 +62,7 @@ TEST_CASE("VirtualRecord.operator=")
     CHECK(record(tag::Vel{}, tag::X{}) == 2);
     CHECK(record(tag::Vel{}, tag::Y{}) == 3); // only Y is propagated
     CHECK(record(tag::Vel{}, tag::Z{}) == 2);
-    CHECK(record(tag::Weight{}) == 2);
+    CHECK(record(tag::Mass{}) == 2);
 
     // larger virtual record to smaller virtual record
     record(tag::Vel{}) = 4;
@@ -70,56 +72,41 @@ TEST_CASE("VirtualRecord.operator=")
     CHECK(record(tag::Vel{}, tag::X{}) == 4);
     CHECK(record(tag::Vel{}, tag::Y{}) == 4);
     CHECK(record(tag::Vel{}, tag::Z{}) == 4);
-    CHECK(record(tag::Weight{}) == 2);
+    CHECK(record(tag::Mass{}) == 2);
 
     // scalar virtual record to larger virtual record, full broadcast
-    record(tag::Weight{}) = 5;
-    record(tag::Vel{}) = record(tag::Weight{});
+    record(tag::Mass{}) = 5;
+    record(tag::Vel{}) = record(tag::Mass{});
     CHECK(record(tag::Pos{}, tag::A{}) == 3);
     CHECK(record(tag::Pos{}, tag::Y{}) == 4);
     CHECK(record(tag::Vel{}, tag::X{}) == 5); // updated
     CHECK(record(tag::Vel{}, tag::Y{}) == 5); // updated
     CHECK(record(tag::Vel{}, tag::Z{}) == 5); // updated
-    CHECK(record(tag::Weight{}) == 5);
+    CHECK(record(tag::Mass{}) == 5);
 }
-
-namespace
-{
-    auto oneParticle()
-    {
-        llama::One<Particle> record;
-        record(tag::Pos{}, tag::A{}) = 1;
-        record(tag::Pos{}, tag::Y{}) = 2;
-        record(tag::Vel{}, tag::X{}) = 3;
-        record(tag::Vel{}, tag::Y{}) = 4;
-        record(tag::Vel{}, tag::Z{}) = 5;
-        record(tag::Weight{}) = 6;
-        return record;
-    }
-} // namespace
 
 TEST_CASE("VirtualRecord.operator+=.scalar")
 {
     {
-        auto record = oneParticle();
+        auto record = oneParticleInt();
         record(tag::Pos{}) += 1;
         CHECK(record(tag::Pos{}, tag::A{}) == 2);
         CHECK(record(tag::Pos{}, tag::Y{}) == 3);
         CHECK(record(tag::Vel{}, tag::X{}) == 3);
         CHECK(record(tag::Vel{}, tag::Y{}) == 4);
         CHECK(record(tag::Vel{}, tag::Z{}) == 5);
-        CHECK(record(tag::Weight{}) == 6);
+        CHECK(record(tag::Mass{}) == 6);
     }
 
     {
-        auto record = oneParticle();
+        auto record = oneParticleInt();
         record += 1;
         CHECK(record(tag::Pos{}, tag::A{}) == 2);
         CHECK(record(tag::Pos{}, tag::Y{}) == 3);
         CHECK(record(tag::Vel{}, tag::X{}) == 4);
         CHECK(record(tag::Vel{}, tag::Y{}) == 5);
         CHECK(record(tag::Vel{}, tag::Z{}) == 6);
-        CHECK(record(tag::Weight{}) == 7);
+        CHECK(record(tag::Mass{}) == 7);
     }
 }
 
@@ -127,83 +114,83 @@ TEST_CASE("VirtualRecord.operator+=.VirtualRecord")
 {
     {
         // smaller virtual record to larger virtual record
-        auto record = oneParticle();
+        auto record = oneParticleInt();
         record(tag::Vel{}) += record(tag::Pos{});
         CHECK(record(tag::Pos{}, tag::A{}) == 1);
         CHECK(record(tag::Pos{}, tag::Y{}) == 2);
         CHECK(record(tag::Vel{}, tag::X{}) == 3);
         CHECK(record(tag::Vel{}, tag::Y{}) == 6);
         CHECK(record(tag::Vel{}, tag::Z{}) == 5);
-        CHECK(record(tag::Weight{}) == 6);
+        CHECK(record(tag::Mass{}) == 6);
     }
 
     {
         // larger virtual record to smaller virtual record
-        auto record = oneParticle();
+        auto record = oneParticleInt();
         record(tag::Pos{}) += record(tag::Vel{});
         CHECK(record(tag::Pos{}, tag::A{}) == 1);
         CHECK(record(tag::Pos{}, tag::Y{}) == 6);
         CHECK(record(tag::Vel{}, tag::X{}) == 3);
         CHECK(record(tag::Vel{}, tag::Y{}) == 4);
         CHECK(record(tag::Vel{}, tag::Z{}) == 5);
-        CHECK(record(tag::Weight{}) == 6);
+        CHECK(record(tag::Mass{}) == 6);
     }
 
     {
         // scalar virtual record to larger virtual record, full broadcast
-        auto record = oneParticle();
-        record(tag::Vel{}) += record(tag::Weight{});
+        auto record = oneParticleInt();
+        record(tag::Vel{}) += record(tag::Mass{});
         CHECK(record(tag::Pos{}, tag::A{}) == 1);
         CHECK(record(tag::Pos{}, tag::Y{}) == 2);
         CHECK(record(tag::Vel{}, tag::X{}) == 9);
         CHECK(record(tag::Vel{}, tag::Y{}) == 10);
         CHECK(record(tag::Vel{}, tag::Z{}) == 11);
-        CHECK(record(tag::Weight{}) == 6);
+        CHECK(record(tag::Mass{}) == 6);
     }
 }
 
 TEST_CASE("VirtualRecord.operator+.scalar")
 {
     {
-        auto record = oneParticle();
+        auto record = oneParticleInt();
         record(tag::Pos{}) = record(tag::Pos{}) + 1;
         CHECK(record(tag::Pos{}, tag::A{}) == 2);
         CHECK(record(tag::Pos{}, tag::Y{}) == 3);
         CHECK(record(tag::Vel{}, tag::X{}) == 3);
         CHECK(record(tag::Vel{}, tag::Y{}) == 4);
         CHECK(record(tag::Vel{}, tag::Z{}) == 5);
-        CHECK(record(tag::Weight{}) == 6);
+        CHECK(record(tag::Mass{}) == 6);
     }
     {
-        auto record = oneParticle();
+        auto record = oneParticleInt();
         record(tag::Pos{}) = 1 + record(tag::Pos{});
         CHECK(record(tag::Pos{}, tag::A{}) == 2);
         CHECK(record(tag::Pos{}, tag::Y{}) == 3);
         CHECK(record(tag::Vel{}, tag::X{}) == 3);
         CHECK(record(tag::Vel{}, tag::Y{}) == 4);
         CHECK(record(tag::Vel{}, tag::Z{}) == 5);
-        CHECK(record(tag::Weight{}) == 6);
+        CHECK(record(tag::Mass{}) == 6);
     }
 
     {
-        auto record = oneParticle();
+        auto record = oneParticleInt();
         record = record + 1;
         CHECK(record(tag::Pos{}, tag::A{}) == 2);
         CHECK(record(tag::Pos{}, tag::Y{}) == 3);
         CHECK(record(tag::Vel{}, tag::X{}) == 4);
         CHECK(record(tag::Vel{}, tag::Y{}) == 5);
         CHECK(record(tag::Vel{}, tag::Z{}) == 6);
-        CHECK(record(tag::Weight{}) == 7);
+        CHECK(record(tag::Mass{}) == 7);
     }
     {
-        auto record = oneParticle();
+        auto record = oneParticleInt();
         record = 1 + record;
         CHECK(record(tag::Pos{}, tag::A{}) == 2);
         CHECK(record(tag::Pos{}, tag::Y{}) == 3);
         CHECK(record(tag::Vel{}, tag::X{}) == 4);
         CHECK(record(tag::Vel{}, tag::Y{}) == 5);
         CHECK(record(tag::Vel{}, tag::Z{}) == 6);
-        CHECK(record(tag::Weight{}) == 7);
+        CHECK(record(tag::Mass{}) == 7);
     }
 }
 
@@ -211,85 +198,88 @@ TEST_CASE("VirtualRecord.operator+.VirtualRecord")
 {
     {
         // smaller virtual record to larger virtual record
-        auto record = oneParticle();
+        auto record = oneParticleInt();
         record(tag::Vel{}) = record(tag::Vel{}) + record(tag::Pos{});
         CHECK(record(tag::Pos{}, tag::A{}) == 1);
         CHECK(record(tag::Pos{}, tag::Y{}) == 2);
         CHECK(record(tag::Vel{}, tag::X{}) == 3);
         CHECK(record(tag::Vel{}, tag::Y{}) == 6);
         CHECK(record(tag::Vel{}, tag::Z{}) == 5);
-        CHECK(record(tag::Weight{}) == 6);
+        CHECK(record(tag::Mass{}) == 6);
     }
 
     {
         // larger virtual record to smaller virtual record
-        auto record = oneParticle();
+        auto record = oneParticleInt();
         record(tag::Pos{}) = record(tag::Pos{}) + record(tag::Vel{});
         CHECK(record(tag::Pos{}, tag::A{}) == 1);
         CHECK(record(tag::Pos{}, tag::Y{}) == 6);
         CHECK(record(tag::Vel{}, tag::X{}) == 3);
         CHECK(record(tag::Vel{}, tag::Y{}) == 4);
         CHECK(record(tag::Vel{}, tag::Z{}) == 5);
-        CHECK(record(tag::Weight{}) == 6);
+        CHECK(record(tag::Mass{}) == 6);
     }
 
     {
         // scalar virtual record to larger virtual record, full broadcast
-        auto record = oneParticle();
-        record(tag::Vel{}) = record(tag::Vel{}) + record(tag::Weight{});
+        auto record = oneParticleInt();
+        record(tag::Vel{}) = record(tag::Vel{}) + record(tag::Mass{});
         CHECK(record(tag::Pos{}, tag::A{}) == 1);
         CHECK(record(tag::Pos{}, tag::Y{}) == 2);
         CHECK(record(tag::Vel{}, tag::X{}) == 9);
         CHECK(record(tag::Vel{}, tag::Y{}) == 10);
         CHECK(record(tag::Vel{}, tag::Z{}) == 11);
-        CHECK(record(tag::Weight{}) == 6);
+        CHECK(record(tag::Mass{}) == 6);
     }
 }
 
-// clang-format off
-using Name2 = llama::Record<
-    llama::Field<tag::Part1, llama::Record<
-        llama::Field<tag::Weight, int>,
-        llama::Field<tag::Pos, llama::Record<
-            llama::Field<tag::X, int>,
-            llama::Field<tag::Y, int>,
+namespace
+{
+    // clang-format off
+    using RecordDim2 = llama::Record<
+        llama::Field<tag::Part1, llama::Record<
+            llama::Field<tag::Mass, int>,
+            llama::Field<tag::Pos, llama::Record<
+                llama::Field<tag::X, int>,
+                llama::Field<tag::Y, int>,
+                llama::Field<tag::Z, int>
+            >>
+        >>,
+        llama::Field<tag::Part2, llama::Record<
+            llama::Field<tag::Mass, int>,
+            llama::Field<tag::Pos, llama::Record<
+                llama::Field<tag::X, int>,
+                llama::Field<tag::Y, int>,
+                llama::Field<tag::A, int>
+            >>,
             llama::Field<tag::Z, int>
         >>
-    >>,
-    llama::Field<tag::Part2, llama::Record<
-        llama::Field<tag::Weight, int>,
-        llama::Field<tag::Pos, llama::Record<
-            llama::Field<tag::X, int>,
-            llama::Field<tag::Y, int>,
-            llama::Field<tag::A, int>
-        >>,
-        llama::Field<tag::Z, int>
-    >>
->;
-// clang-format on
+    >;
+    // clang-format on
+} // namespace
 
 TEST_CASE("VirtualRecord.operator=.propagation")
 {
-    llama::One<Name2> record;
+    llama::One<RecordDim2> record;
 
     record(tag::Part1{}) = 1;
     record(tag::Part2{}) = 2;
-    CHECK(record(tag::Part1{}, tag::Weight{}) == 1);
+    CHECK(record(tag::Part1{}, tag::Mass{}) == 1);
     CHECK(record(tag::Part1{}, tag::Pos{}, tag::X{}) == 1);
     CHECK(record(tag::Part1{}, tag::Pos{}, tag::Y{}) == 1);
     CHECK(record(tag::Part1{}, tag::Pos{}, tag::Z{}) == 1);
-    CHECK(record(tag::Part2{}, tag::Weight{}) == 2);
+    CHECK(record(tag::Part2{}, tag::Mass{}) == 2);
     CHECK(record(tag::Part2{}, tag::Pos{}, tag::X{}) == 2);
     CHECK(record(tag::Part2{}, tag::Pos{}, tag::Y{}) == 2);
     CHECK(record(tag::Part2{}, tag::Pos{}, tag::A{}) == 2);
     CHECK(record(tag::Part2{}, tag::Z{}) == 2);
 
     record(tag::Part2{}) = record(tag::Part1{});
-    CHECK(record(tag::Part1{}, tag::Weight{}) == 1);
+    CHECK(record(tag::Part1{}, tag::Mass{}) == 1);
     CHECK(record(tag::Part1{}, tag::Pos{}, tag::X{}) == 1);
     CHECK(record(tag::Part1{}, tag::Pos{}, tag::Y{}) == 1);
     CHECK(record(tag::Part1{}, tag::Pos{}, tag::Z{}) == 1);
-    CHECK(record(tag::Part2{}, tag::Weight{}) == 1); // propagated
+    CHECK(record(tag::Part2{}, tag::Mass{}) == 1); // propagated
     CHECK(record(tag::Part2{}, tag::Pos{}, tag::X{}) == 1); // propagated
     CHECK(record(tag::Part2{}, tag::Pos{}, tag::Y{}) == 1); // propagated
     CHECK(record(tag::Part2{}, tag::Pos{}, tag::A{}) == 2);
@@ -298,8 +288,8 @@ TEST_CASE("VirtualRecord.operator=.propagation")
 
 TEST_CASE("VirtualRecord.operator=.multiview")
 {
-    llama::One<Particle> record1;
-    llama::One<Name2> record2;
+    llama::One<ParticleInt> record1;
+    llama::One<RecordDim2> record2;
 
     record2 = 1;
     record1 = record2;
@@ -308,7 +298,7 @@ TEST_CASE("VirtualRecord.operator=.multiview")
     CHECK(record1(tag::Vel{}, tag::X{}) == 0);
     CHECK(record1(tag::Vel{}, tag::Y{}) == 0);
     CHECK(record1(tag::Vel{}, tag::Z{}) == 0);
-    CHECK(record1(tag::Weight{}) == 0);
+    CHECK(record1(tag::Mass{}) == 0);
 
     record1 = record2(tag::Part1{});
     CHECK(record1(tag::Pos{}, tag::A{}) == 0);
@@ -316,12 +306,12 @@ TEST_CASE("VirtualRecord.operator=.multiview")
     CHECK(record1(tag::Vel{}, tag::X{}) == 0);
     CHECK(record1(tag::Vel{}, tag::Y{}) == 0);
     CHECK(record1(tag::Vel{}, tag::Z{}) == 0);
-    CHECK(record1(tag::Weight{}) == 1);
+    CHECK(record1(tag::Mass{}) == 1);
 }
 
 TEST_CASE("VirtualRecord.operator==")
 {
-    llama::One<Particle> record;
+    llama::One<ParticleInt> record;
 
     record = 1;
 
@@ -345,7 +335,7 @@ TEST_CASE("VirtualRecord.operator==")
 
 TEST_CASE("VirtualRecord.operator<")
 {
-    llama::One<Particle> record;
+    llama::One<ParticleInt> record;
 
     record = 1;
 
@@ -383,7 +373,7 @@ TEST_CASE("VirtualRecord.operator<")
 TEST_CASE("VirtualRecord.asTuple.types")
 {
     {
-        llama::One<Particle> record;
+        llama::One<ParticleInt> record;
 
         std::tuple<int&, int&> pos = record(tag::Pos{}).asTuple();
         std::tuple<int&, int&, int&> vel = record(tag::Vel{}).asTuple();
@@ -393,7 +383,7 @@ TEST_CASE("VirtualRecord.asTuple.types")
         static_cast<void>(name);
     }
     {
-        const llama::One<Particle> record;
+        const llama::One<ParticleInt> record;
 
         std::tuple<const int&, const int&> pos = record(tag::Pos{}).asTuple();
         std::tuple<const int&, const int&, const int&> vel = record(tag::Vel{}).asTuple();
@@ -407,7 +397,7 @@ TEST_CASE("VirtualRecord.asTuple.types")
 
 TEST_CASE("VirtualRecord.asTuple.assign")
 {
-    llama::One<Particle> record;
+    llama::One<ParticleInt> record;
 
     record(tag::Pos{}).asTuple() = std::tuple{1, 1};
     CHECK(record(tag::Pos{}, tag::A{}) == 1);
@@ -415,7 +405,7 @@ TEST_CASE("VirtualRecord.asTuple.assign")
     CHECK(record(tag::Vel{}, tag::X{}) == 0);
     CHECK(record(tag::Vel{}, tag::Y{}) == 0);
     CHECK(record(tag::Vel{}, tag::Z{}) == 0);
-    CHECK(record(tag::Weight{}) == 0);
+    CHECK(record(tag::Mass{}) == 0);
 
     record(tag::Vel{}).asTuple() = std::tuple{2, 2, 2};
     CHECK(record(tag::Pos{}, tag::A{}) == 1);
@@ -423,7 +413,7 @@ TEST_CASE("VirtualRecord.asTuple.assign")
     CHECK(record(tag::Vel{}, tag::X{}) == 2);
     CHECK(record(tag::Vel{}, tag::Y{}) == 2);
     CHECK(record(tag::Vel{}, tag::Z{}) == 2);
-    CHECK(record(tag::Weight{}) == 0);
+    CHECK(record(tag::Mass{}) == 0);
 
     record.asTuple() = std::tuple{std::tuple{3, 3}, std::tuple{3, 3, 3}, 3};
     CHECK(record(tag::Pos{}, tag::A{}) == 3);
@@ -431,12 +421,12 @@ TEST_CASE("VirtualRecord.asTuple.assign")
     CHECK(record(tag::Vel{}, tag::X{}) == 3);
     CHECK(record(tag::Vel{}, tag::Y{}) == 3);
     CHECK(record(tag::Vel{}, tag::Z{}) == 3);
-    CHECK(record(tag::Weight{}) == 3);
+    CHECK(record(tag::Mass{}) == 3);
 }
 
 TEST_CASE("VirtualRecord.asTuple.structuredBindings")
 {
-    llama::One<Particle> record;
+    llama::One<ParticleInt> record;
 
     {
         auto [a, y] = record(tag::Pos{}).asTuple(); // NOLINT (clang-analyzer-deadcode.DeadStores)
@@ -447,7 +437,7 @@ TEST_CASE("VirtualRecord.asTuple.structuredBindings")
         CHECK(record(tag::Vel{}, tag::X{}) == 0);
         CHECK(record(tag::Vel{}, tag::Y{}) == 0);
         CHECK(record(tag::Vel{}, tag::Z{}) == 0);
-        CHECK(record(tag::Weight{}) == 0);
+        CHECK(record(tag::Mass{}) == 0);
     }
 
     {
@@ -460,7 +450,7 @@ TEST_CASE("VirtualRecord.asTuple.structuredBindings")
         CHECK(record(tag::Vel{}, tag::X{}) == 3);
         CHECK(record(tag::Vel{}, tag::Y{}) == 4);
         CHECK(record(tag::Vel{}, tag::Z{}) == 5);
-        CHECK(record(tag::Weight{}) == 0);
+        CHECK(record(tag::Mass{}) == 0);
     }
 
     {
@@ -478,7 +468,7 @@ TEST_CASE("VirtualRecord.asTuple.structuredBindings")
         CHECK(record(tag::Vel{}, tag::X{}) == 30);
         CHECK(record(tag::Vel{}, tag::Y{}) == 40);
         CHECK(record(tag::Vel{}, tag::Z{}) == 50);
-        CHECK(record(tag::Weight{}) == 60);
+        CHECK(record(tag::Mass{}) == 60);
     }
 }
 
@@ -486,7 +476,7 @@ TEST_CASE("VirtualRecord.asTuple.structuredBindings")
 TEST_CASE("VirtualRecord.asFlatTuple.types")
 {
     {
-        llama::One<Particle> record;
+        llama::One<ParticleInt> record;
 
         std::tuple<int&, int&> pos = record(tag::Pos{}).asFlatTuple();
         std::tuple<int&, int&, int&> vel = record(tag::Vel{}).asFlatTuple();
@@ -496,7 +486,7 @@ TEST_CASE("VirtualRecord.asFlatTuple.types")
         static_cast<void>(name);
     }
     {
-        const llama::One<Particle> record;
+        const llama::One<ParticleInt> record;
 
         std::tuple<const int&, const int&> pos = record(tag::Pos{}).asFlatTuple();
         std::tuple<const int&, const int&, const int&> vel = record(tag::Vel{}).asFlatTuple();
@@ -509,7 +499,7 @@ TEST_CASE("VirtualRecord.asFlatTuple.types")
 
 TEST_CASE("VirtualRecord.asFlatTuple.assign")
 {
-    llama::One<Particle> record;
+    llama::One<ParticleInt> record;
 
     record(tag::Pos{}).asFlatTuple() = std::tuple{1, 1};
     CHECK(record(tag::Pos{}, tag::A{}) == 1);
@@ -517,7 +507,7 @@ TEST_CASE("VirtualRecord.asFlatTuple.assign")
     CHECK(record(tag::Vel{}, tag::X{}) == 0);
     CHECK(record(tag::Vel{}, tag::Y{}) == 0);
     CHECK(record(tag::Vel{}, tag::Z{}) == 0);
-    CHECK(record(tag::Weight{}) == 0);
+    CHECK(record(tag::Mass{}) == 0);
 
     record(tag::Vel{}).asFlatTuple() = std::tuple{2, 2, 2};
     CHECK(record(tag::Pos{}, tag::A{}) == 1);
@@ -525,7 +515,7 @@ TEST_CASE("VirtualRecord.asFlatTuple.assign")
     CHECK(record(tag::Vel{}, tag::X{}) == 2);
     CHECK(record(tag::Vel{}, tag::Y{}) == 2);
     CHECK(record(tag::Vel{}, tag::Z{}) == 2);
-    CHECK(record(tag::Weight{}) == 0);
+    CHECK(record(tag::Mass{}) == 0);
 
     record.asFlatTuple() = std::tuple{3, 3, 3, 3, 3, 3};
     CHECK(record(tag::Pos{}, tag::A{}) == 3);
@@ -533,12 +523,12 @@ TEST_CASE("VirtualRecord.asFlatTuple.assign")
     CHECK(record(tag::Vel{}, tag::X{}) == 3);
     CHECK(record(tag::Vel{}, tag::Y{}) == 3);
     CHECK(record(tag::Vel{}, tag::Z{}) == 3);
-    CHECK(record(tag::Weight{}) == 3);
+    CHECK(record(tag::Mass{}) == 3);
 }
 
 TEST_CASE("VirtualRecord.asFlatTuple.structuredBindings")
 {
-    llama::One<Particle> record;
+    llama::One<ParticleInt> record;
 
     {
         auto [a, y] = record(tag::Pos{}).asFlatTuple(); // NOLINT (clang-analyzer-deadcode.DeadStores)
@@ -549,7 +539,7 @@ TEST_CASE("VirtualRecord.asFlatTuple.structuredBindings")
         CHECK(record(tag::Vel{}, tag::X{}) == 0);
         CHECK(record(tag::Vel{}, tag::Y{}) == 0);
         CHECK(record(tag::Vel{}, tag::Z{}) == 0);
-        CHECK(record(tag::Weight{}) == 0);
+        CHECK(record(tag::Mass{}) == 0);
     }
 
     {
@@ -562,7 +552,7 @@ TEST_CASE("VirtualRecord.asFlatTuple.structuredBindings")
         CHECK(record(tag::Vel{}, tag::X{}) == 3);
         CHECK(record(tag::Vel{}, tag::Y{}) == 4);
         CHECK(record(tag::Vel{}, tag::Z{}) == 5);
-        CHECK(record(tag::Weight{}) == 0);
+        CHECK(record(tag::Mass{}) == 0);
     }
 
     {
@@ -578,7 +568,7 @@ TEST_CASE("VirtualRecord.asFlatTuple.structuredBindings")
         CHECK(record(tag::Vel{}, tag::X{}) == 30);
         CHECK(record(tag::Vel{}, tag::Y{}) == 40);
         CHECK(record(tag::Vel{}, tag::Z{}) == 50);
-        CHECK(record(tag::Weight{}) == 60);
+        CHECK(record(tag::Mass{}) == 60);
     }
 }
 
@@ -587,7 +577,7 @@ struct S;
 
 TEST_CASE("VirtualRecord.structuredBindings")
 {
-    llama::One<Particle> record;
+    llama::One<ParticleInt> record;
 
     {
         auto&& [a, y] = record(tag::Pos{});
@@ -598,7 +588,7 @@ TEST_CASE("VirtualRecord.structuredBindings")
         CHECK(record(tag::Vel{}, tag::X{}) == 0);
         CHECK(record(tag::Vel{}, tag::Y{}) == 0);
         CHECK(record(tag::Vel{}, tag::Z{}) == 0);
-        CHECK(record(tag::Weight{}) == 0);
+        CHECK(record(tag::Mass{}) == 0);
     }
 
     {
@@ -611,7 +601,7 @@ TEST_CASE("VirtualRecord.structuredBindings")
         CHECK(record(tag::Vel{}, tag::X{}) == 3);
         CHECK(record(tag::Vel{}, tag::Y{}) == 4);
         CHECK(record(tag::Vel{}, tag::Z{}) == 5);
-        CHECK(record(tag::Weight{}) == 0);
+        CHECK(record(tag::Mass{}) == 0);
     }
 
     {
@@ -629,7 +619,7 @@ TEST_CASE("VirtualRecord.structuredBindings")
         CHECK(record(tag::Vel{}, tag::X{}) == 30);
         CHECK(record(tag::Vel{}, tag::Y{}) == 40);
         CHECK(record(tag::Vel{}, tag::Z{}) == 50);
-        CHECK(record(tag::Weight{}) == 60);
+        CHECK(record(tag::Mass{}) == 60);
     }
 }
 
@@ -710,7 +700,7 @@ struct std::tuple_size<MyStruct<T>>
 
 TEST_CASE("VirtualRecord.load.value")
 {
-    llama::One<Particle> record;
+    llama::One<ParticleInt> record;
     record = 1;
 
     {
@@ -746,7 +736,7 @@ TEST_CASE("VirtualRecord.load.value")
 
 TEST_CASE("VirtualRecord.load.ref")
 {
-    llama::One<Particle> record;
+    llama::One<ParticleInt> record;
 
     record = 1;
     {
@@ -761,7 +751,7 @@ TEST_CASE("VirtualRecord.load.ref")
         CHECK(record(tag::Vel{}, tag::X{}) == 1);
         CHECK(record(tag::Vel{}, tag::Y{}) == 1);
         CHECK(record(tag::Vel{}, tag::Z{}) == 1);
-        CHECK(record(tag::Weight{}) == 1);
+        CHECK(record(tag::Mass{}) == 1);
     }
 
     record = 1;
@@ -781,13 +771,13 @@ TEST_CASE("VirtualRecord.load.ref")
         CHECK(record(tag::Vel{}, tag::X{}) == 4);
         CHECK(record(tag::Vel{}, tag::Y{}) == 5);
         CHECK(record(tag::Vel{}, tag::Z{}) == 6);
-        CHECK(record(tag::Weight{}) == 7);
+        CHECK(record(tag::Mass{}) == 7);
     }
 }
 
 TEST_CASE("VirtualRecord.load.constref")
 {
-    llama::One<Particle> record;
+    llama::One<ParticleInt> record;
     record = 1;
 
     {
@@ -814,7 +804,7 @@ TEST_CASE("VirtualRecord.load.constref")
 
 TEST_CASE("VirtualRecord.store")
 {
-    llama::One<Particle> record;
+    llama::One<ParticleInt> record;
 
     record = 1;
     {
@@ -825,7 +815,7 @@ TEST_CASE("VirtualRecord.store")
         CHECK(record(tag::Vel{}, tag::X{}) == 1);
         CHECK(record(tag::Vel{}, tag::Y{}) == 1);
         CHECK(record(tag::Vel{}, tag::Z{}) == 1);
-        CHECK(record(tag::Weight{}) == 1);
+        CHECK(record(tag::Mass{}) == 1);
     }
 
     record = 1;
@@ -837,13 +827,13 @@ TEST_CASE("VirtualRecord.store")
         CHECK(record(tag::Vel{}, tag::X{}) == 4);
         CHECK(record(tag::Vel{}, tag::Y{}) == 5);
         CHECK(record(tag::Vel{}, tag::Z{}) == 6);
-        CHECK(record(tag::Weight{}) == 7);
+        CHECK(record(tag::Mass{}) == 7);
     }
 }
 
 TEST_CASE("VirtualRecord.loadAs.value")
 {
-    llama::One<Particle> record;
+    llama::One<ParticleInt> record;
     record = 1;
 
     {
@@ -860,7 +850,7 @@ TEST_CASE("VirtualRecord.loadAs.value")
 
 TEST_CASE("VirtualRecord.loadAs.ref")
 {
-    llama::One<Particle> record;
+    llama::One<ParticleInt> record;
     record = 1;
 
     auto pos = record(tag::Pos{}).loadAs<MyPos<int&>>();
@@ -874,12 +864,12 @@ TEST_CASE("VirtualRecord.loadAs.ref")
     CHECK(record(tag::Vel{}, tag::X{}) == 1);
     CHECK(record(tag::Vel{}, tag::Y{}) == 1);
     CHECK(record(tag::Vel{}, tag::Z{}) == 1);
-    CHECK(record(tag::Weight{}) == 1);
+    CHECK(record(tag::Mass{}) == 1);
 }
 
 TEST_CASE("VirtualRecord.loadAs.constref")
 {
-    llama::One<Particle> record;
+    llama::One<ParticleInt> record;
     record = 1;
 
     {
@@ -896,12 +886,12 @@ TEST_CASE("VirtualRecord.loadAs.constref")
 
 TEST_CASE("VirtualRecord.One_ctor_from_view")
 {
-    auto view = llama::allocView(llama::mapping::AoS{llama::ArrayDims{5}, Particle{}});
+    auto view = llama::allocView(llama::mapping::AoS{llama::ArrayDims{5}, ParticleInt{}});
     view(1u) = 1;
 
-    llama::One<Particle> vr2 = view(1u);
-    llama::One<Particle> vr3(view(1u));
-    llama::One<Particle> vr4{view(1u)};
+    llama::One<ParticleInt> vr2 = view(1u);
+    llama::One<ParticleInt> vr3(view(1u));
+    llama::One<ParticleInt> vr4{view(1u)};
 
     vr2 = 2;
     vr3 = 3;
@@ -915,12 +905,12 @@ TEST_CASE("VirtualRecord.One_ctor_from_view")
 
 TEST_CASE("VirtualRecord.One_range_for")
 {
-    auto view = llama::allocView(llama::mapping::AoS{llama::ArrayDims{5}, Particle{}});
+    auto view = llama::allocView(llama::mapping::AoS{llama::ArrayDims{5}, ParticleInt{}});
     for (auto p : view) // p is a reference object
         p = 1;
     CHECK(view(1u) == 1);
 
-    for (llama::One<Particle> p : view) // p is a copy
+    for (llama::One<ParticleInt> p : view) // p is a copy
         p = 2;
     CHECK(view(1u) == 1);
 }
@@ -928,49 +918,52 @@ TEST_CASE("VirtualRecord.One_range_for")
 TEST_CASE("VirtualRecord.One_concepts")
 {
 #ifdef __cpp_concepts
-    STATIC_REQUIRE(std::regular<llama::One<Particle>>);
+    STATIC_REQUIRE(std::regular<llama::One<ParticleInt>>);
 #endif
 }
 
 TEST_CASE("VirtualRecord.One_inside_std::vector")
 {
-    std::vector<llama::One<Particle>> v(2); // create 2 One
-    v.push_back(oneParticle()); // add 1 more
-    v[0](tag::Weight{}) = 20;
-    v[1](tag::Weight{}) = 30;
-    v[2](tag::Weight{}) = 10;
+    std::vector<llama::One<ParticleInt>> v(2); // create 2 One
+    v.push_back(oneParticleInt()); // add 1 more
+    v[0](tag::Mass{}) = 20;
+    v[1](tag::Mass{}) = 30;
+    v[2](tag::Mass{}) = 10;
     std::sort(
         std::begin(v),
         std::end(v),
-        [](const llama::One<Particle>& a, const llama::One<Particle>& b)
-        { return a(tag::Weight{}) < b(tag::Weight{}); });
-    CHECK(v[0](tag::Weight{}) == 10);
-    CHECK(v[1](tag::Weight{}) == 20);
-    CHECK(v[2](tag::Weight{}) == 30);
+        [](const llama::One<ParticleInt>& a, const llama::One<ParticleInt>& b)
+        { return a(tag::Mass{}) < b(tag::Mass{}); });
+    CHECK(v[0](tag::Mass{}) == 10);
+    CHECK(v[1](tag::Mass{}) == 20);
+    CHECK(v[2](tag::Mass{}) == 30);
 }
 
 TEST_CASE("VirtualRecord.One_from_scalar")
 {
-    llama::One<Particle> p{42};
+    llama::One<ParticleInt> p{42};
     CHECK(p(tag::Pos{}, tag::A{}) == 42);
     CHECK(p(tag::Pos{}, tag::Y{}) == 42);
     CHECK(p(tag::Vel{}, tag::X{}) == 42);
     CHECK(p(tag::Vel{}, tag::Y{}) == 42);
     CHECK(p(tag::Vel{}, tag::Z{}) == 42);
-    CHECK(p(tag::Weight{}) == 42);
+    CHECK(p(tag::Mass{}) == 42);
 }
 
 TEST_CASE("VirtualRecord.operator<<")
 {
-    auto p = oneParticle();
+    llama::One<Particle> p;
+    llama::forEachLeaf<Particle>([&, i = 0](auto coord) mutable { p(coord) = ++i; });
 
     std::stringstream ss;
     ss << p;
-    CHECK(ss.str() == "{Pos: {A: 1, Y: 2}, Vel: {X: 3, Y: 4, Z: 5}, Weight: 6}");
+    const auto expected
+        = "{Pos: {X: 1, Y: 2, Z: 3}, Mass: 4, Vel: {X: 5, Y: 6, Z: 7}, Flags: {[0]: 1, [1]: 1, [2]: 1, [3]: 1}}";
+    CHECK(ss.str() == expected);
 
     ss = {};
     auto view = llama::allocView(llama::mapping::AoS{llama::ArrayDims{1}, Particle{}});
     view(0u) = p;
     ss << view(0u);
-    CHECK(ss.str() == "{Pos: {A: 1, Y: 2}, Vel: {X: 3, Y: 4, Z: 5}, Weight: 6}");
+    CHECK(ss.str() == expected);
 }

--- a/tests/virtualview.cpp
+++ b/tests/virtualview.cpp
@@ -3,39 +3,13 @@
 #include <catch2/catch.hpp>
 #include <llama/llama.hpp>
 
-// clang-format off
-namespace tag
-{
-    struct X {};
-    struct Y {};
-    struct Z {};
-    struct Pos {};
-    struct Vel {};
-    struct Mom {};
-} // namespace tag
-
-using Particle = llama::Record<
-    llama::Field<tag::Pos, llama::Record<
-        llama::Field<tag::X, int>,
-        llama::Field<tag::Y, int>,
-        llama::Field<tag::Z, int>
-    >>,
-    llama::Field<tag::Mom, int>,
-    llama::Field<tag::Vel, llama::Record<
-        llama::Field<tag::Z, int>,
-        llama::Field<tag::Y, int>,
-        llama::Field<tag::X, int>
-    >>
->;
-// clang-format on
-
 template <typename VirtualRecord>
-struct SqrtFunctor
+struct DoubleFunctor
 {
     template <typename Coord>
     void operator()(Coord coord)
     {
-        vd(coord) *= std::sqrt(vd(coord));
+        vd(coord) *= 2;
     }
     VirtualRecord vd;
 };
@@ -109,7 +83,7 @@ TEST_CASE("virtual view")
             for (std::size_t a = 0; a < validMiniSize[0]; ++a)
                 for (std::size_t b = 0; b < validMiniSize[1]; ++b)
                 {
-                    SqrtFunctor<decltype(miniView(a, b))> sqrtF{miniView(a, b)};
+                    DoubleFunctor<decltype(miniView(a, b))> sqrtF{miniView(a, b)};
                     llama::forEachLeaf<Particle>(sqrtF);
                 }
 
@@ -120,5 +94,5 @@ TEST_CASE("virtual view")
 
     for (std::size_t x = 0; x < viewSize[0]; ++x)
         for (std::size_t y = 0; y < viewSize[1]; ++y)
-            CHECK((view(x, y) == x * y * std::sqrt(x * y)));
+            CHECK((view(x, y)) == x * y * 2);
 }

--- a/tests/virtualview.cpp
+++ b/tests/virtualview.cpp
@@ -17,16 +17,16 @@ struct DoubleFunctor
 TEST_CASE("virtual view CTAD")
 {
     using ArrayDims = llama::ArrayDims<2>;
-    constexpr ArrayDims viewSize{4096, 4096};
+    constexpr ArrayDims viewSize{10, 10};
     auto view = allocView(llama::mapping::SoA<ArrayDims, Particle>(viewSize));
 
-    llama::VirtualView virtualView{view, {23, 42}};
+    llama::VirtualView virtualView{view, {2, 4}};
 }
 
 TEST_CASE("fast virtual view")
 {
     using ArrayDims = llama::ArrayDims<2>;
-    constexpr ArrayDims viewSize{4096, 4096};
+    constexpr ArrayDims viewSize{10, 10};
 
     using Mapping = llama::mapping::SoA<ArrayDims, Particle>;
     auto view = allocView(Mapping(viewSize));
@@ -35,21 +35,21 @@ TEST_CASE("fast virtual view")
         for (std::size_t y = 0; y < viewSize[1]; ++y)
             view(x, y) = x * y;
 
-    llama::VirtualView<decltype(view)> virtualView{view, {23, 42}};
+    llama::VirtualView<decltype(view)> virtualView{view, {2, 4}};
 
-    CHECK(virtualView.offset == ArrayDims{23, 42});
+    CHECK(virtualView.offset == ArrayDims{2, 4});
 
-    CHECK(view(virtualView.offset)(tag::Pos(), tag::X()) == 966);
-    CHECK(virtualView({0, 0})(tag::Pos(), tag::X()) == 966);
+    CHECK(view(virtualView.offset)(tag::Pos(), tag::X()) == 8.0);
+    CHECK(virtualView({0, 0})(tag::Pos(), tag::X()) == 8.0);
 
-    CHECK(view({virtualView.offset[0] + 2, virtualView.offset[1] + 3})(tag::Vel(), tag::Z()) == 1125);
-    CHECK(virtualView({2, 3})(tag::Vel(), tag::Z()) == 1125);
+    CHECK(view({virtualView.offset[0] + 2, virtualView.offset[1] + 3})(tag::Vel(), tag::Z()) == 28.0);
+    CHECK(virtualView({2, 3})(tag::Vel(), tag::Z()) == 28.0);
 }
 
 TEST_CASE("virtual view")
 {
     using ArrayDims = llama::ArrayDims<2>;
-    constexpr ArrayDims viewSize{256, 256};
+    constexpr ArrayDims viewSize{32, 32};
     constexpr ArrayDims miniSize{8, 8};
     using Mapping = llama::mapping::SoA<ArrayDims, Particle>;
     auto view = allocView(Mapping(viewSize));


### PR DESCRIPTION
This PR tries to unify the many different record dimensions used in the unit tests.

A few bugs were found and fixed on the way:
* fix outdated wording in error message
* allow `prettyPrintType` to be used without an argument
* fix virtual record put operator not supporting arrays
* rename `fieldCount[Before]` into `flatFieldCount[Before]`, because it counts recursively through the structure hierarchy

Furthermore, the problem size for the `VirtualView` has been reduced to improve test execution time.