### PR TITLE
Add CI job to lint with clang-tidy

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -49,7 +49,7 @@ Checks: >
     -altera-struct-pack-align,
     -misc-no-recursion
 
-WarningsAsErrors: ''
+WarningsAsErrors: '*'
 HeaderFilterRegex: ''
 AnalyzeTemporaryDtors: false
 FormatStyle: none

--- a/.clang-tidy
+++ b/.clang-tidy
@@ -44,7 +44,10 @@ Checks: >
     -readability-magic-numbers,
     -readability-misleading-indentation,
     -readability-named-parameter,
-    -readability-uppercase-literal-suffix
+    -readability-uppercase-literal-suffix,
+    -readability-function-cognitive-complexity,
+    -altera-struct-pack-align,
+    -misc-no-recursion
 
 WarningsAsErrors: ''
 HeaderFilterRegex: ''

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -15,6 +15,34 @@ jobs:
         exclude: './thirdparty'
         clangFormatVersion: 12
 
+  clang-tidy:
+    runs-on: ubuntu-latest
+    env: {CXX: clang++-12}
+    steps:
+    - uses: actions/checkout@v2
+    - name: apt install boost and clang-12
+      run: |
+        wget -O - https://apt.llvm.org/llvm-snapshot.gpg.key|sudo apt-key add -
+        sudo add-apt-repository 'deb http://apt.llvm.org/focal/ llvm-toolchain-focal-12 main'
+        sudo apt update
+        sudo apt install libboost-all-dev clang-12 libomp-12-dev clang-tidy-12
+    - name: vcpkg install dependencies
+      run: |
+        vcpkg install catch2 fmt vc tinyobjloader
+    - name: install alpaka
+      run: |
+        git clone https://github.com/alpaka-group/alpaka.git
+        mkdir alpaka/build
+        cd alpaka/build
+        cmake .. -DCMAKE_TOOLCHAIN_FILE=/usr/local/share/vcpkg/scripts/buildsystems/vcpkg.cmake
+        sudo cmake --build . --target install
+    - name: run clang-tidy
+      run: |
+        mkdir build
+        cd build
+        cmake .. -DCMAKE_EXPORT_COMPILE_COMMANDS=ON -DCMAKE_BUILD_TYPE=$CONFIG -DALPAKA_ACC_CPU_B_SEQ_T_SEQ_ENABLE=ON -DALPAKA_CXX_STANDARD=17 -DCMAKE_TOOLCHAIN_FILE=/usr/local/share/vcpkg/scripts/buildsystems/vcpkg.cmake
+        run-clang-tidy-12
+
   amalgamation:
     runs-on: ubuntu-latest
     steps:

--- a/examples/alpaka/asyncblur/asyncblur.cpp
+++ b/examples/alpaka/asyncblur/asyncblur.cpp
@@ -388,12 +388,12 @@ try
             for (std::size_t x = 0; x < img_x; ++x)
             {
                 auto* pixel = &image[(y * img_x + x) * 3];
-                pixel[0] = hostView(y + KERNEL_SIZE, x + KERNEL_SIZE)(tag::R()) * 255.;
-                pixel[1] = hostView(y + KERNEL_SIZE, x + KERNEL_SIZE)(tag::G()) * 255.;
-                pixel[2] = hostView(y + KERNEL_SIZE, x + KERNEL_SIZE)(tag::B()) * 255.;
+                pixel[0] = static_cast<unsigned char>(hostView(y + KERNEL_SIZE, x + KERNEL_SIZE)(tag::R()) * 255.);
+                pixel[1] = static_cast<unsigned char>(hostView(y + KERNEL_SIZE, x + KERNEL_SIZE)(tag::G()) * 255.);
+                pixel[2] = static_cast<unsigned char>(hostView(y + KERNEL_SIZE, x + KERNEL_SIZE)(tag::B()) * 255.);
             }
         }
-        stbi_write_png(out_filename.c_str(), img_x, img_y, 3, image.data(), 0);
+        stbi_write_png(out_filename.c_str(), static_cast<int>(img_x), static_cast<int>(img_y), 3, image.data(), 0);
     }
 
     return 0;

--- a/examples/alpaka/nbody/nbody.cpp
+++ b/examples/alpaka/nbody/nbody.cpp
@@ -48,7 +48,7 @@ namespace tag
     struct Y{};
     struct Z{};
     struct Mass{};
-}
+} // namespace tag
 
 using Particle = llama::Record<
     llama::Field<tag::Pos, llama::Record<
@@ -71,7 +71,7 @@ enum Mapping
 
 namespace stdext
 {
-    LLAMA_FN_HOST_ACC_INLINE FP rsqrt(FP f)
+    LLAMA_FN_HOST_ACC_INLINE auto rsqrt(FP f) -> FP
     {
         return 1.0f / std::sqrt(f);
     }
@@ -332,7 +332,7 @@ void run(std::ostream& plotFile)
     watch.printAndReset("copy D->H");
 }
 
-int main()
+auto main() -> int
 try
 {
     std::cout << PROBLEM_SIZE / 1000 << "k particles (" << PROBLEM_SIZE * llama::sizeOf<Particle> / 1024 << "kiB)\n"

--- a/examples/alpaka/vectoradd/vectoradd.cpp
+++ b/examples/alpaka/vectoradd/vectoradd.cpp
@@ -128,8 +128,8 @@ try
     LLAMA_INDEPENDENT_DATA
     for (std::size_t i = 0; i < PROBLEM_SIZE; ++i)
     {
-        hostA(i) = seed + i;
-        hostB(i) = seed - i;
+        hostA(i) = seed + static_cast<FP>(i);
+        hostB(i) = seed - static_cast<FP>(i);
     }
     chrono.printAndReset("Init");
 

--- a/examples/nbody/nbody.cpp
+++ b/examples/nbody/nbody.cpp
@@ -1222,7 +1222,15 @@ namespace manualSoA_Vc
     using manualAoSoA_Vc::pPInteraction;
 
     template <typename vec>
-    void update(FP* posx, FP* posy, FP* posz, FP* velx, FP* vely, FP* velz, FP* mass, int threads)
+    void update(
+        const FP* posx,
+        const FP* posy,
+        const FP* posz,
+        FP* velx,
+        FP* vely,
+        FP* velz,
+        const FP* mass,
+        int threads)
     {
 #    pragma omp parallel for schedule(static) num_threads(threads)
         for (std::ptrdiff_t i = 0; i < PROBLEM_SIZE; i += vec::size())
@@ -1335,7 +1343,7 @@ try
 #endif
 
     const auto numThreads = static_cast<std::size_t>(omp_get_max_threads());
-    const char* affinity = std::getenv("GOMP_CPU_AFFINITY");
+    const char* affinity = std::getenv("GOMP_CPU_AFFINITY"); // NOLINT(concurrency-mt-unsafe)
     affinity = affinity == nullptr ? "NONE - PLEASE PIN YOUR THREADS!" : affinity;
 
     fmt::print(

--- a/examples/vectoradd/vectoradd.cpp
+++ b/examples/vectoradd/vectoradd.cpp
@@ -72,10 +72,11 @@ namespace usellama
         LLAMA_INDEPENDENT_DATA
         for (std::size_t i = 0; i < PROBLEM_SIZE; ++i)
         {
-            a[i](tag::X{}) = i; // X
-            a[i](tag::Y{}) = i; // Y
-            a[i](llama::RecordCoord<2>{}) = i; // Z
-            b(i) = i; // writes to all (X, Y, Z)
+            const auto value = static_cast<FP>(i);
+            a[i](tag::X{}) = value; // X
+            a[i](tag::Y{}) = value; // Y
+            a[i](llama::RecordCoord<2>{}) = value; // Z
+            b(i) = value; // writes to all (X, Y, Z)
         }
         watch.printAndReset("init");
 
@@ -124,12 +125,13 @@ namespace manualAoS
         LLAMA_INDEPENDENT_DATA
         for (std::size_t i = 0; i < PROBLEM_SIZE; ++i)
         {
-            a[i].x = i;
-            a[i].y = i;
-            a[i].z = i;
-            b[i].x = i;
-            b[i].y = i;
-            b[i].z = i;
+            const auto value = static_cast<FP>(i);
+            a[i].x = value;
+            a[i].y = value;
+            a[i].z = value;
+            b[i].x = value;
+            b[i].y = value;
+            b[i].z = value;
         }
         watch.printAndReset("init");
 
@@ -141,7 +143,7 @@ namespace manualAoS
         }
         plotFile << "AoS\t" << acc / STEPS << '\n';
 
-        return c[0].x;
+        return static_cast<int>(c[0].x);
     }
 } // namespace manualAoS
 
@@ -187,12 +189,13 @@ namespace manualSoA
         LLAMA_INDEPENDENT_DATA
         for (std::size_t i = 0; i < PROBLEM_SIZE; ++i)
         {
-            ax[i] = i;
-            ay[i] = i;
-            az[i] = i;
-            bx[i] = i;
-            by[i] = i;
-            bz[i] = i;
+            const auto value = static_cast<FP>(i);
+            ax[i] = value;
+            ay[i] = value;
+            az[i] = value;
+            bx[i] = value;
+            by[i] = value;
+            bz[i] = value;
         }
         watch.printAndReset("init");
 
@@ -204,7 +207,7 @@ namespace manualSoA
         }
         plotFile << "SoA\t" << acc / STEPS << '\n';
 
-        return cx[0];
+        return static_cast<int>(cx[0]);
     }
 } // namespace manualSoA
 
@@ -256,12 +259,13 @@ namespace manualAoSoA
             LLAMA_INDEPENDENT_DATA
             for (std::size_t i = 0; i < LANES; ++i)
             {
-                a[bi].x[i] = bi * LANES + i;
-                a[bi].y[i] = bi * LANES + i;
-                a[bi].z[i] = bi * LANES + i;
-                b[bi].x[i] = bi * LANES + i;
-                b[bi].y[i] = bi * LANES + i;
-                b[bi].z[i] = bi * LANES + i;
+                const auto value = static_cast<float>(bi * LANES + i);
+                a[bi].x[i] = value;
+                a[bi].y[i] = value;
+                a[bi].z[i] = value;
+                b[bi].x[i] = value;
+                b[bi].y[i] = value;
+                b[bi].z[i] = value;
             }
         }
         watch.printAndReset("init");
@@ -274,7 +278,7 @@ namespace manualAoSoA
         }
         plotFile << "AoSoA\t" << acc / STEPS << '\n';
 
-        return c[0].x[0];
+        return static_cast<int>(c[0].x[0]);
     }
 } // namespace manualAoSoA
 

--- a/tests/computedprop.cpp
+++ b/tests/computedprop.cpp
@@ -118,7 +118,7 @@ namespace
 
         constexpr ComputedMapping() = default;
 
-        constexpr ComputedMapping(ArrayDims, RecordDim = {})
+        constexpr explicit ComputedMapping(ArrayDims, RecordDim = {})
         {
         }
 
@@ -164,7 +164,7 @@ namespace
 
         constexpr CompressedBoolMapping() = default;
 
-        constexpr CompressedBoolMapping(ArrayDims size) : arrayDimsSize(size)
+        constexpr explicit CompressedBoolMapping(ArrayDims size) : arrayDimsSize(size)
         {
         }
 
@@ -175,14 +175,14 @@ namespace
             Word& word;
             unsigned char bit;
 
-            operator bool() const
+            operator bool() const // NOLINT(google-explicit-constructor,hicpp-explicit-conversions)
             {
-                return word & (Word{1} << bit);
+                return (word & (Word{1} << bit)) != 0;
             }
 
-            auto operator=(bool b) -> BoolRef
+            auto operator=(bool b) -> BoolRef&
             {
-                word ^= (-Word{b} ^ word) & (Word{1} << bit);
+                word ^= (-static_cast<Word>(b) ^ word) & (Word{1} << bit);
                 return *this;
             }
         };
@@ -245,9 +245,9 @@ TEST_CASE("compressed_bools")
     {
         for (auto x = 0u; x < 8; x++)
         {
-            view(y, x)(tag::A{}) = static_cast<bool>(x * y & 1);
-            view(y, x)(tag::B{}, tag::X{}) = static_cast<bool>(x & 1);
-            view(y, x)(tag::B{}, tag::Y{}) = static_cast<bool>(y & 1);
+            view(y, x)(tag::A{}) = static_cast<bool>(x * y & 1u);
+            view(y, x)(tag::B{}, tag::X{}) = static_cast<bool>(x & 1u);
+            view(y, x)(tag::B{}, tag::Y{}) = static_cast<bool>(y & 1u);
         }
     }
 
@@ -255,9 +255,9 @@ TEST_CASE("compressed_bools")
     {
         for (auto x = 0u; x < 8; x++)
         {
-            CHECK(view(y, x)(tag::A{}) == static_cast<bool>(x * y & 1));
-            CHECK(view(y, x)(tag::B{}, tag::X{}) == static_cast<bool>(x & 1));
-            CHECK(view(y, x)(tag::B{}, tag::Y{}) == static_cast<bool>(y & 1));
+            CHECK(view(y, x)(tag::A{}) == static_cast<bool>(x * y & 1u));
+            CHECK(view(y, x)(tag::B{}, tag::X{}) == static_cast<bool>(x & 1u));
+            CHECK(view(y, x)(tag::B{}, tag::Y{}) == static_cast<bool>(y & 1u));
         }
     }
 }

--- a/tests/core.cpp
+++ b/tests/core.cpp
@@ -9,7 +9,7 @@ TEST_CASE("prettyPrintType")
 #ifdef _WIN32
     replace_all(str, "__int64", "long");
 #endif
-    const auto ref = R"(llama::Record<
+    const auto* const ref = R"(llama::Record<
     llama::Field<
         tag::Pos,
         llama::Record<

--- a/tests/iterator.cpp
+++ b/tests/iterator.cpp
@@ -35,7 +35,7 @@ TEST_CASE("iterator")
         const auto& cview = std::as_const(view);
         const int sumY
             = std::accumulate(begin(cview), end(cview), 0, [](int acc, auto vd) { return acc + vd(tag::Y{}); });
-        CHECK(sumY == 128);
+        CHECK(sumY == 128); // NOLINT(bugprone-infinite-loop)
     };
     test(llama::ArrayDims{32});
     test(llama::ArrayDims{4, 8});

--- a/tests/treemap.cpp
+++ b/tests/treemap.cpp
@@ -766,7 +766,7 @@ TEST_CASE("treemapping")
 #ifdef _LIBCPP_VERSION
     replace_all(raw, "std::__1::", "std::");
 #endif
-    const auto ref = R"(llama::mapping::tree::Node<
+    const auto* const ref = R"(llama::mapping::tree::Node<
     llama::NoName,
     llama::Tuple<
         llama::mapping::tree::Node<
@@ -910,7 +910,7 @@ TEST_CASE("treemapping")
 #ifdef _LIBCPP_VERSION
     replace_all(raw2, "std::__1::", "std::");
 #endif
-    const auto ref2 = R"(llama::mapping::tree::Node<
+    const auto* const ref2 = R"(llama::mapping::tree::Node<
     llama::NoName,
     llama::Tuple<
         llama::mapping::tree::Node<

--- a/tests/vector.cpp
+++ b/tests/vector.cpp
@@ -47,7 +47,7 @@ TEST_CASE("vector.copy_ctor")
     llama::One<RecordDim> p{42};
     const Vector v(10, p);
 
-    const Vector v2(v);
+    const Vector v2(v); // NOLINT(performance-unnecessary-copy-initialization)
     for (auto i = 0; i < 10; i++)
         CHECK(v2[i] == p);
 }
@@ -60,7 +60,7 @@ TEST_CASE("vector.move_ctor")
     Vector v2(std::move(v));
     for (auto i = 0; i < 10; i++)
         CHECK(v2[i] == p);
-    CHECK(v.empty());
+    CHECK(v.empty()); // NOLINT(bugprone-use-after-move,hicpp-invalid-access-moved)
 }
 
 TEST_CASE("vector.copy_assign")
@@ -83,7 +83,7 @@ TEST_CASE("vector.move_assign")
     v2 = std::move(v);
     for (auto i = 0; i < 10; i++)
         CHECK(v2[i] == p);
-    CHECK(v.empty());
+    CHECK(v.empty()); // NOLINT(bugprone-use-after-move,hicpp-invalid-access-moved)
 }
 
 namespace

--- a/tests/view.cpp
+++ b/tests/view.cpp
@@ -69,6 +69,7 @@ TEST_CASE("view.allocator.Vector")
         view(i) = 42;
 }
 
+#ifndef __clang_analyzer__
 TEST_CASE("view.allocator.SharedPtr")
 {
     using ArrayDims = llama::ArrayDims<2>;
@@ -80,6 +81,7 @@ TEST_CASE("view.allocator.SharedPtr")
     for (auto i : llama::ArrayDimsIndexRange{viewSize})
         view(i) = 42;
 }
+#endif
 
 TEST_CASE("view.allocator.stack")
 {
@@ -291,8 +293,16 @@ TEST_CASE("view.indexing")
     auto view = llama::allocView(llama::mapping::AoS{llama::ArrayDims{16, 16}, Particle{}});
     view(0u, 0u)(tag::Mass{}) = 42.0f;
 
-    using integrals = boost::mp11::
-        mp_list<char, unsigned char, signed char, short, unsigned short, int, unsigned int, long, unsigned long>;
+    using integrals = boost::mp11::mp_list<
+        char,
+        unsigned char,
+        signed char,
+        short, // NOLINT(google-runtime-int)
+        unsigned short, // NOLINT(google-runtime-int)
+        int,
+        unsigned int,
+        long, // NOLINT(google-runtime-int)
+        unsigned long>; // NOLINT(google-runtime-int)
 
     boost::mp11::mp_for_each<integrals>(
         [&](auto i)

--- a/tests/virtualrecord.cpp
+++ b/tests/virtualrecord.cpp
@@ -957,7 +957,7 @@ TEST_CASE("VirtualRecord.operator<<")
 
     std::stringstream ss;
     ss << p;
-    const auto expected
+    const auto* const expected
         = "{Pos: {X: 1, Y: 2, Z: 3}, Mass: 4, Vel: {X: 5, Y: 6, Z: 7}, Flags: {[0]: 1, [1]: 1, [2]: 1, [3]: 1}}";
     CHECK(ss.str() == expected);
 


### PR DESCRIPTION
This PR adds a CI job that runs clang-tidy on the entire codebase.

Specifically:
* A new CI job has been added.
* All existing clang-tidy warnings have been addressed.
* The `.clang-tidy` file has been changed to treat warnings as errors, so they show up and break the CI if they occur.