### PR TITLE
Fix build for VS 16.11

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -28,9 +28,11 @@ if (BUILD_TESTING)
 	file(GLOB_RECURSE testSources "${CMAKE_CURRENT_SOURCE_DIR}/tests/**")
 	add_executable(tests ${testSources})
 	source_group(TREE "${CMAKE_CURRENT_LIST_DIR}/tests" FILES ${testSources})
-	target_compile_features(tests PRIVATE cxx_std_20)
 	if (MSVC)
+		target_compile_options(tests PRIVATE /std:c++latest) # C++20 does not include ranges yet in MSVC, because the ABI is not finalized
 		target_compile_options(tests PRIVATE /permissive- /constexpr:steps10000000 /diagnostics:caret)
+	else()
+		target_compile_features(tests PRIVATE cxx_std_20)
 	endif()
 	target_link_libraries(tests PRIVATE Catch2::Catch2 llama::llama)
 

--- a/include/llama/Copy.hpp
+++ b/include/llama/Copy.hpp
@@ -144,8 +144,8 @@ namespace llama
         using RecordDim = typename SrcMapping::RecordDim;
         internal::assertTrivialCopyable<RecordDim>();
 
-        constexpr bool MBSrc = SrcMapping::blobCount > 1;
-        constexpr bool MBDst = DstMapping::blobCount > 1;
+        static constexpr bool MBSrc = SrcMapping::blobCount > 1;
+        static constexpr bool MBDst = DstMapping::blobCount > 1;
         static constexpr auto LanesSrc = internal::aosoaLanes<SrcMapping>;
         static constexpr auto LanesDst = internal::aosoaLanes<DstMapping>;
 
@@ -214,7 +214,7 @@ namespace llama
             }
         };
 
-        constexpr auto L = []
+        static constexpr auto L = []
         {
             if constexpr(srcIsAoSoA && dstIsAoSoA)
                 return std::gcd(LanesSrc, LanesDst);


### PR DESCRIPTION
VS 16.11 introduced a flag to select C++20: `/std:c++20`, which CMake now sets instead of requesting `/std:c++latest`. This is a problem because `/std:c++20` does not include ranges yet in MSVC, because the ABI is not finalized.