### PR TITLE
VirtualRecord and View size reductions

### DIFF
--- a/examples/alpaka/asyncblur/asyncblur.cpp
+++ b/examples/alpaka/asyncblur/asyncblur.cpp
@@ -105,8 +105,14 @@ struct BlurKernel
             const std::size_t bStart[2]
                 = {bi[0] * ElemsPerBlock + threadIdxInBlock[0], bi[1] * ElemsPerBlock + threadIdxInBlock[1]};
             const std::size_t bEnd[2] = {
-                alpaka::math::min(acc, bStart[0] + ElemsPerBlock + 2 * KernelSize, oldImage.mapping.arrayDimsSize[0]),
-                alpaka::math::min(acc, bStart[1] + ElemsPerBlock + 2 * KernelSize, oldImage.mapping.arrayDimsSize[1]),
+                alpaka::math::min(
+                    acc,
+                    bStart[0] + ElemsPerBlock + 2 * KernelSize,
+                    oldImage.mapping().arrayDimsSize[0]),
+                alpaka::math::min(
+                    acc,
+                    bStart[1] + ElemsPerBlock + 2 * KernelSize,
+                    oldImage.mapping().arrayDimsSize[1]),
             };
             LLAMA_INDEPENDENT_DATA
             for(auto y = bStart[0]; y < bEnd[0]; y += threadsPerBlock)
@@ -119,8 +125,8 @@ struct BlurKernel
 
         const std::size_t start[2] = {ti[0] * Elems, ti[1] * Elems};
         const std::size_t end[2] = {
-            alpaka::math::min(acc, start[0] + Elems, oldImage.mapping.arrayDimsSize[0] - 2 * KernelSize),
-            alpaka::math::min(acc, start[1] + Elems, oldImage.mapping.arrayDimsSize[1] - 2 * KernelSize),
+            alpaka::math::min(acc, start[0] + Elems, oldImage.mapping().arrayDimsSize[0] - 2 * KernelSize),
+            alpaka::math::min(acc, start[1] + Elems, oldImage.mapping().arrayDimsSize[1] - 2 * KernelSize),
         };
 
         LLAMA_INDEPENDENT_DATA

--- a/examples/viewcopy/viewcopy.cpp
+++ b/examples/viewcopy/viewcopy.cpp
@@ -51,7 +51,7 @@ void std_copy(const llama::View<SrcMapping, SrcBlobType>& srcView, llama::View<D
 {
     static_assert(std::is_same_v<typename SrcMapping::RecordDim, typename DstMapping::RecordDim>);
 
-    if(srcView.mapping.arrayDims() != dstView.mapping.arrayDims())
+    if(srcView.mapping().arrayDims() != dstView.mapping().arrayDims())
         throw std::runtime_error{"Array dimensions sizes are different"};
 
     std::copy(srcView.begin(), srcView.end(), dstView.begin());
@@ -105,7 +105,7 @@ template<typename Mapping, typename BlobType>
 auto hash(const llama::View<Mapping, BlobType>& view)
 {
     std::size_t acc = 0;
-    for(auto ad : llama::ArrayDimsIndexRange{view.mapping.arrayDims()})
+    for(auto ad : llama::ArrayDimsIndexRange{view.mapping().arrayDims()})
         llama::forEachLeaf<typename Mapping::RecordDim>([&](auto coord)
                                                         { boost::hash_combine(acc, view(ad)(coord)); });
     return acc;

--- a/include/llama/Copy.hpp
+++ b/include/llama/Copy.hpp
@@ -54,7 +54,7 @@ namespace llama
         internal::assertTrivialCopyable<typename Mapping::RecordDim>();
 
         // TODO: we do not verify if the mappings have other runtime state than the array dimensions
-        if(srcView.mapping.arrayDims() != dstView.mapping.arrayDims())
+        if(srcView.mapping().arrayDims() != dstView.mapping().arrayDims())
             throw std::runtime_error{"Array dimensions sizes are different"};
 
         // TODO: this is maybe not the best parallel copying strategy
@@ -62,7 +62,7 @@ namespace llama
             internal::parallel_memcpy(
                 &dstView.storageBlobs[i][0],
                 &srcView.storageBlobs[i][0],
-                dstView.mapping.blobSize(i),
+                dstView.mapping().blobSize(i),
                 threadId,
                 threadCount);
     }
@@ -82,7 +82,7 @@ namespace llama
             std::is_same_v<typename SrcMapping::RecordDim, typename DstMapping::RecordDim>,
             "The source and destination record dimensions must be the same");
 
-        if(srcView.mapping.arrayDims() != dstView.mapping.arrayDims())
+        if(srcView.mapping().arrayDims() != dstView.mapping().arrayDims())
             throw std::runtime_error{"Array dimensions sizes are different"};
 
         auto copyOne = [&](auto ad) LLAMA_LAMBDA_INLINE
@@ -92,7 +92,7 @@ namespace llama
         };
 
         constexpr auto dims = SrcMapping::ArrayDims::rank;
-        const auto& adSize = srcView.mapping.arrayDims();
+        const auto& adSize = srcView.mapping().arrayDims();
         const auto workPerThread = (adSize[0] + threadCount - 1) / threadCount;
         const auto start = threadId * workPerThread;
         const auto end = std::min((threadId + 1) * workPerThread, adSize[0]);
@@ -149,7 +149,7 @@ namespace llama
         static constexpr auto LanesSrc = internal::aosoaLanes<SrcMapping>;
         static constexpr auto LanesDst = internal::aosoaLanes<DstMapping>;
 
-        if(srcView.mapping.arrayDims() != dstView.mapping.arrayDims())
+        if(srcView.mapping().arrayDims() != dstView.mapping().arrayDims())
             throw std::runtime_error{"Array dimensions sizes are different"};
 
         static constexpr auto srcIsAoSoA = LanesSrc != std::numeric_limits<std::size_t>::max();
@@ -163,7 +163,7 @@ namespace llama
             !dstIsAoSoA || decltype(dstView.storageBlobs)::rank == 1,
             "Implementation assumes AoSoA with single blob");
 
-        const auto arrayDims = dstView.mapping.arrayDims();
+        const auto arrayDims = dstView.mapping().arrayDims();
         const auto flatSize
             = std::reduce(std::begin(arrayDims), std::end(arrayDims), std::size_t{1}, std::multiplies<>{});
 

--- a/include/llama/Core.hpp
+++ b/include/llama/Core.hpp
@@ -28,6 +28,10 @@ namespace llama
     static_assert(std::is_trivially_default_constructible_v<ArrayDims<1>>); // so ArrayDims<1>{} will produce a zeroed
                                                                             // coord. Should hold for all dimensions,
                                                                             // but just checking for <1> here.
+    static_assert(std::is_trivially_copy_constructible_v<ArrayDims<1>>);
+    static_assert(std::is_trivially_move_constructible_v<ArrayDims<1>>);
+    static_assert(std::is_trivially_copy_assignable_v<ArrayDims<1>>);
+    static_assert(std::is_trivially_move_assignable_v<ArrayDims<1>>);
 
     template<typename... Args>
     ArrayDims(Args...) -> ArrayDims<sizeof...(Args)>;

--- a/include/llama/Vector.hpp
+++ b/include/llama/Vector.hpp
@@ -178,7 +178,7 @@ namespace llama
 
         LLAMA_FN_HOST_ACC_INLINE auto capacity() const -> std::size_t
         {
-            return m_view.mapping.arrayDims()[0];
+            return m_view.mapping().arrayDims()[0];
         }
 
         LLAMA_FN_HOST_ACC_INLINE void shrink_to_fit()

--- a/tests/common.hpp
+++ b/tests/common.hpp
@@ -122,7 +122,7 @@ template<typename View>
 void zeroStorage(View& view)
 {
     for(auto i = 0; i < View::Mapping::blobCount; i++)
-        internal::zeroBlob(view.storageBlobs[i], view.mapping.blobSize(i));
+        internal::zeroBlob(view.storageBlobs[i], view.mapping().blobSize(i));
 }
 
 template<typename View>
@@ -131,6 +131,6 @@ void iotaStorage(View& view)
     for(auto i = 0; i < View::Mapping::blobCount; i++)
     {
         auto fillFunc = [val = 0]() mutable { return static_cast<typename View::BlobType::PrimType>(val++); };
-        std::generate_n(view.storageBlobs[i].storageBlobs.get(), view.mapping.blobSize(i), fillFunc);
+        std::generate_n(view.storageBlobs[i].storageBlobs.get(), view.mapping().blobSize(i), fillFunc);
     }
 }

--- a/tests/heatmap.cpp
+++ b/tests/heatmap.cpp
@@ -35,7 +35,7 @@ TEST_CASE("Heatmap.nbody")
         for(std::size_t i = 0; i < N; i++)
             particles(i)(tag::Pos{}) += particles(i)(tag::Vel{}) * TIMESTEP;
 
-        std::ofstream{"Heatmap." + name + ".sh"} << particles.mapping.toGnuplotScript();
+        std::ofstream{"Heatmap." + name + ".sh"} << particles.mapping().toGnuplotScript();
     };
 
     using ArrayDims = llama::ArrayDims<1>;

--- a/tests/virtualrecord.cpp
+++ b/tests/virtualrecord.cpp
@@ -955,20 +955,17 @@ TEST_CASE("VirtualRecord.size")
     auto view = llama::allocView(llama::mapping::AoS{llama::ArrayDims{5}, ParticleInt{}});
     [[maybe_unused]] auto vr = view[0];
     STATIC_REQUIRE(
-        sizeof(vr) == sizeof(llama::ArrayDims<1>::value_type) + sizeof(&view)); // sizeof array dims and view reference
+        sizeof(vr)
+        == sizeof(llama::ArrayDims<1>::value_type) + sizeof(&view)); // sizeof array dims and view reference // NOLINT
 }
 
 TEST_CASE("VirtualRecord.One.size")
 {
     STATIC_REQUIRE(llama::mapping::MinAlignedOne<llama::ArrayDims<0>, Particle>{}.blobSize(0) == 56);
-#ifdef __has_cpp_attribute
-#    if __has_cpp_attribute(no_unique_address)
     [[maybe_unused]] const auto v = llama::allocViewStack<0, Particle>();
     STATIC_REQUIRE(sizeof(v) == 56);
     [[maybe_unused]] const auto p = llama::One<Particle>{};
     STATIC_REQUIRE(sizeof(p) == 56);
-#    endif
-#endif
 }
 
 TEST_CASE("VirtualRecord.operator<<")

--- a/tests/virtualrecord.cpp
+++ b/tests/virtualrecord.cpp
@@ -950,18 +950,26 @@ TEST_CASE("VirtualRecord.One_from_scalar")
     CHECK(p(tag::Mass{}) == 42);
 }
 
-#ifdef __has_cpp_attribute
-#    if __has_cpp_attribute(no_unique_address)
+TEST_CASE("VirtualRecord.size")
+{
+    auto view = llama::allocView(llama::mapping::AoS{llama::ArrayDims{5}, ParticleInt{}});
+    [[maybe_unused]] auto vr = view[0];
+    STATIC_REQUIRE(
+        sizeof(vr) == sizeof(llama::ArrayDims<1>::value_type) + sizeof(&view)); // sizeof array dims and view reference
+}
+
 TEST_CASE("VirtualRecord.One.size")
 {
     STATIC_REQUIRE(llama::mapping::MinAlignedOne<llama::ArrayDims<0>, Particle>{}.blobSize(0) == 56);
+#ifdef __has_cpp_attribute
+#    if __has_cpp_attribute(no_unique_address)
     [[maybe_unused]] const auto v = llama::allocViewStack<0, Particle>();
     STATIC_REQUIRE(sizeof(v) == 56);
     [[maybe_unused]] const auto p = llama::One<Particle>{};
     STATIC_REQUIRE(sizeof(p) == 56);
-}
 #    endif
 #endif
+}
 
 TEST_CASE("VirtualRecord.operator<<")
 {


### PR DESCRIPTION
This PR reduces the size of `VirtualRecord` and `View` using empty base optimization. It also asserts that the special member functions of `ArrayDims` are trivial.