### PR TITLE
add Vector, a 1D container

### DIFF
--- a/include/llama/ArrayDimsIndexRange.hpp
+++ b/include/llama/ArrayDimsIndexRange.hpp
@@ -222,7 +222,7 @@ namespace llama
         }
 
     private:
-        ArrayDims<Dim> size;
+        ArrayDims<Dim> size; // TODO: we only need to store Dim - 1 sizes
         ArrayDims<Dim> current;
     };
 

--- a/include/llama/Vector.hpp
+++ b/include/llama/Vector.hpp
@@ -1,0 +1,305 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#pragma once
+
+#include "View.hpp"
+#include "VirtualRecord.hpp"
+
+#include <algorithm>
+#include <stdexcept>
+#include <string>
+
+namespace llama
+{
+    // TODO: expose blob allocator
+    /// An equivalent of std::vector<T> backed by a \ref View. Elements are never value initialized though. No strong
+    /// exception guarantee.
+    /// WARNING: This class is experimental.
+    /// @tparam Mapping The mapping to be used for the underlying view. Needs to have 1 array dimension.
+    template <typename Mapping>
+    struct Vector
+    {
+        static_assert(Mapping::ArrayDims::rank == 1, "llama::Vector only supports 1D mappings");
+
+        using ViewType = decltype(allocView<Mapping>());
+        using RecordDim = typename Mapping::RecordDim;
+
+        using iterator = decltype(std::declval<ViewType>().begin());
+        using value_type = typename iterator::value_type;
+
+        Vector() = default;
+
+        template <typename VirtualRecord = One<RecordDim>>
+        LLAMA_FN_HOST_ACC_INLINE explicit Vector(std::size_t count, const VirtualRecord& value = {})
+        {
+            reserve(count);
+            for (std::size_t i = 0; i < count; i++)
+                push_back(value);
+        }
+
+        template <typename Iterator>
+        LLAMA_FN_HOST_ACC_INLINE Vector(Iterator first, Iterator last)
+        {
+            if constexpr (std::is_same_v<
+                              typename std::iterator_traits<Iterator>::iterator_category,
+                              std::random_access_iterator_tag>)
+                reserve(std::distance(first, last));
+            for (; first != last; ++first)
+                push_back(*first);
+        }
+
+        LLAMA_FN_HOST_ACC_INLINE Vector(const Vector& other)
+        {
+            m_view = other.m_view; // we depend on the copy semantic of View here
+            m_size = other.m_size;
+        }
+
+        LLAMA_FN_HOST_ACC_INLINE Vector(Vector&& other) noexcept
+        {
+            swap(other);
+        }
+
+        LLAMA_FN_HOST_ACC_INLINE auto operator=(const Vector& other) -> Vector&
+        {
+            m_view = other.m_view; // we depend on the copy semantic of View here
+            m_size = other.m_size;
+            return *this;
+        }
+
+        LLAMA_FN_HOST_ACC_INLINE auto operator=(Vector&& other) noexcept -> Vector&
+        {
+            swap(other);
+            return *this;
+        }
+
+        // TODO: assign
+
+        LLAMA_FN_HOST_ACC_INLINE decltype(auto) at(std::size_t i)
+        {
+            if (i >= m_size)
+                throw std::out_of_range{
+                    "Index " + std::to_string(i) + "out of range [0:" + std::to_string(m_size) + "["};
+            return m_view(i);
+        }
+
+        LLAMA_FN_HOST_ACC_INLINE decltype(auto) at(std::size_t i) const
+        {
+            if (i >= m_size)
+                throw std::out_of_range{
+                    "Index " + std::to_string(i) + "out of range [0:" + std::to_string(m_size) + "["};
+            return m_view(i);
+        }
+
+        LLAMA_FN_HOST_ACC_INLINE decltype(auto) operator[](std::size_t i)
+        {
+            return m_view(i);
+        }
+
+        LLAMA_FN_HOST_ACC_INLINE decltype(auto) operator[](std::size_t i) const
+        {
+            return m_view(i);
+        }
+
+        LLAMA_FN_HOST_ACC_INLINE decltype(auto) front()
+        {
+            return m_view(0);
+        }
+
+        LLAMA_FN_HOST_ACC_INLINE decltype(auto) front() const
+        {
+            return m_view(0);
+        }
+
+        LLAMA_FN_HOST_ACC_INLINE decltype(auto) back()
+        {
+            return m_view(m_size - 1);
+        }
+
+        LLAMA_FN_HOST_ACC_INLINE decltype(auto) back() const
+        {
+            return m_view(m_size - 1);
+        }
+
+        LLAMA_FN_HOST_ACC_INLINE decltype(auto) begin()
+        {
+            return m_view.begin();
+        }
+
+        LLAMA_FN_HOST_ACC_INLINE decltype(auto) begin() const
+        {
+            return m_view.begin();
+        }
+
+        LLAMA_FN_HOST_ACC_INLINE decltype(auto) cbegin()
+        {
+            return std::as_const(m_view).begin();
+        }
+
+        LLAMA_FN_HOST_ACC_INLINE decltype(auto) cbegin() const
+        {
+            return m_view.begin();
+        }
+
+        LLAMA_FN_HOST_ACC_INLINE decltype(auto) end()
+        {
+            return m_view.begin() + m_size;
+        }
+
+        LLAMA_FN_HOST_ACC_INLINE decltype(auto) end() const
+        {
+            return m_view.begin() + m_size;
+        }
+
+        LLAMA_FN_HOST_ACC_INLINE decltype(auto) cend()
+        {
+            return std::as_const(m_view).begin() + m_size;
+        }
+
+        LLAMA_FN_HOST_ACC_INLINE decltype(auto) cend() const
+        {
+            return m_view.begin() + m_size;
+        }
+
+        LLAMA_FN_HOST_ACC_INLINE auto empty() const -> bool
+        {
+            return m_size == 0;
+        }
+
+        LLAMA_FN_HOST_ACC_INLINE auto size() const -> std::size_t
+        {
+            return m_size;
+        }
+
+        LLAMA_FN_HOST_ACC_INLINE void reserve(std::size_t cap)
+        {
+            if (cap > capacity())
+                changeCapacity(cap);
+        }
+
+        LLAMA_FN_HOST_ACC_INLINE auto capacity() const -> std::size_t
+        {
+            return m_view.mapping.arrayDims()[0];
+        }
+
+        LLAMA_FN_HOST_ACC_INLINE void shrink_to_fit()
+        {
+            changeCapacity(m_size);
+        }
+
+        LLAMA_FN_HOST_ACC_INLINE void clear()
+        {
+            m_size = 0;
+        }
+
+        template <typename T>
+        LLAMA_FN_HOST_ACC_INLINE auto insert(iterator pos, T&& t) -> iterator
+        {
+            const auto i = pos - begin();
+            reserve(m_size + 1); // might invalidate pos
+            pos = begin() + i;
+            std::copy_backward(pos, end(), end() + 1);
+            m_view[i] = std::forward<T>(t);
+            m_size++;
+            return pos;
+        }
+
+        // TODO: more insert overloads
+
+        // TODO emplace
+
+        LLAMA_FN_HOST_ACC_INLINE auto erase(iterator pos) -> iterator
+        {
+            std::copy(pos + 1, end(), pos);
+            m_size--;
+            return pos;
+        }
+
+        // TODO: more erase overloads
+
+        // TODO: T here is probably a virtual record. We could also allow any struct that is storable to the view via
+        // VirtualRecord::store().
+        template <typename T>
+        LLAMA_FN_HOST_ACC_INLINE void push_back(T&& t)
+        {
+            if (const auto cap = capacity(); m_size == cap)
+                reserve(std::max(cap + cap / 2, m_size + 1));
+
+            m_view[m_size++] = std::forward<T>(t);
+        }
+
+        // TODO: emplace_back
+
+        LLAMA_FN_HOST_ACC_INLINE void pop_back()
+        {
+            m_size--;
+        }
+
+        template <typename VirtualRecord = One<RecordDim>>
+        LLAMA_FN_HOST_ACC_INLINE void resize(std::size_t count, const VirtualRecord& value = {})
+        {
+            reserve(count);
+            for (std::size_t i = m_size; i < count; i++)
+                m_view[i] = value;
+            m_size = count;
+        }
+
+        LLAMA_FN_HOST_ACC_INLINE friend auto operator==(const Vector& a, const Vector& b) -> bool
+        {
+            if (a.m_size != b.m_size)
+                return false;
+            return std::equal(a.begin(), a.end(), b.begin());
+        }
+
+        LLAMA_FN_HOST_ACC_INLINE friend auto operator!=(const Vector& a, const Vector& b) -> bool
+        {
+            return !(a == b);
+        }
+
+        LLAMA_FN_HOST_ACC_INLINE friend auto operator<(const Vector& a, const Vector& b) -> bool
+        {
+            return std::lexicographical_compare(a.begin(), a.end(), b.begin(), b.end());
+        }
+
+        LLAMA_FN_HOST_ACC_INLINE friend auto operator<=(const Vector& a, const Vector& b) -> bool
+        {
+            return !(b < a);
+        }
+
+        LLAMA_FN_HOST_ACC_INLINE friend auto operator>(const Vector& a, const Vector& b) -> bool
+        {
+            return b < a;
+        }
+
+        LLAMA_FN_HOST_ACC_INLINE friend auto operator>=(const Vector& a, const Vector& b) -> bool
+        {
+            return !(a < b);
+        }
+
+        LLAMA_FN_HOST_ACC_INLINE friend void swap(Vector& a, Vector& b) noexcept
+        {
+            a.swap(b);
+        }
+
+    private:
+        LLAMA_FN_HOST_ACC_INLINE void changeCapacity(std::size_t cap)
+        {
+            auto newView = llama::allocView<Mapping>(Mapping{typename Mapping::ArrayDims{cap}});
+            auto b = begin();
+            std::copy(begin(), b + std::min(m_size, cap), newView.begin());
+            using std::swap;
+            swap(m_view, newView); // depends on move semantic of View
+        }
+
+        LLAMA_FN_HOST_ACC_INLINE void swap(Vector& other)
+        {
+            using std::swap;
+            swap(m_view, other.m_view); // depends on move semantic of View
+            swap(m_size, other.m_size);
+        }
+
+        ViewType m_view = {};
+        std::size_t m_size = 0;
+    };
+
+
+} // namespace llama

--- a/include/llama/llama.hpp
+++ b/include/llama/llama.hpp
@@ -39,6 +39,7 @@
 #include "ArrayDimsIndexRange.hpp"
 #include "BlobAllocators.hpp"
 #include "Core.hpp"
+#include "Vector.hpp"
 #include "View.hpp"
 #include "VirtualRecord.hpp"
 #include "macros.hpp"

--- a/tests/vector.cpp
+++ b/tests/vector.cpp
@@ -1,0 +1,277 @@
+#include "common.h"
+
+#include <catch2/catch.hpp>
+#include <llama/llama.hpp>
+
+using RecordDim = Vec3D;
+using Mapping = llama::mapping::AoS<llama::ArrayDims<1>, RecordDim>;
+using Vector = llama::Vector<Mapping>;
+
+TEST_CASE("Vector.ctor.default")
+{
+    const Vector v;
+    CHECK(v.empty());
+    CHECK(v.size() == 0);
+}
+
+TEST_CASE("Vector.ctor.count")
+{
+    const Vector v(10);
+    CHECK(!v.empty());
+    CHECK(v.size() == 10);
+}
+
+TEST_CASE("Vector.ctor.count_and_value")
+{
+    llama::One<RecordDim> p{42};
+    const Vector v(10, p);
+    CHECK(v.size() == 10);
+    for (auto i = 0; i < 10; i++)
+        CHECK(v[i] == p);
+}
+
+TEST_CASE("Vector.ctor.iterator_pair")
+{
+    auto view = llama::allocView(Mapping{llama::ArrayDims{10}});
+    for (auto i = 0; i < 10; i++)
+        view[i] = i;
+
+    const Vector v{view.begin(), view.end()};
+    CHECK(v.size() == 10);
+    for (auto i = 0; i < 10; i++)
+        CHECK(v[i] == i);
+}
+
+TEST_CASE("vector.copy_ctor")
+{
+    llama::One<RecordDim> p{42};
+    const Vector v(10, p);
+
+    const Vector v2(v);
+    for (auto i = 0; i < 10; i++)
+        CHECK(v2[i] == p);
+}
+
+TEST_CASE("vector.move_ctor")
+{
+    llama::One<RecordDim> p{42};
+    Vector v(10, p);
+
+    Vector v2(std::move(v));
+    for (auto i = 0; i < 10; i++)
+        CHECK(v2[i] == p);
+    CHECK(v.empty());
+}
+
+TEST_CASE("vector.copy_assign")
+{
+    llama::One<RecordDim> p{42};
+    const Vector v(10, p);
+
+    Vector v2;
+    v2 = v;
+    for (auto i = 0; i < 10; i++)
+        CHECK(v2[i] == p);
+}
+
+TEST_CASE("vector.move_assign")
+{
+    llama::One<RecordDim> p{42};
+    Vector v(10, p);
+
+    Vector v2;
+    v2 = std::move(v);
+    for (auto i = 0; i < 10; i++)
+        CHECK(v2[i] == p);
+    CHECK(v.empty());
+}
+
+namespace
+{
+    auto iotaVec(std::size_t count)
+    {
+        Vector v(count);
+        for (auto i = 0; i < count; i++)
+            v[i] = i;
+        return v;
+    }
+} // namespace
+
+TEST_CASE("vector.swap")
+{
+    llama::One<RecordDim> p{21};
+    Vector v1(5, p);
+
+    auto v2 = iotaVec(10);
+
+    swap(v1, v2);
+
+    for (auto i = 0; i < 10; i++)
+        CHECK(v1[i] == i);
+    for (auto i = 0; i < 5; i++)
+        CHECK(v2[i] == p);
+}
+
+TEST_CASE("vector.subscript")
+{
+    auto v = iotaVec(10);
+    for (auto i = 0; i < 10; i++)
+        CHECK(v[i] == i);
+    for (auto i = 0; i < 10; i++)
+        CHECK(v.at(i) == i);
+    CHECK_THROWS(v.at(10));
+}
+
+TEST_CASE("vector.front")
+{
+    auto v = iotaVec(10);
+    CHECK(v.front() == 0);
+}
+
+TEST_CASE("vector.back")
+{
+    auto v = iotaVec(10);
+    CHECK(v.back() == 9);
+}
+
+TEST_CASE("vector.begin_end")
+{
+    auto v = iotaVec(10);
+    auto b = v.begin();
+    auto e = v.end();
+    CHECK(*b == 0);
+    CHECK(e[-1] == 9);
+    for (auto i = 0; b != e; ++b, i++)
+        CHECK(*b == i);
+    b = v.begin();
+    for (auto i = 0; b != e; ++b, i++)
+        *b = i * 2;
+    for (auto i = 0; i < 10; i++)
+        CHECK(v[i] == i * 2);
+}
+
+TEST_CASE("vector.cbegin_cend")
+{
+    auto v = iotaVec(10);
+    auto b = v.cbegin();
+    auto e = v.cend();
+    CHECK(*b == 0);
+    CHECK(e[-1] == 9);
+    for (auto i = 0; b != e; ++b, i++)
+        CHECK(*b == i);
+}
+
+TEST_CASE("vector.reserve")
+{
+    Vector v;
+    CHECK(v.capacity() == 0);
+    CHECK(v.size() == 0);
+    v.reserve(100);
+    CHECK(v.capacity() == 100);
+    CHECK(v.size() == 0);
+}
+
+TEST_CASE("vector.clear_shrink_to_fit")
+{
+    auto v = iotaVec(10);
+    CHECK(v.capacity() == 10);
+    CHECK(v.size() == 10);
+    v.clear();
+    CHECK(v.capacity() == 10);
+    CHECK(v.size() == 0);
+    v.shrink_to_fit();
+    CHECK(v.capacity() == 0);
+    CHECK(v.size() == 0);
+}
+
+TEST_CASE("vector.insert")
+{
+    auto v = iotaVec(2);
+    CHECK(*(v.insert(v.begin(), llama::One<RecordDim>{42})) == 42);
+    CHECK(v.size() == 3);
+    CHECK(v[0] == 42);
+    CHECK(v[1] == 0);
+    CHECK(v[2] == 1);
+    CHECK(*(v.insert(v.begin() + 2, llama::One<RecordDim>{43})) == 43);
+    CHECK(v.size() == 4);
+    CHECK(v[0] == 42);
+    CHECK(v[1] == 0);
+    CHECK(v[2] == 43);
+    CHECK(v[3] == 1);
+    CHECK(*(v.insert(v.end(), llama::One<RecordDim>{44})) == 44);
+    CHECK(v.size() == 5);
+    CHECK(v[0] == 42);
+    CHECK(v[1] == 0);
+    CHECK(v[2] == 43);
+    CHECK(v[3] == 1);
+    CHECK(v[4] == 44);
+}
+
+TEST_CASE("vector.push_back")
+{
+    Vector v;
+    v.push_back(llama::One<RecordDim>{42});
+    CHECK(v.size() == 1);
+    CHECK(v[0] == 42);
+    v.push_back(llama::One<RecordDim>{43});
+    CHECK(v.size() == 2);
+    CHECK(v[0] == 42);
+    CHECK(v[1] == 43);
+}
+
+TEST_CASE("vector.pop_back")
+{
+    auto v = iotaVec(2);
+    v.pop_back();
+    CHECK(v.size() == 1);
+    CHECK(v[0] == 0);
+    v.pop_back();
+    CHECK(v.size() == 0);
+}
+
+TEST_CASE("vector.resize")
+{
+    auto v = iotaVec(5);
+    v.resize(2);
+    CHECK(v.size() == 2);
+    CHECK(v[0] == 0);
+    CHECK(v[1] == 1);
+    v.resize(4);
+    CHECK(v.size() == 4);
+    CHECK(v[0] == 0);
+    CHECK(v[1] == 1);
+    CHECK(v[2] == 0);
+    CHECK(v[3] == 0);
+    v.resize(6, llama::One<RecordDim>{42});
+    CHECK(v.size() == 6);
+    CHECK(v[0] == 0);
+    CHECK(v[1] == 1);
+    CHECK(v[2] == 0);
+    CHECK(v[3] == 0);
+    CHECK(v[4] == 42);
+    CHECK(v[5] == 42);
+    v.resize(2, llama::One<RecordDim>{42});
+    CHECK(v.size() == 2);
+    CHECK(v[0] == 0);
+    CHECK(v[1] == 1);
+    v.resize(0);
+    CHECK(v.size() == 0);
+}
+
+TEST_CASE("vector.erase")
+{
+    auto v = iotaVec(4);
+    CHECK(*v.erase(v.begin()) == 1);
+    CHECK(v.size() == 3);
+    CHECK(v[0] == 1);
+    CHECK(v[1] == 2);
+    CHECK(v[2] == 3);
+    CHECK(*v.erase(v.begin() + 1) == 3);
+    CHECK(v.size() == 2);
+    CHECK(v[0] == 1);
+    CHECK(v[1] == 3);
+    auto e = v.erase(v.end() - 1);
+    CHECK(e == v.end()); // sequence v.end() after v.erase()
+    CHECK(v.size() == 1);
+    CHECK(v[0] == 1);
+}


### PR DESCRIPTION
Addresses #296.

The implementation is not complete but contains a reasonably usable subset of what `std::vector` offers.

For the unit tests, I started with https://github.com/MFHava/PTL/blob/master/test/vector.cpp, but the current state is far different now. @MFHava would you consider the tests/vector.cpp in this PR still derived work from your original source? If yes, I would leave the license header as is and still need to add the Boost license file somewhere.