### PR TITLE
Fix AoSoA blob size for array dims not divisible by Lanes

### DIFF
--- a/include/llama/Core.hpp
+++ b/include/llama/Core.hpp
@@ -558,4 +558,11 @@ namespace llama
         {
         };
     } // namespace internal
+
+    /// Returns the integral n rounded up to be a multiple of mult.
+    template<typename Integral>
+    LLAMA_FN_HOST_ACC_INLINE constexpr auto roundUpToMultiple(Integral n, Integral mult) -> Integral
+    {
+        return (n + mult - 1) / mult * mult;
+    }
 } // namespace llama

--- a/include/llama/mapping/AoSoA.hpp
+++ b/include/llama/mapping/AoSoA.hpp
@@ -53,11 +53,14 @@ namespace llama::mapping
 
         LLAMA_FN_HOST_ACC_INLINE constexpr auto blobSize(std::size_t) const -> std::size_t
         {
-            return LinearizeArrayDimsFunctor{}.size(arrayDimsSize) * sizeOf<RecordDim>;
+            return roundUpToMultiple(
+                LinearizeArrayDimsFunctor{}.size(arrayDimsSize) * sizeOf<RecordDim>,
+                Lanes * sizeOf<RecordDim>);
         }
 
         template<std::size_t... RecordCoords>
-        LLAMA_FN_HOST_ACC_INLINE constexpr auto blobNrAndOffset(ArrayDims coord) const -> NrAndOffset
+        LLAMA_FN_HOST_ACC_INLINE constexpr auto blobNrAndOffset(ArrayDims coord, RecordCoord<RecordCoords...> = {})
+            const -> NrAndOffset
         {
             const auto flatArrayIndex = LinearizeArrayDimsFunctor{}(coord, arrayDimsSize);
             const auto blockIndex = flatArrayIndex / Lanes;

--- a/tests/mapping.cpp
+++ b/tests/mapping.cpp
@@ -631,3 +631,32 @@ TEST_CASE("maxLanes")
     STATIC_REQUIRE(llama::mapping::maxLanes<RecordDim2, 256> == 16);
     STATIC_REQUIRE(llama::mapping::maxLanes<RecordDim2, 512> == 32);
 }
+
+TEST_CASE("AoSoA.size_round_up")
+{
+    using AoSoA = llama::mapping::AoSoA<llama::ArrayDims<1>, Particle, 4>;
+    constexpr auto psize = llama::sizeOf<Particle>;
+
+    CHECK(AoSoA{{0}}.blobSize(0) == 0 * psize);
+    CHECK(AoSoA{{1}}.blobSize(0) == 4 * psize);
+    CHECK(AoSoA{{2}}.blobSize(0) == 4 * psize);
+    CHECK(AoSoA{{3}}.blobSize(0) == 4 * psize);
+    CHECK(AoSoA{{4}}.blobSize(0) == 4 * psize);
+    CHECK(AoSoA{{5}}.blobSize(0) == 8 * psize);
+    CHECK(AoSoA{{6}}.blobSize(0) == 8 * psize);
+    CHECK(AoSoA{{7}}.blobSize(0) == 8 * psize);
+    CHECK(AoSoA{{8}}.blobSize(0) == 8 * psize);
+    CHECK(AoSoA{{9}}.blobSize(0) == 12 * psize);
+}
+
+TEST_CASE("AoSoA.address_within_bounds")
+{
+    using AD = llama::ArrayDims<1>;
+    using AoSoA = llama::mapping::AoSoA<AD, Particle, 4>;
+
+    const auto ad = AD{3};
+    auto mapping = AoSoA{ad};
+    for(auto i : llama::ArrayDimsIndexRange{ad})
+        llama::forEachLeaf<Particle>([&](auto rc)
+                                     { CHECK(mapping.blobNrAndOffset(i, rc).offset < mapping.blobSize(0)); });
+}


### PR DESCRIPTION
Rounds up the blob size of the AoSoA mappings to avoid out of bounds access.
This PR also adds a new function `roundUpToMultiple`.