### PR TITLE
Arbitarily cat and compare record coords

### DIFF
--- a/include/llama/RecordCoord.hpp
+++ b/include/llama/RecordCoord.hpp
@@ -96,15 +96,15 @@ namespace llama
     template <typename L>
     using RecordCoordFromList = internal::mp_unwrap_sizes<L>;
 
-    /// Concatenate two \ref RecordCoord.
-    template <typename RecordCoord1, typename RecordCoord2>
-    using Cat = RecordCoordFromList<boost::mp11::mp_append<typename RecordCoord1::List, typename RecordCoord2::List>>;
+    /// Concatenate a set of \ref RecordCoord.
+    template <typename... RecordCoords>
+    using Cat = RecordCoordFromList<boost::mp11::mp_append<typename RecordCoords::List...>>;
 
-    /// Concatenate two \ref RecordCoord instances.
-    template <typename RecordCoord1, typename RecordCoord2>
-    constexpr auto cat(RecordCoord1, RecordCoord2)
+    /// Concatenate a set of \ref RecordCoord instances.
+    template <typename... RecordCoords>
+    constexpr auto cat(RecordCoords...)
     {
-        return Cat<RecordCoord1, RecordCoord2>{};
+        return Cat<RecordCoords...>{};
     }
 
     /// RecordCoord without first coordinate component.

--- a/include/llama/RecordCoord.hpp
+++ b/include/llama/RecordCoord.hpp
@@ -30,6 +30,24 @@ namespace llama
         static constexpr std::size_t size = 0;
     };
 
+    template <std::size_t... CoordsA, std::size_t... CoordsB>
+    LLAMA_FN_HOST_ACC_INLINE constexpr auto operator==(RecordCoord<CoordsA...>, RecordCoord<CoordsB...>)
+    {
+        return false;
+    }
+
+    template <std::size_t... Coords>
+    LLAMA_FN_HOST_ACC_INLINE constexpr auto operator==(RecordCoord<Coords...>, RecordCoord<Coords...>)
+    {
+        return true;
+    }
+
+    template <std::size_t... CoordsA, std::size_t... CoordsB>
+    LLAMA_FN_HOST_ACC_INLINE constexpr auto operator!=(RecordCoord<CoordsA...> a, RecordCoord<CoordsB...> b)
+    {
+        return !(a == b);
+    }
+
     template <typename T>
     inline constexpr bool isRecordCoord = false;
 

--- a/tests/recordcoord.cpp
+++ b/tests/recordcoord.cpp
@@ -14,6 +14,44 @@ TEST_CASE("RecordCoord.operator!=")
     STATIC_REQUIRE(llama::RecordCoord<1, 2, 3>{} != llama::RecordCoord<4, 1, 2, 3>{});
 }
 
+TEST_CASE("Cat")
+{
+    STATIC_REQUIRE(std::is_same_v<llama::Cat<>, llama::RecordCoord<>>);
+
+    STATIC_REQUIRE(std::is_same_v<llama::Cat<llama::RecordCoord<>>, llama::RecordCoord<>>);
+    STATIC_REQUIRE(std::is_same_v<llama::Cat<llama::RecordCoord<1, 2, 3>>, llama::RecordCoord<1, 2, 3>>);
+
+    STATIC_REQUIRE(std::is_same_v<llama::Cat<llama::RecordCoord<>, llama::RecordCoord<>>, llama::RecordCoord<>>);
+    STATIC_REQUIRE(std::is_same_v<llama::Cat<llama::RecordCoord<1>, llama::RecordCoord<>>, llama::RecordCoord<1>>);
+    STATIC_REQUIRE(std::is_same_v<llama::Cat<llama::RecordCoord<>, llama::RecordCoord<1>>, llama::RecordCoord<1>>);
+    STATIC_REQUIRE(std::is_same_v<llama::Cat<llama::RecordCoord<1>, llama::RecordCoord<1>>, llama::RecordCoord<1, 1>>);
+
+    STATIC_REQUIRE(std::is_same_v<
+                   llama::Cat<llama::RecordCoord<1, 2>, llama::RecordCoord<>, llama::RecordCoord<3>>,
+                   llama::RecordCoord<1, 2, 3>>);
+
+    STATIC_REQUIRE(std::is_same_v<
+                   llama::Cat<
+                       llama::RecordCoord<>,
+                       llama::RecordCoord<1, 2>,
+                       llama::RecordCoord<3, 4, 5, 6>,
+                       llama::RecordCoord<>,
+                       llama::RecordCoord<7>>,
+                   llama::RecordCoord<1, 2, 3, 4, 5, 6, 7>>);
+}
+
+TEST_CASE("cat")
+{
+    STATIC_REQUIRE(
+        llama::cat(
+            llama::RecordCoord{},
+            llama::RecordCoord<1, 2>{},
+            llama::RecordCoord<3, 4, 5, 6>{},
+            llama::RecordCoord{},
+            llama::RecordCoord<7>{})
+        == llama::RecordCoord<1, 2, 3, 4, 5, 6, 7>{});
+}
+
 TEST_CASE("RecordCoordCommonPrefixIsBigger")
 {
     // clang-format off

--- a/tests/recordcoord.cpp
+++ b/tests/recordcoord.cpp
@@ -1,6 +1,19 @@
 #include <catch2/catch.hpp>
 #include <llama/llama.hpp>
 
+TEST_CASE("RecordCoord.operator==")
+{
+    STATIC_REQUIRE(llama::RecordCoord{} == llama::RecordCoord{});
+    STATIC_REQUIRE(llama::RecordCoord<1, 2, 3>{} == llama::RecordCoord<1, 2, 3>{});
+}
+
+TEST_CASE("RecordCoord.operator!=")
+{
+    STATIC_REQUIRE(llama::RecordCoord{} != llama::RecordCoord<1>{});
+    STATIC_REQUIRE(llama::RecordCoord<1>{} != llama::RecordCoord{});
+    STATIC_REQUIRE(llama::RecordCoord<1, 2, 3>{} != llama::RecordCoord<4, 1, 2, 3>{});
+}
+
 TEST_CASE("RecordCoordCommonPrefixIsBigger")
 {
     // clang-format off


### PR DESCRIPTION
* add `operator==` and `operator!=` for `RecordCoord`
* support arbitrary many record coords in `Cat` and `cat`