### PR TITLE
Let blobNrAndOffset deduce record coordinates

### DIFF
--- a/examples/bufferguard/bufferguard.cpp
+++ b/examples/bufferguard/bufferguard.cpp
@@ -70,7 +70,8 @@ struct GuardMapping2D
     }
 
     template<std::size_t... RecordCoords>
-    constexpr auto blobNrAndOffset(ArrayDims coord) const -> llama::NrAndOffset
+    constexpr auto blobNrAndOffset(ArrayDims coord, llama::RecordCoord<RecordCoords...> rc = {}) const
+        -> llama::NrAndOffset
     {
         // [0][0] is at left top
         const auto [row, col] = coord;
@@ -79,24 +80,24 @@ struct GuardMapping2D
         if(col == 0)
         {
             if(row == 0)
-                return offsetBlobNr(leftTop.template blobNrAndOffset<RecordCoords...>({}), leftTopOff);
+                return offsetBlobNr(leftTop.blobNrAndOffset({}, rc), leftTopOff);
             if(row == rowMax - 1)
-                return offsetBlobNr(leftBot.template blobNrAndOffset<RecordCoords...>({}), leftBotOff);
-            return offsetBlobNr(left.template blobNrAndOffset<RecordCoords...>({row - 1}), leftOff);
+                return offsetBlobNr(leftBot.blobNrAndOffset({}, rc), leftBotOff);
+            return offsetBlobNr(left.blobNrAndOffset({row - 1}, rc), leftOff);
         }
         if(col == colMax - 1)
         {
             if(row == 0)
-                return offsetBlobNr(rightTop.template blobNrAndOffset<RecordCoords...>({}), rightTopOff);
+                return offsetBlobNr(rightTop.blobNrAndOffset({}, rc), rightTopOff);
             if(row == rowMax - 1)
-                return offsetBlobNr(rightBot.template blobNrAndOffset<RecordCoords...>({}), rightBotOff);
-            return offsetBlobNr(right.template blobNrAndOffset<RecordCoords...>({row - 1}), rightOff);
+                return offsetBlobNr(rightBot.blobNrAndOffset({}, rc), rightBotOff);
+            return offsetBlobNr(right.blobNrAndOffset({row - 1}, rc), rightOff);
         }
         if(row == 0)
-            return offsetBlobNr(top.template blobNrAndOffset<RecordCoords...>({col - 1}), topOff);
+            return offsetBlobNr(top.blobNrAndOffset({col - 1}, rc), topOff);
         if(row == rowMax - 1)
-            return offsetBlobNr(bot.template blobNrAndOffset<RecordCoords...>({col - 1}), botOff);
-        return offsetBlobNr(center.template blobNrAndOffset<RecordCoords...>({row - 1, col - 1}), centerOff);
+            return offsetBlobNr(bot.blobNrAndOffset({col - 1}, rc), botOff);
+        return offsetBlobNr(center.blobNrAndOffset({row - 1, col - 1}, rc), centerOff);
     }
 
     constexpr auto centerBlobs() const

--- a/include/llama/Concepts.hpp
+++ b/include/llama/Concepts.hpp
@@ -21,6 +21,8 @@ namespace llama
         Array<int, M::blobCount>{}; // validates constexpr-ness
         { m.blobSize(std::size_t{}) } -> std::same_as<std::size_t>;
         { m.blobNrAndOffset(typename M::ArrayDims{}) } -> std::same_as<NrAndOffset>;
+        { m.template blobNrAndOffset<0>(typename M::ArrayDims{}) } -> std::same_as<NrAndOffset>;
+        { m.blobNrAndOffset(typename M::ArrayDims{}, llama::RecordCoord<0>{}) } -> std::same_as<NrAndOffset>;
     };
     // clang-format on
 

--- a/include/llama/DumpMapping.hpp
+++ b/include/llama/DumpMapping.hpp
@@ -56,12 +56,6 @@ namespace llama
             return v;
         }
 
-        template<typename Mapping, typename ArrayDims, std::size_t... Coords>
-        auto mappingBlobNrAndOffset(const Mapping& mapping, const ArrayDims& adCoord, RecordCoord<Coords...>)
-        {
-            return mapping.template blobNrAndOffset<Coords...>(adCoord);
-        }
-
         inline auto color(const std::vector<std::size_t>& recordCoord) -> std::size_t
         {
             auto c = boost::hash<std::vector<std::size_t>>{}(recordCoord) &0xFFFFFF;
@@ -130,7 +124,7 @@ namespace llama
                             {adCoord,
                              internal::toVec(coord),
                              internal::tagsAsStrings<RecordDim>(coord),
-                             internal::mappingBlobNrAndOffset(mapping, adCoord, coord),
+                             mapping.blobNrAndOffset(adCoord, coord),
                              size});
                     });
             }

--- a/include/llama/Proofs.hpp
+++ b/include/llama/Proofs.hpp
@@ -9,12 +9,6 @@ namespace llama
 {
     namespace internal
     {
-        template<typename Mapping, std::size_t... Is, typename ArrayDims>
-        constexpr auto blobNrAndOffset(const Mapping& m, RecordCoord<Is...>, ArrayDims ad)
-        {
-            return m.template blobNrAndOffset<Is...>(ad);
-        }
-
         constexpr auto divRoundUp(std::size_t dividend, std::size_t divisor) -> std::size_t
         {
             return (dividend + divisor - 1) / divisor;
@@ -79,8 +73,7 @@ namespace llama
                                                      {
                                                          using Type
                                                              = GetType<typename Mapping::RecordDim, decltype(coord)>;
-                                                         const auto [blob, offset]
-                                                             = internal::blobNrAndOffset(m, coord, ad);
+                                                         const auto [blob, offset] = m.blobNrAndOffset(ad, coord);
                                                          for(auto b = 0; b < sizeof(Type); b++)
                                                              if(testAndSet(blob, offset + b))
                                                              {
@@ -110,8 +103,7 @@ namespace llama
                                                      {
                                                          using Type
                                                              = GetType<typename Mapping::RecordDim, decltype(coord)>;
-                                                         const auto [blob, offset]
-                                                             = internal::blobNrAndOffset(m, coord, ad);
+                                                         const auto [blob, offset] = m.blobNrAndOffset(ad, coord);
                                                          if(flatIndex % PieceLength != 0
                                                             && (lastBlob != blob
                                                                 || lastOffset + sizeof(Type) != offset))

--- a/include/llama/View.hpp
+++ b/include/llama/View.hpp
@@ -396,14 +396,14 @@ namespace llama
 
         LLAMA_SUPPRESS_HOST_DEVICE_WARNING
         template<std::size_t... Coords>
-        LLAMA_FN_HOST_ACC_INLINE auto accessor(ArrayDims arrayDims, RecordCoord<Coords...> dc = {}) const
+        LLAMA_FN_HOST_ACC_INLINE auto accessor(ArrayDims arrayDims, RecordCoord<Coords...> rc = {}) const
             -> decltype(auto)
         {
             if constexpr(isComputed<Mapping, RecordCoord<Coords...>>)
-                return mapping().compute(arrayDims, dc, storageBlobs);
+                return mapping().compute(arrayDims, rc, storageBlobs);
             else
             {
-                const auto [nr, offset] = mapping().template blobNrAndOffset<Coords...>(arrayDims);
+                const auto [nr, offset] = mapping().blobNrAndOffset(arrayDims, rc);
                 using Type = GetType<RecordDim, RecordCoord<Coords...>>;
                 return reinterpret_cast<const Type&>(storageBlobs[nr][offset]);
             }
@@ -411,13 +411,13 @@ namespace llama
 
         LLAMA_SUPPRESS_HOST_DEVICE_WARNING
         template<std::size_t... Coords>
-        LLAMA_FN_HOST_ACC_INLINE auto accessor(ArrayDims arrayDims, RecordCoord<Coords...> dc = {}) -> decltype(auto)
+        LLAMA_FN_HOST_ACC_INLINE auto accessor(ArrayDims arrayDims, RecordCoord<Coords...> rc = {}) -> decltype(auto)
         {
             if constexpr(isComputed<Mapping, RecordCoord<Coords...>>)
-                return mapping().compute(arrayDims, dc, storageBlobs);
+                return mapping().compute(arrayDims, rc, storageBlobs);
             else
             {
-                const auto [nr, offset] = mapping().template blobNrAndOffset<Coords...>(arrayDims);
+                const auto [nr, offset] = mapping().blobNrAndOffset(arrayDims, rc);
                 using Type = GetType<RecordDim, RecordCoord<Coords...>>;
                 return reinterpret_cast<Type&>(storageBlobs[nr][offset]);
             }

--- a/include/llama/mapping/AoS.hpp
+++ b/include/llama/mapping/AoS.hpp
@@ -46,7 +46,8 @@ namespace llama::mapping
         }
 
         template<std::size_t... RecordCoords>
-        LLAMA_FN_HOST_ACC_INLINE constexpr auto blobNrAndOffset(ArrayDims coord) const -> NrAndOffset
+        LLAMA_FN_HOST_ACC_INLINE constexpr auto blobNrAndOffset(ArrayDims coord, RecordCoord<RecordCoords...> = {})
+            const -> NrAndOffset
         {
             constexpr std::size_t flatIndex =
 #ifdef __NVCC__

--- a/include/llama/mapping/Heatmap.hpp
+++ b/include/llama/mapping/Heatmap.hpp
@@ -47,9 +47,10 @@ namespace llama::mapping
         }
 
         template<std::size_t... RecordCoords>
-        LLAMA_FN_HOST_ACC_INLINE auto blobNrAndOffset(ArrayDims coord) const -> NrAndOffset
+        LLAMA_FN_HOST_ACC_INLINE auto blobNrAndOffset(ArrayDims coord, RecordCoord<RecordCoords...> rc = {}) const
+            -> NrAndOffset
         {
-            const auto nao = mapping.template blobNrAndOffset<RecordCoords...>(coord);
+            const auto nao = mapping.blobNrAndOffset(coord, rc);
             for(auto i = 0; i < sizeof(GetType<RecordDim, RecordCoord<RecordCoords...>>); i++)
                 byteHits[nao.nr][nao.offset + i]++;
             return nao;

--- a/include/llama/mapping/One.hpp
+++ b/include/llama/mapping/One.hpp
@@ -48,7 +48,8 @@ namespace llama::mapping
         }
 
         template<std::size_t... RecordCoords>
-        LLAMA_FN_HOST_ACC_INLINE constexpr auto blobNrAndOffset(ArrayDims) const -> NrAndOffset
+        LLAMA_FN_HOST_ACC_INLINE constexpr auto blobNrAndOffset(ArrayDims, RecordCoord<RecordCoords...> = {}) const
+            -> NrAndOffset
         {
             constexpr std::size_t flatIndex =
 #ifdef __NVCC__

--- a/include/llama/mapping/SoA.hpp
+++ b/include/llama/mapping/SoA.hpp
@@ -60,7 +60,8 @@ namespace llama::mapping
         }
 
         template<std::size_t... RecordCoords>
-        LLAMA_FN_HOST_ACC_INLINE constexpr auto blobNrAndOffset(ArrayDims coord) const -> NrAndOffset
+        LLAMA_FN_HOST_ACC_INLINE constexpr auto blobNrAndOffset(ArrayDims coord, RecordCoord<RecordCoords...> = {})
+            const -> NrAndOffset
         {
             if constexpr(SeparateBuffers)
             {

--- a/include/llama/mapping/Trace.hpp
+++ b/include/llama/mapping/Trace.hpp
@@ -76,12 +76,13 @@ namespace llama::mapping
         }
 
         template<std::size_t... RecordCoords>
-        LLAMA_FN_HOST_ACC_INLINE auto blobNrAndOffset(ArrayDims coord) const -> NrAndOffset
+        LLAMA_FN_HOST_ACC_INLINE auto blobNrAndOffset(ArrayDims coord, RecordCoord<RecordCoords...> rc = {}) const
+            -> NrAndOffset
         {
             const static auto name = internal::coordName<RecordDim>(RecordCoord<RecordCoords...>{});
             fieldHits.at(name)++;
 
-            LLAMA_FORCE_INLINE_RECURSIVE return mapping.template blobNrAndOffset<RecordCoords...>(coord);
+            LLAMA_FORCE_INLINE_RECURSIVE return mapping.blobNrAndOffset(coord, rc);
         }
 
         Mapping mapping;

--- a/include/llama/mapping/tree/Mapping.hpp
+++ b/include/llama/mapping/tree/Mapping.hpp
@@ -203,7 +203,8 @@ namespace llama::mapping::tree
         }
 
         template<std::size_t... RecordCoords>
-        LLAMA_FN_HOST_ACC_INLINE auto blobNrAndOffset(ArrayDims coord) const -> NrAndOffset
+        LLAMA_FN_HOST_ACC_INLINE auto blobNrAndOffset(ArrayDims coord, RecordCoord<RecordCoords...> = {}) const
+            -> NrAndOffset
         {
             auto const basicTreeCoord = createTreeCoord<RecordCoord<RecordCoords...>>(coord);
             auto const resultTreeCoord = mergedFunctors.basicCoordToResultCoord(basicTreeCoord, basicTree);

--- a/tests/proofs.cpp
+++ b/tests/proofs.cpp
@@ -76,8 +76,8 @@ namespace
             return arraySize * llama::sizeOf<RecordDim>;
         }
 
-        template<std::size_t... DDCs>
-        constexpr auto blobNrAndOffset(ArrayDims) const -> llama::NrAndOffset
+        template<std::size_t... RecordCoords>
+        constexpr auto blobNrAndOffset(ArrayDims, llama::RecordCoord<RecordCoords...> = {}) const -> llama::NrAndOffset
         {
             return {0, 0};
         }
@@ -124,12 +124,13 @@ namespace
             return Modulus * llama::sizeOf<RecordDim>;
         }
 
-        template<std::size_t... DDCs>
-        constexpr auto blobNrAndOffset(ArrayDims coord) const -> llama::NrAndOffset
+        template<std::size_t... RecordCoords>
+        constexpr auto blobNrAndOffset(ArrayDims coord, llama::RecordCoord<RecordCoords...> = {}) const
+            -> llama::NrAndOffset
         {
-            const auto blob = llama::flatRecordCoord<RecordDim, llama::RecordCoord<DDCs...>>;
+            const auto blob = llama::flatRecordCoord<RecordDim, llama::RecordCoord<RecordCoords...>>;
             const auto offset = (llama::mapping::LinearizeArrayDimsCpp{}(coord, arrayDimsSize) % Modulus)
-                * sizeof(llama::GetType<RecordDim, llama::RecordCoord<DDCs...>>);
+                * sizeof(llama::GetType<RecordDim, llama::RecordCoord<RecordCoords...>>);
             return {blob, offset};
         }
 


### PR DESCRIPTION
This is a convenience feature, allowing a mappings `blobNrAndOffset` to be called with explicit template arguments or deduced ones based on a passed instance of `llama::RecordCoord<...>`.