### PR TITLE
Fix nvcc compilation with MSVC

### DIFF
--- a/include/llama/macros.hpp
+++ b/include/llama/macros.hpp
@@ -44,7 +44,7 @@
 #ifndef LLAMA_LAMBDA_INLINE_WITH_SPECIFIERS
 #    if defined(__clang__) || defined(__INTEL_LLVM_COMPILER)
 #        define LLAMA_LAMBDA_INLINE_WITH_SPECIFIERS(...) __attribute__((always_inline)) __VA_ARGS__
-#    elif defined(__GNUC__) || defined(__INTEL_COMPILER) || defined(__NVCC__)
+#    elif defined(__GNUC__) || defined(__INTEL_COMPILER) || (defined(__NVCC__) && !defined(_MSC_VER))
 #        define LLAMA_LAMBDA_INLINE_WITH_SPECIFIERS(...) __VA_ARGS__ __attribute__((always_inline))
 #    elif defined(_MSC_VER)
 #        define LLAMA_LAMBDA_INLINE_WITH_SPECIFIERS(...)                                                              \

--- a/include/llama/mapping/AoS.hpp
+++ b/include/llama/mapping/AoS.hpp
@@ -50,10 +50,9 @@ namespace llama::mapping
         {
             constexpr std::size_t flatIndex =
 #ifdef __NVCC__
-                Flattener{}.template flatIndex<RecordCoords...>;
-#else
-                Flattener::template flatIndex<RecordCoords...>;
+                *& // mess with nvcc compiler state to workaround bug
 #endif
+                 Flattener::template flatIndex<RecordCoords...>;
             const auto offset
                 = LinearizeArrayDimsFunctor{}(coord, arrayDimsSize)
                     * flatSizeOf<

--- a/include/llama/mapping/One.hpp
+++ b/include/llama/mapping/One.hpp
@@ -52,10 +52,9 @@ namespace llama::mapping
         {
             constexpr std::size_t flatIndex =
 #ifdef __NVCC__
-                Flattener{}.template flatIndex<RecordCoords...>;
-#else
-                Flattener::template flatIndex<RecordCoords...>;
+                *& // mess with nvcc compiler state to workaround bug
 #endif
+                 Flattener::template flatIndex<RecordCoords...>;
             constexpr auto offset = flatOffsetOf<typename Flattener::FlatRecordDim, flatIndex, AlignAndPad>;
             return {0, offset};
         }


### PR DESCRIPTION
This PR fixes compiling with nvcc and MSVC by different handling inside `LLAMA_LAMBDA_INLINE_WITH_SPECIFIERS` and finding a different workaround for an nvcc bug.