### PR TITLE
Sufficiently align blobs

### DIFF
--- a/docs/pages/api.rst
+++ b/docs/pages/api.rst
@@ -47,6 +47,7 @@ Record dimension
 .. doxygentypedef:: llama::GetFieldType
 .. doxygenvariable:: llama::offsetOf
 .. doxygenvariable:: llama::sizeOf
+.. doxygenvariable:: llama::alignOf
 .. doxygentypedef:: llama::GetTags
 .. doxygentypedef:: llama::GetTag
 .. doxygenvariable:: llama::hasSameTags

--- a/examples/cuda/nbody/nbody.cu
+++ b/examples/cuda/nbody/nbody.cu
@@ -210,10 +210,11 @@ try
     auto hostView = llama::allocView(mapping);
     auto accView = llama::allocView(
         mapping,
-        [](std::size_t size)
+        [](auto alignment, std::size_t size)
         {
             std::byte* p;
             checkError(cudaMalloc(&p, size));
+            assert(reinterpret_cast<std::intptr_t>(p) & (alignment - 1) == 0); // assert cudaMalloc sufficiently aligns
             return p;
         });
 

--- a/examples/nbody_benchmark/nbody.cpp
+++ b/examples/nbody_benchmark/nbody.cpp
@@ -94,7 +94,10 @@ void run(std::ostream& plotFile)
             return llama::mapping::SoA<decltype(arrayDims), Particle, true>{arrayDims};
     }();
 
-    auto particles = llama::allocView(std::move(mapping), llama::bloballoc::Vector<Alignment>{});
+    auto particles = llama::allocView(
+        std::move(mapping),
+        [](auto, std::size_t size)
+        { return llama::bloballoc::Vector{}(std::integral_constant<std::size_t, Alignment>{}, size); });
 
     if constexpr(PRINT_BLOCK_PLACEMENT)
     {

--- a/include/llama/Concepts.hpp
+++ b/include/llama/Concepts.hpp
@@ -34,8 +34,8 @@ namespace llama
 
     // clang-format off
     template <typename BA>
-    concept BlobAllocator = requires(BA ba, std::size_t i) {
-        { ba(i) } -> Blob;
+    concept BlobAllocator = requires(BA ba, std::integral_constant<std::size_t, 16> alignment, std::size_t size) {
+        { ba(alignment, size) } -> Blob;
     };
     // clang-format on
 } // namespace llama

--- a/tests/core.cpp
+++ b/tests/core.cpp
@@ -110,6 +110,25 @@ TEST_CASE("offsetOf.Align")
     STATIC_REQUIRE(llama::offsetOf<Particle, llama::RecordCoord<3, 3>, true> == 59);
 }
 
+TEST_CASE("alignOf")
+{
+    STATIC_REQUIRE(llama::alignOf<std::byte> == 1);
+    STATIC_REQUIRE(llama::alignOf<unsigned short> == 2);
+    STATIC_REQUIRE(llama::alignOf<float> == 4);
+    STATIC_REQUIRE(llama::alignOf<Vec3D> == 8);
+    STATIC_REQUIRE(llama::alignOf<Vec2F> == 4);
+    STATIC_REQUIRE(llama::alignOf<Particle> == 8);
+
+    struct alignas(32) Overaligned
+    {
+    };
+
+    using OveralignedRD = llama::Record<llama::Field<int, Overaligned>>;
+
+    STATIC_REQUIRE(llama::alignOf<Overaligned> == 32);
+    STATIC_REQUIRE(llama::alignOf<OveralignedRD> == 32);
+}
+
 namespace
 {
     // clang-format off

--- a/tests/virtualrecord.cpp
+++ b/tests/virtualrecord.cpp
@@ -968,6 +968,13 @@ TEST_CASE("VirtualRecord.One.size")
     STATIC_REQUIRE(sizeof(p) == 56);
 }
 
+TEST_CASE("VirtualRecord.One.alignment")
+{
+    STATIC_REQUIRE(alignof(llama::One<Vec2F>) == 4);
+    STATIC_REQUIRE(alignof(llama::One<Vec3I>) == 4);
+    STATIC_REQUIRE(alignof(llama::One<Particle>) == 8);
+}
+
 TEST_CASE("VirtualRecord.operator<<")
 {
     llama::One<Particle> p;


### PR DESCRIPTION
This PR fixes #339, by extending the blob allocator interface to also receive an alignment. This alignment is computed in `allocView`.
The new APIs `alignOf` and `flatAlignOf` are added as well.