### PR TITLE
AoS will be aligned and SoA will be multiblob by default

### DIFF
--- a/examples/alpaka/asyncblur/asyncblur.cpp
+++ b/examples/alpaka/asyncblur/asyncblur.cpp
@@ -85,9 +85,9 @@ struct BlurKernel
             {
                 // Using SoA for the shared memory
                 constexpr auto sharedChunkSize = ElemsPerBlock + 2 * KernelSize;
-                const auto sharedMapping = llama::mapping::SoA(
-                    typename View::ArrayDims{sharedChunkSize, sharedChunkSize},
-                    typename View::RecordDim{});
+                const auto sharedMapping
+                    = llama::mapping::SoA<typename View::ArrayDims, typename View::RecordDim, false>(
+                        {sharedChunkSize, sharedChunkSize});
                 constexpr auto sharedMemSize = llama::sizeOf<PixelOnAcc> * sharedChunkSize * sharedChunkSize;
                 auto& sharedMem = alpaka::declareSharedVar<std::byte[sharedMemSize], __COUNTER__>(acc);
                 return llama::View(sharedMapping, llama::Array<std::byte*, 1>{&sharedMem[0]});

--- a/examples/alpaka/nbody/nbody.cpp
+++ b/examples/alpaka/nbody/nbody.cpp
@@ -162,7 +162,7 @@ struct UpdateKernel
                     if constexpr (MappingSM == AoS)
                         return llama::mapping::AoS{arrayDims, Particle{}};
                     if constexpr (MappingSM == SoA)
-                        return llama::mapping::SoA{arrayDims, Particle{}};
+                        return llama::mapping::SoA<decltype(arrayDims), Particle, false>{arrayDims};
                     if constexpr (MappingSM == AoSoA)
                         return llama::mapping::AoSoA<decltype(arrayDims), Particle, AOSOA_LANES>{arrayDims};
                 }();
@@ -268,7 +268,7 @@ void run(std::ostream& plotFile)
         if constexpr (MappingGM == AoS)
             return llama::mapping::AoS{arrayDims, Particle{}};
         if constexpr (MappingGM == SoA)
-            return llama::mapping::SoA{arrayDims, Particle{}};
+            return llama::mapping::SoA<decltype(arrayDims), Particle, false>{arrayDims};
         // if constexpr (MappingGM == 2)
         //    return llama::mapping::SoA<decltype(arrayDims), Particle, true>{arrayDims};
         if constexpr (MappingGM == AoSoA)

--- a/examples/alpaka/vectoradd/vectoradd.cpp
+++ b/examples/alpaka/vectoradd/vectoradd.cpp
@@ -80,14 +80,13 @@ try
     Queue queue(devAcc);
 
     // LLAMA
-    const auto arrayDims = llama::ArrayDims{PROBLEM_SIZE};
-
     const auto mapping = [&]
     {
+        const auto arrayDims = llama::ArrayDims{PROBLEM_SIZE};
         if constexpr (MAPPING == 0)
             return llama::mapping::AoS{arrayDims, Vector{}};
         if constexpr (MAPPING == 1)
-            return llama::mapping::SoA{arrayDims, Vector{}};
+            return llama::mapping::SoA<decltype(arrayDims), Vector, false>{arrayDims, Vector{}};
         if constexpr (MAPPING == 2)
             return llama::mapping::SoA<decltype(arrayDims), Vector, true>{arrayDims};
         if constexpr (MAPPING == 3)

--- a/examples/simpletest/simpletest.cpp
+++ b/examples/simpletest/simpletest.cpp
@@ -134,8 +134,10 @@ try
 
     // Printing dimensions information at runtime
     std::cout << "Record dimension is " << addLineBreaks(type(Name())) << '\n';
-    std::cout << "AoS address of (0,100) <0,1>: "
-              << llama::mapping::AoS<ArrayDims, Name>(adSize).blobNrAndOffset<0, 1>({0, 100}).offset << '\n';
+    std::cout << "AlignedAoS address of (0,100) <0,1>: "
+              << llama::mapping::AlignedAoS<ArrayDims, Name>(adSize).blobNrAndOffset<0, 1>({0, 100}).offset << '\n';
+    std::cout << "PackedAoS address of (0,100) <0,1>: "
+              << llama::mapping::PackedAoS<ArrayDims, Name>(adSize).blobNrAndOffset<0, 1>({0, 100}).offset << '\n';
     std::cout << "SoA address of (0,100) <0,1>: "
               << llama::mapping::SoA<ArrayDims, Name>(adSize).blobNrAndOffset<0, 1>({0, 100}).offset << '\n';
     std::cout << "sizeOf RecordDim: " << llama::sizeOf<Name> << '\n';

--- a/include/llama/View.hpp
+++ b/include/llama/View.hpp
@@ -242,6 +242,10 @@ namespace llama
         using iterator = Iterator<View>;
         using const_iterator = Iterator<const View>;
 
+        static_assert(
+            !std::is_reference_v<ArrayDims>,
+            "Mapping::ArrayDims must not be a reference. Are you using decltype(...) as mapping template argument?");
+
         View() = default;
 
         LLAMA_FN_HOST_ACC_INLINE

--- a/include/llama/mapping/AoS.hpp
+++ b/include/llama/mapping/AoS.hpp
@@ -15,7 +15,7 @@ namespace llama::mapping
     template <
         typename T_ArrayDims,
         typename T_RecordDim,
-        bool AlignAndPad = false,
+        bool AlignAndPad = true,
         typename LinearizeArrayDimsFunctor = LinearizeArrayDimsCpp>
     struct AoS
     {

--- a/include/llama/mapping/SoA.hpp
+++ b/include/llama/mapping/SoA.hpp
@@ -16,7 +16,7 @@ namespace llama::mapping
     template <
         typename T_ArrayDims,
         typename T_RecordDim,
-        bool SeparateBuffers = false,
+        bool SeparateBuffers = true,
         typename LinearizeArrayDimsFunctor = LinearizeArrayDimsCpp>
     struct SoA
     {

--- a/tests/dump.cpp
+++ b/tests/dump.cpp
@@ -22,19 +22,24 @@ namespace
     }
 } // namespace
 
-TEST_CASE("dump.Particle.AoS")
+TEST_CASE("dump.Particle.AoS_Aligned")
 {
-    dump(llama::mapping::AoS{arrayDims, Particle{}});
+    dump(llama::mapping::AlignedAoS<ArrayDims, Particle>{arrayDims});
 }
 
-TEST_CASE("dump.Particle.SoA")
+TEST_CASE("dump.Particle.AoS_Packed")
 {
-    dump(llama::mapping::SoA{arrayDims, Particle{}});
+    dump(llama::mapping::PackedAoS<ArrayDims, Particle>{arrayDims});
+}
+
+TEST_CASE("dump.Particle.SoA_SB")
+{
+    dump(llama::mapping::SingleBlobSoA<ArrayDims, Particle>{arrayDims});
 }
 
 TEST_CASE("dump.Particle.SoA_MB")
 {
-    dump(llama::mapping::SoA<ArrayDims, Particle, true>{arrayDims});
+    dump(llama::mapping::MultiBlobSoA<ArrayDims, Particle>{arrayDims});
 }
 
 TEST_CASE("dump.Particle.AoSoA8")
@@ -104,22 +109,22 @@ TEST_CASE("dump.Particle.Split.AoSoA8.AoS.One.SoA")
 
 TEST_CASE("dump.ParticleUnaligned.AoS")
 {
-    dump(llama::mapping::AoS{arrayDims, ParticleUnaligned{}});
+    dump(llama::mapping::PackedAoS<ArrayDims, ParticleUnaligned>{arrayDims});
 }
 
 TEST_CASE("dump.ParticleUnaligned.AoS_Aligned")
 {
-    dump(llama::mapping::AoS<ArrayDims, ParticleUnaligned, true>{arrayDims});
+    dump(llama::mapping::AlignedAoS<ArrayDims, ParticleUnaligned>{arrayDims});
 }
 
-TEST_CASE("dump.ParticleUnaligned.SoA")
+TEST_CASE("dump.ParticleUnaligned.SoA_SB")
 {
-    dump(llama::mapping::SoA{arrayDims, ParticleUnaligned{}});
+    dump(llama::mapping::SingleBlobSoA<ArrayDims, ParticleUnaligned>{arrayDims});
 }
 
 TEST_CASE("dump.ParticleUnaligned.SoA_MB")
 {
-    dump(llama::mapping::SoA<ArrayDims, ParticleUnaligned, true>{arrayDims});
+    dump(llama::mapping::MultiBlobSoA<ArrayDims, ParticleUnaligned>{arrayDims});
 }
 
 TEST_CASE("dump.ParticleUnaligned.AoSoA8")
@@ -199,7 +204,7 @@ TEST_CASE("dump.ParticleUnaligned.Split.AoSoA8.SoA.One.AoS")
 
 TEST_CASE("AoS.Aligned")
 {
-    const auto mapping = llama::mapping::AoS<ArrayDims, ParticleUnaligned, true>{arrayDims};
+    const auto mapping = llama::mapping::AlignedAoS<ArrayDims, ParticleUnaligned>{arrayDims};
     auto view = llama::allocView(mapping);
     llama::forEachLeaf<ParticleUnaligned>(
         [&](auto rc)
@@ -246,7 +251,7 @@ using ParticleAligned = llama::Record<
 >;
 // clang-format on
 
-TEST_CASE("dump.ParticleAligned.AoS")
+TEST_CASE("dump.ParticleAligned.PackedAoS")
 {
-    dump(llama::mapping::AoS{arrayDims, ParticleAligned{}});
+    dump(llama::mapping::PackedAoS<ArrayDims, ParticleAligned>{arrayDims});
 }

--- a/tests/mapping.cpp
+++ b/tests/mapping.cpp
@@ -7,17 +7,19 @@
 #ifdef __cpp_lib_concepts
 TEST_CASE("mapping.concepts")
 {
-    STATIC_REQUIRE(llama::Mapping<llama::mapping::AoS<llama::ArrayDims<2>, Particle>>);
-    STATIC_REQUIRE(llama::Mapping<llama::mapping::SoA<llama::ArrayDims<2>, Particle>>);
+    STATIC_REQUIRE(llama::Mapping<llama::mapping::AlignedAoS<llama::ArrayDims<2>, Particle>>);
+    STATIC_REQUIRE(llama::Mapping<llama::mapping::PackedAoS<llama::ArrayDims<2>, Particle>>);
+    STATIC_REQUIRE(llama::Mapping<llama::mapping::SingleBlobSoA<llama::ArrayDims<2>, Particle>>);
+    STATIC_REQUIRE(llama::Mapping<llama::mapping::MultiBlobSoA<llama::ArrayDims<2>, Particle>>);
     STATIC_REQUIRE(llama::Mapping<llama::mapping::AoSoA<llama::ArrayDims<2>, Particle, 8>>);
 }
 #endif
 
-TEST_CASE("address.AoS")
+TEST_CASE("address.AoS.Packed")
 {
     using ArrayDims = llama::ArrayDims<2>;
     auto arrayDims = ArrayDims{16, 16};
-    auto mapping = llama::mapping::AoS<ArrayDims, Particle>{arrayDims};
+    auto mapping = llama::mapping::PackedAoS<ArrayDims, Particle>{arrayDims};
 
     {
         const auto coord = ArrayDims{0, 0};
@@ -65,12 +67,11 @@ TEST_CASE("address.AoS")
     }
 }
 
-TEST_CASE("address.AoS.fortran")
+TEST_CASE("address.AoS.Packed.fortran")
 {
     using ArrayDims = llama::ArrayDims<2>;
     auto arrayDims = ArrayDims{16, 16};
-    auto mapping
-        = llama::mapping::AoS<ArrayDims, Particle, false, llama::mapping::LinearizeArrayDimsFortran>{arrayDims};
+    auto mapping = llama::mapping::PackedAoS<ArrayDims, Particle, llama::mapping::LinearizeArrayDimsFortran>{arrayDims};
 
     {
         const auto coord = ArrayDims{0, 0};
@@ -118,11 +119,11 @@ TEST_CASE("address.AoS.fortran")
     }
 }
 
-TEST_CASE("address.AoS.morton")
+TEST_CASE("address.AoS.Packed.morton")
 {
     using ArrayDims = llama::ArrayDims<2>;
     auto arrayDims = ArrayDims{16, 16};
-    auto mapping = llama::mapping::AoS<ArrayDims, Particle, false, llama::mapping::LinearizeArrayDimsMorton>{arrayDims};
+    auto mapping = llama::mapping::PackedAoS<ArrayDims, Particle, llama::mapping::LinearizeArrayDimsMorton>{arrayDims};
 
     {
         const auto coord = ArrayDims{0, 0};
@@ -170,11 +171,11 @@ TEST_CASE("address.AoS.morton")
     }
 }
 
-TEST_CASE("address.AoS.aligned")
+TEST_CASE("address.AoS.Aligned")
 {
     using ArrayDims = llama::ArrayDims<2>;
     auto arrayDims = ArrayDims{16, 16};
-    auto mapping = llama::mapping::AoS<ArrayDims, Particle, true>{arrayDims};
+    auto mapping = llama::mapping::AlignedAoS<ArrayDims, Particle>{arrayDims};
 
     {
         const auto coord = ArrayDims{0, 0};
@@ -222,11 +223,11 @@ TEST_CASE("address.AoS.aligned")
     }
 }
 
-TEST_CASE("address.SoA")
+TEST_CASE("address.SoA.SingleBlob")
 {
     using ArrayDims = llama::ArrayDims<2>;
     auto arrayDims = ArrayDims{16, 16};
-    auto mapping = llama::mapping::SoA<ArrayDims, Particle>{arrayDims};
+    auto mapping = llama::mapping::SingleBlobSoA<ArrayDims, Particle>{arrayDims};
 
     {
         const auto coord = ArrayDims{0, 0};
@@ -274,12 +275,12 @@ TEST_CASE("address.SoA")
     }
 }
 
-TEST_CASE("address.SoA.fortran")
+TEST_CASE("address.SoA.SingleBlob.fortran")
 {
     using ArrayDims = llama::ArrayDims<2>;
     auto arrayDims = ArrayDims{16, 16};
     auto mapping
-        = llama::mapping::SoA<ArrayDims, Particle, false, llama::mapping::LinearizeArrayDimsFortran>{arrayDims};
+        = llama::mapping::SingleBlobSoA<ArrayDims, Particle, llama::mapping::LinearizeArrayDimsFortran>{arrayDims};
 
     {
         const auto coord = ArrayDims{0, 0};
@@ -327,7 +328,7 @@ TEST_CASE("address.SoA.fortran")
     }
 }
 
-TEST_CASE("address.SoA.morton")
+TEST_CASE("address.SoA.SingleBlob.morton")
 {
     struct Value
     {
@@ -335,7 +336,8 @@ TEST_CASE("address.SoA.morton")
 
     using ArrayDims = llama::ArrayDims<2>;
     auto arrayDims = ArrayDims{16, 16};
-    auto mapping = llama::mapping::SoA<ArrayDims, Particle, false, llama::mapping::LinearizeArrayDimsMorton>{arrayDims};
+    auto mapping
+        = llama::mapping::SingleBlobSoA<ArrayDims, Particle, llama::mapping::LinearizeArrayDimsMorton>{arrayDims};
 
     {
         const auto coord = ArrayDims{0, 0};
@@ -387,7 +389,7 @@ TEST_CASE("address.SoA.MultiBlob")
 {
     using ArrayDims = llama::ArrayDims<2>;
     auto arrayDims = ArrayDims{16, 16};
-    auto mapping = llama::mapping::SoA<ArrayDims, Particle, true>{arrayDims};
+    auto mapping = llama::mapping::MultiBlobSoA<ArrayDims, Particle>{arrayDims};
 
     {
         const auto coord = ArrayDims{0, 0};

--- a/tests/proofs.cpp
+++ b/tests/proofs.cpp
@@ -29,12 +29,19 @@ using Particle = llama::Record<
 >;
 // clang-format on
 
-TEST_CASE("mapsNonOverlappingly.AoS")
+TEST_CASE("mapsNonOverlappingly.PackedAoS")
 {
-    using ArrayDims = llama::ArrayDims<2>;
-    constexpr auto arrayDims = ArrayDims{32, 32};
-    constexpr auto mapping = llama::mapping::AoS<ArrayDims, Particle>{arrayDims};
+    constexpr auto mapping = llama::mapping::PackedAoS<llama::ArrayDims<2>, Particle>{{32, 32}};
+#ifdef __cpp_constexpr_dynamic_alloc
+    STATIC_REQUIRE(llama::mapsNonOverlappingly(mapping));
+#else
+    INFO("Test disabled because compiler does not support __cpp_constexpr_dynamic_alloc");
+#endif
+}
 
+TEST_CASE("mapsNonOverlappingly.AlignedAoS")
+{
+    constexpr auto mapping = llama::mapping::AlignedAoS<llama::ArrayDims<2>, Particle>{{32, 32}};
 #ifdef __cpp_constexpr_dynamic_alloc
     STATIC_REQUIRE(llama::mapsNonOverlappingly(mapping));
 #else

--- a/tests/splitmapping.cpp
+++ b/tests/splitmapping.cpp
@@ -5,7 +5,7 @@
 #include <llama/DumpMapping.hpp>
 #include <llama/llama.hpp>
 
-TEST_CASE("Split.SoA.AoS.1Buffer")
+TEST_CASE("Split.SoA_SingleBlob.AoS_Packed.1Buffer")
 {
     using ArrayDims = llama::ArrayDims<2>;
     auto arrayDims = ArrayDims{16, 16};
@@ -30,7 +30,7 @@ TEST_CASE("Split.SoA.AoS.1Buffer")
     CHECK(mapping.blobNrAndOffset<3, 3>(coord) == llama::NrAndOffset{0, mapping1Size + 55});
 }
 
-TEST_CASE("Split.AoSoA8.AoS.One.SoA.4Buffer")
+TEST_CASE("Split.AoSoA8.AoS_Packed.One.SoA_SingleBlob.4Buffer")
 {
     // split out momentum as AoSoA8, mass into a single value, position into AoS, and the flags into SoA, makes 4
     // buffers

--- a/tests/view.cpp
+++ b/tests/view.cpp
@@ -19,10 +19,12 @@ TEST_CASE("view.default-ctor")
     using ArrayDims = llama::ArrayDims<2>;
     constexpr ArrayDims viewSize{16, 16};
 
-    [[maybe_unused]] llama::View<llama::mapping::SoA<ArrayDims, RecordDim>, std::byte*> view1;
-    [[maybe_unused]] llama::View<llama::mapping::AoS<ArrayDims, RecordDim>, std::byte*> view2;
-    [[maybe_unused]] llama::View<llama::mapping::One<ArrayDims, RecordDim>, std::byte*> view3;
-    [[maybe_unused]] llama::View<llama::mapping::tree::Mapping<ArrayDims, RecordDim, llama::Tuple<>>, std::byte*> view4;
+    [[maybe_unused]] llama::View<llama::mapping::AlignedAoS<ArrayDims, RecordDim>, std::byte*> view1;
+    [[maybe_unused]] llama::View<llama::mapping::PackedAoS<ArrayDims, RecordDim>, std::byte*> view2;
+    [[maybe_unused]] llama::View<llama::mapping::SingleBlobSoA<ArrayDims, RecordDim>, std::byte*> view3;
+    [[maybe_unused]] llama::View<llama::mapping::MultiBlobSoA<ArrayDims, RecordDim>, std::byte*> view4;
+    [[maybe_unused]] llama::View<llama::mapping::One<ArrayDims, RecordDim>, std::byte*> view5;
+    [[maybe_unused]] llama::View<llama::mapping::tree::Mapping<ArrayDims, RecordDim, llama::Tuple<>>, std::byte*> view6;
 }
 
 TEST_CASE("view.move")
@@ -192,7 +194,7 @@ TEST_CASE("view.addresses")
     using ArrayDims = llama::ArrayDims<2>;
     ArrayDims arrayDims{16, 16};
 
-    using Mapping = llama::mapping::SoA<ArrayDims, Particle>;
+    using Mapping = llama::mapping::SingleBlobSoA<ArrayDims, Particle>;
     Mapping mapping{arrayDims};
     auto view = allocView(mapping);
 


### PR DESCRIPTION
This PR changes the defaults for `AoS` and `SoA` to align better with user expectations:

AoS will use alignment and padding by default. This is how native structs in C++ behave.
SoA will use multible blobs by default. This is how SoA is usually implemented. It is sometimes also more efficient.