### PR TITLE
Fix LLAMA_INDEPENDENT_DATA not correctly defined for clang

### DIFF
--- a/include/llama/macros.hpp
+++ b/include/llama/macros.hpp
@@ -6,7 +6,7 @@
 #if defined(__INTEL_COMPILER) || defined(__INTEL_LLVM_COMPILER)
 #    define LLAMA_INDEPENDENT_DATA _Pragma("ivdep")
 #elif defined(__clang__)
-#    define LLAMA_INDEPENDENT_DATA _Pragma("clang loop vectorize(enable) interleave(enable) distribute(enable)")
+#    define LLAMA_INDEPENDENT_DATA _Pragma("clang loop vectorize(assume_safety) interleave(assume_safety)")
 #elif defined(__GNUC__)
 #    define LLAMA_INDEPENDENT_DATA _Pragma("GCC ivdep")
 #elif defined(_MSC_VER)

--- a/include/llama/macros.hpp
+++ b/include/llama/macros.hpp
@@ -3,12 +3,12 @@
 
 #pragma once
 
-#if defined(__GNUC__)
-#    define LLAMA_INDEPENDENT_DATA _Pragma("GCC ivdep")
-#elif defined(__INTEL_COMPILER) || defined(__INTEL_LLVM_COMPILER)
+#if defined(__INTEL_COMPILER) || defined(__INTEL_LLVM_COMPILER)
 #    define LLAMA_INDEPENDENT_DATA _Pragma("ivdep")
 #elif defined(__clang__)
 #    define LLAMA_INDEPENDENT_DATA _Pragma("clang loop vectorize(enable) interleave(enable) distribute(enable)")
+#elif defined(__GNUC__)
+#    define LLAMA_INDEPENDENT_DATA _Pragma("GCC ivdep")
 #elif defined(_MSC_VER)
 #    define LLAMA_INDEPENDENT_DATA __pragma(loop(ivdep))
 #else


### PR DESCRIPTION
clang in addition to gcc also defines `__GNUC__` and this is the first check when defining `LLAMA_INDEPENDENT_DATA`, so the macro will be defined using GCC's pragmas and not clang's.
Furthermore, `LLAMA_INDEPENDENT_DATA` will be changed for clang to also guarantee safe parallel memory access (more guarantees then now), but not encourage loop destribution (which is not part of the semantic of `LLAMA_INDEPENDENT_DATA`). 