### PR TITLE
Run field constructors when views are allocated

### DIFF
--- a/docs/pages/api.rst
+++ b/docs/pages/api.rst
@@ -36,6 +36,8 @@ Array dimensions
 .. doxygenstruct:: llama::ArrayDimsIndexRange
    :members:
 
+.. doxygenfunction:: llama::forEachADCoord
+
 Record dimension
 ----------------
 
@@ -77,6 +79,8 @@ View creation
 
 .. _label-api-allocView:
 .. doxygenfunction:: llama::allocView
+.. doxygenfunction:: llama::constructFields
+.. doxygenfunction:: llama::allocViewUninitialized
 .. doxygenfunction:: llama::allocViewStack
 .. doxygentypedef:: llama::One
 .. doxygenfunction:: llama::copyVirtualRecordStack

--- a/examples/alpaka/nbody/nbody.cpp
+++ b/examples/alpaka/nbody/nbody.cpp
@@ -184,7 +184,7 @@ struct UpdateKernel
             constexpr auto mapping
                 = llama::mapping::SoA<typename View::ArrayDims, typename View::RecordDim, false>{arrayDims};
             constexpr auto blobAlloc = llama::bloballoc::Stack<llama::sizeOf<typename View::RecordDim> * Elems>{};
-            return llama::allocView(mapping, blobAlloc);
+            return llama::allocViewUninitialized(mapping, blobAlloc);
         }();
         // TODO(bgruber): vector load
         LLAMA_INDEPENDENT_DATA

--- a/examples/alpaka/pic/pic.cpp
+++ b/examples/alpaka/pic/pic.cpp
@@ -297,9 +297,9 @@ auto setup(Queue& queue, const Dev& dev, const DevHost& devHost)
     std::vector<decltype(alpaka::allocBuf<std::byte, Size>(dev, std::size_t{}))> buffers;
     auto allocAlpakaBuffer = [&](auto, std::size_t s)
     { return alpaka::getPtrNative(buffers.emplace_back(alpaka::allocBuf<std::byte, Size>(dev, s))); };
-    auto E = llama::allocView(fieldMapping, allocAlpakaBuffer);
-    auto B = llama::allocView(fieldMapping, allocAlpakaBuffer);
-    auto J = llama::allocView(fieldMapping, allocAlpakaBuffer);
+    auto E = llama::allocViewUninitialized(fieldMapping, allocAlpakaBuffer);
+    auto B = llama::allocViewUninitialized(fieldMapping, allocAlpakaBuffer);
+    auto J = llama::allocViewUninitialized(fieldMapping, allocAlpakaBuffer);
 
     initFields<Acc>(queue, E, B, J);
 
@@ -320,8 +320,8 @@ auto setup(Queue& queue, const Dev& dev, const DevHost& devHost)
     }();
     const auto particleBufferSize = particleMapping.blobSize(0);
 
-    auto particles = llama::allocView(particleMapping, allocAlpakaBuffer);
-    auto particlesHost = llama::allocView(particleMapping);
+    auto particles = llama::allocViewUninitialized(particleMapping, allocAlpakaBuffer);
+    auto particlesHost = llama::allocViewUninitialized(particleMapping);
 
     std::default_random_engine engine;
     auto uniform = [&] { return std::uniform_real_distribution<Real>{}(engine); };
@@ -824,7 +824,7 @@ void run(std::ostream& plotFile)
             {
                 const auto fieldMapping = E.mapping();
                 constexpr auto blobsPerField = decltype(fieldMapping)::blobCount;
-                auto hostFieldView = llama::allocView(fieldMapping);
+                auto hostFieldView = llama::allocViewUninitialized(fieldMapping);
                 auto copyBlobs = [&, &buffers = buffers](std::size_t bufferOffset)
                 {
                     for(auto i = 0; i < blobsPerField; i++)
@@ -844,7 +844,7 @@ void run(std::ostream& plotFile)
                 output(n, "J", hostFieldView);
             }
 
-            auto hostParticleView = llama::allocView(particles.mapping());
+            auto hostParticleView = llama::allocViewUninitialized(particles.mapping());
             for(auto i = 0; i < std::remove_reference_t<decltype(particles.mapping())>::blobCount; i++)
             {
                 auto dst = alpaka::ViewPlainPtr<DevHost, std::byte, alpaka::DimInt<1>, Size>{

--- a/examples/bufferguard/bufferguard.cpp
+++ b/examples/bufferguard/bufferguard.cpp
@@ -213,7 +213,7 @@ void run(const std::string& mappingName)
     const auto mapping = GuardMapping2D<Mapping, llama::ArrayDims<2>, Vector>{arrayDims};
     std::ofstream{"bufferguard_" + mappingName + ".svg"} << llama::toSvg(mapping);
 
-    auto view1 = allocView(mapping);
+    auto view1 = llama::allocViewUninitialized(mapping);
 
     int i = 0;
     for(std::size_t row = 0; row < rows; row++)
@@ -227,7 +227,7 @@ void run(const std::string& mappingName)
     std::cout << "View 1:\n";
     printView(view1, rows, cols);
 
-    auto view2 = allocView(mapping);
+    auto view2 = llama::allocViewUninitialized(mapping);
     for(std::size_t row = 0; row < rows; row++)
         for(std::size_t col = 0; col < cols; col++)
             view2(row, col) = 0; // broadcast

--- a/examples/cuda/nbody/nbody.cu
+++ b/examples/cuda/nbody/nbody.cu
@@ -207,8 +207,8 @@ try
 
     Stopwatch watch;
 
-    auto hostView = llama::allocView(mapping);
-    auto accView = llama::allocView(
+    auto hostView = llama::allocViewUninitialized(mapping);
+    auto accView = llama::allocViewUninitialized(
         mapping,
         [](auto alignment, std::size_t size)
         {

--- a/examples/heatequation/heatequation.cpp
+++ b/examples/heatequation/heatequation.cpp
@@ -110,8 +110,8 @@ try
     }
 
     const auto mapping = llama::mapping::SoA{llama::ArrayDims{extent}, double{}};
-    auto uNext = llama::allocView(mapping);
-    auto uCurr = llama::allocView(mapping);
+    auto uNext = llama::allocViewUninitialized(mapping);
+    auto uCurr = llama::allocViewUninitialized(mapping);
 
     auto run = [&](std::string_view updateName, auto update)
     {

--- a/examples/nbody/nbody.cpp
+++ b/examples/nbody/nbody.cpp
@@ -157,7 +157,7 @@ namespace usellama
                 return std::move(tmapping);
         }();
 
-        auto particles = llama::allocView(std::move(hmapping));
+        auto particles = llama::allocViewUninitialized(std::move(hmapping));
         watch.printAndReset("alloc");
 
         std::default_random_engine engine;

--- a/examples/nbody_benchmark/nbody.cpp
+++ b/examples/nbody_benchmark/nbody.cpp
@@ -94,7 +94,7 @@ void run(std::ostream& plotFile)
             return llama::mapping::SoA<decltype(arrayDims), Particle, true>{arrayDims};
     }();
 
-    auto particles = llama::allocView(
+    auto particles = llama::allocViewUninitialized(
         std::move(mapping),
         [](auto, std::size_t size)
         { return llama::bloballoc::Vector{}(std::integral_constant<std::size_t, Alignment>{}, size); });

--- a/examples/simpletest/simpletest.cpp
+++ b/examples/simpletest/simpletest.cpp
@@ -151,7 +151,7 @@ try
     // Instantiating the mapping with the array dimensions size
     Mapping mapping(adSize);
     // getting a view with memory from the default allocator
-    auto view = allocView(mapping);
+    auto view = llama::allocViewUninitialized(mapping);
 
     // defining a position in the array dimensions
     const ArrayDims pos{0, 0};

--- a/examples/vectoradd/vectoradd.cpp
+++ b/examples/vectoradd/vectoradd.cpp
@@ -64,9 +64,9 @@ namespace usellama
                     Vector{}};
         }();
 
-        auto a = allocView(mapping);
-        auto b = allocView(mapping);
-        auto c = allocView(mapping);
+        auto a = allocViewUninitialized(mapping);
+        auto b = allocViewUninitialized(mapping);
+        auto c = allocViewUninitialized(mapping);
         watch.printAndReset("alloc");
 
         LLAMA_INDEPENDENT_DATA

--- a/examples/viewcopy/viewcopy.cpp
+++ b/examples/viewcopy/viewcopy.cpp
@@ -112,7 +112,7 @@ auto hash(const llama::View<Mapping, BlobType>& view)
 template<typename Mapping>
 auto prepareViewAndHash(Mapping mapping)
 {
-    auto view = llama::allocView(mapping);
+    auto view = llama::allocViewUninitialized(mapping);
 
     auto value = std::size_t{0};
     for(auto ad : llama::ArrayDimsIndexRange{mapping.arrayDims()})
@@ -218,7 +218,7 @@ $data << EOD
 
         auto benchmarkCopy = [&, srcView = srcView, srcHash = srcHash](std::string_view name, auto copy)
         {
-            auto dstView = llama::allocView(dstMapping);
+            auto dstView = llama::allocViewUninitialized(dstMapping);
             Stopwatch watch;
             for(auto i = 0; i < REPETITIONS; i++)
                 copy(srcView, dstView);

--- a/include/llama/Core.hpp
+++ b/include/llama/Core.hpp
@@ -59,8 +59,7 @@ namespace llama
     /// @brief Tells whether the given type is allowed as a field type in LLAMA. Such types need to be trivially
     /// constructible and trivially destructible.
     template<typename T>
-    inline constexpr bool isAllowedFieldType
-        = std::is_trivially_default_constructible_v<T>&& std::is_trivially_destructible_v<T>;
+    inline constexpr bool isAllowedFieldType = std::is_trivially_destructible_v<T>;
 
     /// Record dimension tree node which may either be a leaf or refer to a child tree presented as another \ref
     /// Record.
@@ -555,13 +554,11 @@ namespace llama
     template<std::size_t Dim, typename Func, typename... OuterIndices>
     LLAMA_FN_HOST_ACC_INLINE void forEachADCoord(ArrayDims<Dim> adSize, Func&& func, OuterIndices... outerIndices)
     {
-        for(std::size_t i = 0; i < adSize[0]; i++)
-        {
-            if constexpr(Dim > 1)
+        if constexpr(Dim > 0)
+            for(std::size_t i = 0; i < adSize[0]; i++)
                 forEachADCoord(ArrayDims<Dim - 1>{pop_front(adSize)}, std::forward<Func>(func), outerIndices..., i);
-            else
-                std::forward<Func>(func)(ArrayDims<sizeof...(outerIndices) + 1>{outerIndices..., i});
-        }
+        else
+            std::forward<Func>(func)(ArrayDims<sizeof...(outerIndices)>{outerIndices...});
     }
 
     namespace internal

--- a/include/llama/Vector.hpp
+++ b/include/llama/Vector.hpp
@@ -21,7 +21,7 @@ namespace llama
     {
         static_assert(Mapping::ArrayDims::rank == 1, "llama::Vector only supports 1D mappings");
 
-        using ViewType = decltype(allocView<Mapping>());
+        using ViewType = decltype(allocViewUninitialized<Mapping>());
         using RecordDim = typename Mapping::RecordDim;
 
         using iterator = decltype(std::declval<ViewType>().begin());
@@ -276,7 +276,7 @@ namespace llama
     private:
         LLAMA_FN_HOST_ACC_INLINE void changeCapacity(std::size_t cap)
         {
-            auto newView = llama::allocView<Mapping>(Mapping{typename Mapping::ArrayDims{cap}});
+            auto newView = allocViewUninitialized<Mapping>(Mapping{typename Mapping::ArrayDims{cap}});
             auto b = begin();
             std::copy(begin(), b + std::min(m_size, cap), newView.begin());
             using std::swap;

--- a/include/llama/mapping/One.hpp
+++ b/include/llama/mapping/One.hpp
@@ -38,8 +38,9 @@ namespace llama::mapping
         {
             // TODO(bgruber): not sure if this is the right approach, since we take any ArrayDims in the ctor
             ArrayDims ad;
-            for(auto i = 0; i < ArrayDims::rank; i++)
-                ad[i] = 1;
+            if constexpr(ArrayDims::rank > 0)
+                for(auto i = 0; i < ArrayDims::rank; i++)
+                    ad[i] = 1;
             return ad;
         }
 

--- a/include/llama/mapping/tree/Mapping.hpp
+++ b/include/llama/mapping/tree/Mapping.hpp
@@ -196,6 +196,11 @@ namespace llama::mapping::tree
         {
         }
 
+        LLAMA_FN_HOST_ACC_INLINE auto arrayDims() const
+        {
+            return arrayDimsSize;
+        }
+
         LLAMA_FN_HOST_ACC_INLINE
         auto blobSize(std::size_t const) const -> std::size_t
         {

--- a/tests/arraydomain.cpp
+++ b/tests/arraydomain.cpp
@@ -23,7 +23,7 @@ TEST_CASE("ArrayDims.dim0")
 
     using Mapping = llama::mapping::SoA<ArrayDims, Particle>;
     Mapping mapping{arrayDims};
-    auto view = allocView(mapping);
+    auto view = llama::allocView(mapping);
 
     double& x1 = view(ArrayDims{})(tag::Pos{}, tag::X{});
     double& x2 = view()(tag::Pos{}, tag::X{});
@@ -36,7 +36,7 @@ TEST_CASE("ArrayDims.dim1")
 
     using Mapping = llama::mapping::SoA<ArrayDims, Particle>;
     Mapping mapping{arrayDims};
-    auto view = allocView(mapping);
+    auto view = llama::allocView(mapping);
 
     double& x = view(ArrayDims{0})(tag::Pos{}, tag::X{});
     x = 0;
@@ -49,7 +49,7 @@ TEST_CASE("ArrayDims.dim2")
 
     using Mapping = llama::mapping::SoA<ArrayDims, Particle>;
     Mapping mapping{arrayDims};
-    auto view = allocView(mapping);
+    auto view = llama::allocView(mapping);
 
     double& x = view(ArrayDims{0, 0})(tag::Pos{}, tag::X{});
     x = 0;
@@ -62,7 +62,7 @@ TEST_CASE("ArrayDims.dim3")
 
     using Mapping = llama::mapping::SoA<ArrayDims, Particle>;
     Mapping mapping{arrayDims};
-    auto view = allocView(mapping);
+    auto view = llama::allocView(mapping);
 
     double& x = view(ArrayDims{0, 0, 0})(tag::Pos{}, tag::X{});
     x = 0;
@@ -75,7 +75,7 @@ TEST_CASE("ArrayDims.dim10")
 
     using Mapping = llama::mapping::SoA<ArrayDims, Particle>;
     Mapping mapping{arrayDims};
-    auto view = allocView(mapping);
+    auto view = llama::allocView(mapping);
 
     double& x = view(ArrayDims{0, 0, 0, 0, 0, 0, 0, 0, 0, 0})(tag::Pos{}, tag::X{});
     x = 0;

--- a/tests/common.hpp
+++ b/tests/common.hpp
@@ -119,13 +119,6 @@ namespace internal
 } // namespace internal
 
 template<typename View>
-void zeroStorage(View& view)
-{
-    for(auto i = 0; i < View::Mapping::blobCount; i++)
-        internal::zeroBlob(view.storageBlobs[i], view.mapping().blobSize(i));
-}
-
-template<typename View>
 void iotaStorage(View& view)
 {
     for(auto i = 0; i < View::Mapping::blobCount; i++)

--- a/tests/computedprop.cpp
+++ b/tests/computedprop.cpp
@@ -88,7 +88,7 @@ TEST_CASE("computedprop")
     STATIC_REQUIRE(mapping.blobCount == 1);
     CHECK(mapping.blobSize(0) == 10 * 12 * sizeof(double));
 
-    auto view = llama::allocView(mapping);
+    auto view = llama::allocViewUninitialized(mapping);
 
     using namespace tag;
     view(5u)(A{}, X{}) = 0.0f;
@@ -124,6 +124,11 @@ namespace
         {
         }
 
+        auto arrayDims() const
+        {
+            return ArrayDims{};
+        }
+
         template<std::size_t... RecordCoords>
         static constexpr auto isComputed(llama::RecordCoord<RecordCoords...>)
         {
@@ -142,14 +147,14 @@ namespace
 TEST_CASE("fully_computed_mapping")
 {
     auto arrayDims = llama::ArrayDims<3>{10, 10, 10};
-    auto mapping = ComputedMapping<decltype(arrayDims), Triangle>{arrayDims};
+    auto mapping = ComputedMapping<decltype(arrayDims), int>{arrayDims};
 
-    auto view = llama::allocView(mapping);
+    auto view = llama::allocViewUninitialized(mapping);
 
     using namespace tag;
-    CHECK(view(0u, 1u, 2u)(A{}, X{}) == 0);
-    CHECK(view(2u, 1u, 2u)(A{}, Y{}) == 4);
-    CHECK(view(2u, 5u, 2u)(A{}, Z{}) == 20);
+    CHECK(view(0u, 1u, 2u) == 0);
+    CHECK(view(2u, 1u, 2u) == 4);
+    CHECK(view(2u, 5u, 2u) == 20);
 }
 
 namespace
@@ -168,6 +173,11 @@ namespace
 
         constexpr explicit CompressedBoolMapping(ArrayDims size) : arrayDimsSize(size)
         {
+        }
+
+        auto arrayDims() const
+        {
+            return arrayDimsSize;
         }
 
         using Word = std::uint64_t;
@@ -242,7 +252,7 @@ TEST_CASE("compressed_bools")
     CHECK(mapping.blobSize(1) == 8);
     CHECK(mapping.blobSize(2) == 8);
 
-    auto view = llama::allocView(mapping);
+    auto view = llama::allocViewUninitialized(mapping);
     for(auto y = 0u; y < 8; y++)
     {
         for(auto x = 0u; x < 8; x++)

--- a/tests/copy.cpp
+++ b/tests/copy.cpp
@@ -13,7 +13,7 @@ namespace
     {
         const auto viewSize = ArrayDims{4, 8};
         const auto srcMapping = SrcMapping(viewSize);
-        auto srcView = llama::allocView(srcMapping);
+        auto srcView = llama::allocViewUninitialized(srcMapping);
         auto value = std::size_t{0};
         for(auto ad : llama::ArrayDimsIndexRange{srcMapping.arrayDims()})
             llama::forEachLeaf<RecordDim>(
@@ -23,7 +23,7 @@ namespace
                     value++;
                 });
 
-        auto dstView = llama::allocView(DstMapping(viewSize));
+        auto dstView = llama::allocViewUninitialized(DstMapping(viewSize));
         copy(srcView, dstView);
 
         value = 0;

--- a/tests/heatmap.cpp
+++ b/tests/heatmap.cpp
@@ -11,9 +11,6 @@ TEST_CASE("Heatmap.nbody")
     {
         auto particles = llama::allocView(llama::mapping::Heatmap{mapping});
 
-        for(std::size_t i = 0; i < N; i++)
-            particles(i) = 0;
-
         constexpr float TIMESTEP = 0.0001f;
         constexpr float EPS2 = 0.01f;
         for(std::size_t i = 0; i < N; i++)

--- a/tests/iterator.cpp
+++ b/tests/iterator.cpp
@@ -24,7 +24,7 @@ TEST_CASE("iterator")
     {
         using ArrayDims = decltype(arrayDims);
         auto mapping = llama::mapping::AoS<ArrayDims, Position>{arrayDims};
-        auto view = llama::allocView(mapping);
+        auto view = llama::allocViewUninitialized(mapping);
 
         for(auto vd : view)
         {
@@ -47,8 +47,8 @@ TEST_CASE("iterator.std_copy")
 {
     auto test = [](auto arrayDims)
     {
-        auto aosView = llama::allocView(llama::mapping::AoS{arrayDims, Position{}});
-        auto soaView = llama::allocView(llama::mapping::SoA{arrayDims, Position{}});
+        auto aosView = llama::allocViewUninitialized(llama::mapping::AoS{arrayDims, Position{}});
+        auto soaView = llama::allocViewUninitialized(llama::mapping::SoA{arrayDims, Position{}});
 
         int i = 0;
         for(auto vd : aosView)
@@ -75,8 +75,8 @@ TEST_CASE("iterator.transform_reduce")
 {
     auto test = [](auto arrayDims)
     {
-        auto aosView = llama::allocView(llama::mapping::AoS{arrayDims, Position{}});
-        auto soaView = llama::allocView(llama::mapping::SoA{arrayDims, Position{}});
+        auto aosView = llama::allocViewUninitialized(llama::mapping::AoS{arrayDims, Position{}});
+        auto soaView = llama::allocViewUninitialized(llama::mapping::SoA{arrayDims, Position{}});
 
         int i = 0;
         for(auto vd : aosView)
@@ -108,7 +108,7 @@ TEST_CASE("iterator.transform_inplace")
 {
     auto test = [](auto arrayDims)
     {
-        auto view = llama::allocView(llama::mapping::AoS{arrayDims, Position{}});
+        auto view = llama::allocViewUninitialized(llama::mapping::AoS{arrayDims, Position{}});
 
         int i = 0;
         for(auto vd : view)
@@ -145,7 +145,7 @@ TEST_CASE("iterator.transform_to")
 {
     auto test = [](auto arrayDims)
     {
-        auto view = llama::allocView(llama::mapping::AoS{arrayDims, Position{}});
+        auto view = llama::allocViewUninitialized(llama::mapping::AoS{arrayDims, Position{}});
 
         int i = 0;
         for(auto vd : view)
@@ -155,7 +155,7 @@ TEST_CASE("iterator.transform_to")
             vd(tag::Z{}) = ++i;
         }
 
-        auto dst = llama::allocView(llama::mapping::SoA{arrayDims, Position{}});
+        auto dst = llama::allocViewUninitialized(llama::mapping::SoA{arrayDims, Position{}});
         std::transform(
             begin(view),
             end(view),
@@ -197,8 +197,8 @@ TEST_CASE("iterator.different_record_dim")
     using WrappedPos = llama::Record<llama::Field<Pos1, Position>, llama::Field<Pos2, Position>>;
 
     auto arrayDims = llama::ArrayDims{32};
-    auto aosView = llama::allocView(llama::mapping::AoS{arrayDims, WrappedPos{}});
-    auto soaView = llama::allocView(llama::mapping::SoA{arrayDims, Position{}});
+    auto aosView = llama::allocViewUninitialized(llama::mapping::AoS{arrayDims, WrappedPos{}});
+    auto soaView = llama::allocViewUninitialized(llama::mapping::SoA{arrayDims, Position{}});
 
     int i = 0;
     for(auto vd : aosView)
@@ -230,7 +230,7 @@ TEST_CASE("ranges")
     auto test = [](auto arrayDims)
     {
         auto mapping = llama::mapping::AoS{arrayDims, Position{}};
-        auto view = llama::allocView(mapping);
+        auto view = llama::allocViewUninitialized(mapping);
 
         STATIC_REQUIRE(std::ranges::range<decltype(view)>);
 
@@ -257,7 +257,7 @@ TEST_CASE("ranges")
 TEST_CASE("iterator.sort")
 {
     constexpr auto n = 10;
-    auto view = llama::allocView(llama::mapping::AoS{llama::ArrayDims{n}, Position{}});
+    auto view = llama::allocViewUninitialized(llama::mapping::AoS{llama::ArrayDims{n}, Position{}});
 
     std::default_random_engine e{};
     std::uniform_int_distribution<int> d{0, 1000};

--- a/tests/recorddimension.cpp
+++ b/tests/recorddimension.cpp
@@ -17,7 +17,7 @@ namespace
 TEST_CASE("recorddim.record_with_int")
 {
     using RecordDim = llama::Record<llama::Field<Tag, int>>;
-    auto view = allocView(llama::mapping::AoS{llama::ArrayDims{1}, RecordDim{}});
+    auto view = llama::allocView(llama::mapping::AoS{llama::ArrayDims{1}, RecordDim{}});
 
     int& e = view(0u)(Tag{});
     e = 0;
@@ -28,48 +28,49 @@ TEST_CASE("recorddim.record_with_int[3]")
     using namespace llama::literals;
 
     using RecordDim = llama::Record<llama::Field<Tag, int[3]>>;
-    auto view = allocView(llama::mapping::AoS{llama::ArrayDims{1}, RecordDim{}});
+    auto view = llama::allocView(llama::mapping::AoS{llama::ArrayDims{1}, RecordDim{}});
 
     int& e0 = view(0u)(Tag{})(0_RC);
     int& e1 = view(0u)(Tag{})(1_RC);
     int& e2 = view(0u)(Tag{})(2_RC);
 }
 
-// TEST_CASE("recorddim.record_with_std::complex<float>")
-//{
-//    using RecordDim = llama::Record<llama::Field<Tag, std::complex<float>>>;
-//    auto view = allocView(llama::mapping::AoS{llama::ArrayDims{1}, RecordDim{}});
-//
-//    std::complex<float>& e = view(0u)(Tag{});
-//    e = {2, 3};
-//}
+TEST_CASE("recorddim.record_with_std::complex<float>")
+{
+    using RecordDim = llama::Record<llama::Field<Tag, std::complex<float>>>;
+    auto view = llama::allocView(llama::mapping::AoS{llama::ArrayDims{1}, RecordDim{}});
+
+    std::complex<float>& e = view(0u)(Tag{});
+    e = {2, 3};
+}
 
 TEST_CASE("recorddim.record_with_std::array<float, 4>")
 {
     using RecordDim = llama::Record<llama::Field<Tag, std::array<float, 4>>>;
-    auto view = allocView(llama::mapping::AoS{llama::ArrayDims{1}, RecordDim{}});
+    auto view = llama::allocView(llama::mapping::AoS{llama::ArrayDims{1}, RecordDim{}});
 
     std::array<float, 4>& e = view(0u)(Tag{});
     e = {2, 3, 4, 5};
 }
 
+// FIXME(bgruber): LLAMA does not handle destructors yet
 // TEST_CASE("recorddim.record_with_std::vector<float>")
 //{
 //    using RecordDim = llama::Record<llama::Field<Tag, std::vector<float>>>;
 //    auto view = allocView(llama::mapping::AoS{llama::ArrayDims{1}, RecordDim{}});
 //
 //    std::vector<float>& e = view(0u)(Tag{});
-//    // e = {2, 3, 4, 5}; // FIXME: LLAMA memory is uninitialized
+//    e = {2, 3, 4, 5};
 //}
 
-// TEST_CASE("recorddim.record_with_std::atomic<int>")
-//{
-//    using RecordDim = llama::Record<llama::Field<Tag, std::atomic<int>>>;
-//    auto view = allocView(llama::mapping::AoS{llama::ArrayDims{1}, RecordDim{}});
-//
-//    std::atomic<int>& e = view(0u)(Tag{});
-//    // e++; // FIXME: LLAMA memory is uninitialized
-//}
+TEST_CASE("recorddim.record_with_std::atomic<int>")
+{
+    using RecordDim = llama::Record<llama::Field<Tag, std::atomic<int>>>;
+    auto view = llama::allocView(llama::mapping::AoS{llama::ArrayDims{1}, RecordDim{}});
+
+    std::atomic<int>& e = view(0u)(Tag{});
+    e++;
+}
 
 TEST_CASE("recorddim.record_with_noncopyable")
 {
@@ -86,7 +87,7 @@ TEST_CASE("recorddim.record_with_noncopyable")
     };
 
     using RecordDim = llama::Record<llama::Field<Tag, Element>>;
-    auto view = allocView(llama::mapping::AoS{llama::ArrayDims{1}, RecordDim{}});
+    auto view = llama::allocView(llama::mapping::AoS{llama::ArrayDims{1}, RecordDim{}});
 
     Element& e = view(0u)(Tag{});
     e.value = 0;
@@ -107,73 +108,103 @@ TEST_CASE("recorddim.record_with_nonmoveable")
     };
 
     using RecordDim = llama::Record<llama::Field<Tag, Element>>;
-    auto view = allocView(llama::mapping::AoS{llama::ArrayDims{1}, RecordDim{}});
+    auto view = llama::allocView(llama::mapping::AoS{llama::ArrayDims{1}, RecordDim{}});
 
     Element& e = view(0u)(Tag{});
     e.value = 0;
 }
 
-// TEST_CASE("recorddim.record_with_nondefaultconstructible")
-//{
-//    struct Element
-//    {
-//        Element() = delete;
-//        int value;
-//    };
-//
-//    using RecordDim = llama::Record<llama::Field<Tag, Element>>;
-//    auto view = allocView(llama::mapping::AoS{llama::ArrayDims{1}, RecordDim{}});
-//
-//    Element& e = view(0u)(Tag{});
-//    e.value = 0;
-//}
+TEST_CASE("recorddim.record_with_nondefaultconstructible")
+{
+    struct Element
+    {
+        Element() = delete;
+        int value;
+    };
 
-// TEST_CASE("recorddim.record_with_nontrivial_ctor")
-//{
-//    struct Element
-//    {
-//        int value = 42;
-//    };
-//
-//    using RecordDim = llama::Record<llama::Field<Tag, Element>>;
-//    auto view = allocView(llama::mapping::AoS{llama::ArrayDims{1}, RecordDim{}});
-//
-//    Element& e = view(0u)(Tag{});
-//    // CHECK(e.value == 42); // FIXME: LLAMA memory is uninitialized
-//}
+    using RecordDim = llama::Record<llama::Field<Tag, Element>>;
+    auto view = llama::allocViewUninitialized(llama::mapping::AoS{llama::ArrayDims{1}, RecordDim{}});
 
-// namespace
-//{
-//    struct UniqueInt
-//    {
-//        int value = counter++;
-//
-//        explicit operator int() const
-//        {
-//            return value;
-//        }
-//
-//    private:
-//        inline static int counter = 0;
-//    };
-//} // namespace
-//
-// TEST_CASE("recorddim.record_with_nontrivial_ctor2")
-//{
-//    using RecordDim = llama::Record<llama::Field<Tag, UniqueInt>>;
-//    auto view = allocView(llama::mapping::AoS{llama::ArrayDims{1}, RecordDim{}});
-//
-//    // FIXME: LLAMA memory is uninitialized
-//    // CHECK(view(ArrayDims{0})(Tag{}) == 0);
-//    // CHECK(view(ArrayDims{1})(Tag{}) == 1);
-//    // CHECK(view(ArrayDims{2})(Tag{}) == 2);
-//    // CHECK(view(ArrayDims{15})(Tag{}) == 15);
-//}
+    Element& e = view(0u)(Tag{});
+    e.value = 0;
+}
+
+namespace
+{
+    struct ElementWithCtor
+    {
+        int value = 42;
+    };
+} // namespace
+
+TEST_CASE("recorddim.record_with_nontrivial_ctor")
+{
+    using RecordDim = llama::Record<llama::Field<Tag, ElementWithCtor>>;
+    auto view = llama::allocView(llama::mapping::AoS{llama::ArrayDims{1}, RecordDim{}});
+
+    ElementWithCtor& e = view(0u)(Tag{});
+    CHECK(e.value == 42);
+}
+
+namespace
+{
+    struct UniqueInt
+    {
+        int value = counter++;
+
+        explicit operator int() const
+        {
+            return value;
+        }
+
+    private:
+        inline static int counter = 0;
+    };
+} // namespace
+
+TEST_CASE("recorddim.record_with_nontrivial_ctor2")
+{
+    using RecordDim = llama::Record<llama::Field<Tag, UniqueInt>>;
+    auto view = llama::allocView(llama::mapping::AoS{llama::ArrayDims{16}, RecordDim{}});
+
+    CHECK(view(llama::ArrayDims{0})(Tag{}).value == 0);
+    CHECK(view(llama::ArrayDims{1})(Tag{}).value == 1);
+    CHECK(view(llama::ArrayDims{2})(Tag{}).value == 2);
+    CHECK(view(llama::ArrayDims{15})(Tag{}).value == 15);
+}
+
+TEST_CASE("recorddim.uninitialized_trivial")
+{
+    using RecordDim = int;
+    auto mapping = llama::mapping::AoS{llama::ArrayDims{256}, RecordDim{}};
+    auto view = llama::allocViewUninitialized(
+        mapping,
+        [](auto /*alignment*/, std::size_t size) { return std::vector(size, std::byte{0xAA}); });
+
+    for(auto i = 0u; i < 256u; i++)
+        CHECK(view(i) == 0xAAAAAAAA);
+}
+
+TEST_CASE("recorddim.uninitialized_ctor.constructFields")
+{
+    auto mapping = llama::mapping::AoS{llama::ArrayDims{256}, ElementWithCtor{}};
+    auto view = llama::allocViewUninitialized(
+        mapping,
+        [](auto /*alignment*/, std::size_t size) { return std::vector(size, std::byte{0xAA}); });
+
+    for(auto i = 0u; i < 256u; i++)
+        CHECK(view(i).value == 0xAAAAAAAA); // ctor has not run
+
+    llama::constructFields(view); // run ctors
+
+    for(auto i = 0u; i < 256u; i++)
+        CHECK(view(i).value == 42);
+}
 
 TEST_CASE("recorddim.int")
 {
     using RecordDim = int;
-    auto view = allocView(llama::mapping::AoS{llama::ArrayDims{1}, RecordDim{}});
+    auto view = llama::allocView(llama::mapping::AoS{llama::ArrayDims{1}, RecordDim{}});
 
     STATIC_REQUIRE(std::is_same_v<decltype(view(0u)), int&>);
     view(0u) = 42;
@@ -193,7 +224,7 @@ TEST_CASE("recorddim.int[3]")
     using namespace llama::literals;
 
     using RecordDim = int[3];
-    auto view = allocView(llama::mapping::AoS<llama::ArrayDims<1>, RecordDim>{llama::ArrayDims{1}});
+    auto view = llama::allocView(llama::mapping::AoS<llama::ArrayDims<1>, RecordDim>{llama::ArrayDims{1}});
 
     view(0u)(0_RC) = 42;
     view(0u)(1_RC) = 43;
@@ -206,7 +237,7 @@ TEST_CASE("recorddim.int[200]")
     using namespace llama::literals;
 
     using RecordDim = int[200];
-    auto view = allocView(llama::mapping::AoS<llama::ArrayDims<1>, RecordDim>{llama::ArrayDims{1}});
+    auto view = llama::allocView(llama::mapping::AoS<llama::ArrayDims<1>, RecordDim>{llama::ArrayDims{1}});
 
     view(0u)(0_RC) = 42;
     view(0u)(199_RC) = 43;
@@ -217,7 +248,7 @@ TEST_CASE("recorddim.int[3][2]")
     using namespace llama::literals;
 
     using RecordDim = int[3][2];
-    auto view = allocView(llama::mapping::AoS<llama::ArrayDims<1>, RecordDim>{llama::ArrayDims{1}});
+    auto view = llama::allocView(llama::mapping::AoS<llama::ArrayDims<1>, RecordDim>{llama::ArrayDims{1}});
 
     view(0u)(0_RC)(0_RC) = 42;
     view(0u)(0_RC)(1_RC) = 43;
@@ -232,7 +263,7 @@ TEST_CASE("recorddim.int[1][1][1][1][1][1][1][1][1][1]")
     using namespace llama::literals;
 
     using RecordDim = int[1][1][1][1][1][1][1][1][1][1];
-    auto view = allocView(llama::mapping::AoS<llama::ArrayDims<1>, RecordDim>{llama::ArrayDims{1}});
+    auto view = llama::allocView(llama::mapping::AoS<llama::ArrayDims<1>, RecordDim>{llama::ArrayDims{1}});
 
     view(0u)(0_RC)(0_RC) (0_RC) (0_RC) (0_RC) (0_RC) (0_RC) (0_RC) (0_RC) (0_RC) = 42;
 }

--- a/tests/treemap.cpp
+++ b/tests/treemap.cpp
@@ -1035,9 +1035,7 @@ TEST_CASE("treemapping")
     CHECK(mapping.blobNrAndOffset<2, 1>({50, 100}).offset == 10784);
     CHECK(mapping.blobNrAndOffset<2, 1>({50, 101}).offset == 10792);
 
-    auto view = allocView(mapping);
-    zeroStorage(view);
-
+    auto view = llama::allocView(mapping);
     for(size_t x = 0; x < arrayDims[0]; ++x)
         for(size_t y = 0; y < arrayDims[1]; ++y)
         {

--- a/tests/view.cpp
+++ b/tests/view.cpp
@@ -34,7 +34,7 @@ TEST_CASE("view.move")
     constexpr ArrayDims viewSize{16, 16};
 
     using Mapping = llama::mapping::SoA<ArrayDims, RecordDim>;
-    auto view1 = allocView(Mapping(viewSize));
+    auto view1 = llama::allocView(Mapping(viewSize));
 
     decltype(view1) view2;
     view1({3, 3}) = 1;
@@ -48,8 +48,8 @@ TEST_CASE("view.swap")
     constexpr ArrayDims viewSize{16, 16};
 
     using Mapping = llama::mapping::SoA<ArrayDims, RecordDim>;
-    auto view1 = allocView(Mapping(viewSize));
-    auto view2 = allocView(Mapping(viewSize));
+    auto view1 = llama::allocView(Mapping(viewSize));
+    auto view2 = llama::allocView(Mapping(viewSize));
 
     view1({3, 3}) = 1;
     view2({3, 3}) = 2;
@@ -66,7 +66,7 @@ TEST_CASE("view.allocator.Vector")
     constexpr ArrayDims viewSize{16, 16};
 
     using Mapping = llama::mapping::SoA<ArrayDims, RecordDim>;
-    auto view = allocView(Mapping(viewSize), llama::bloballoc::Vector{});
+    auto view = llama::allocView(Mapping(viewSize), llama::bloballoc::Vector{});
 
     for(auto i : llama::ArrayDimsIndexRange{viewSize})
         view(i) = 42;
@@ -79,7 +79,7 @@ TEST_CASE("view.allocator.SharedPtr")
     constexpr ArrayDims viewSize{16, 16};
 
     using Mapping = llama::mapping::SoA<ArrayDims, RecordDim>;
-    auto view = allocView(Mapping(viewSize), llama::bloballoc::SharedPtr{});
+    auto view = llama::allocView(Mapping(viewSize), llama::bloballoc::SharedPtr{});
 
     for(auto i : llama::ArrayDimsIndexRange{viewSize})
         view(i) = 42;
@@ -92,7 +92,7 @@ TEST_CASE("view.allocator.stack")
     constexpr ArrayDims viewSize{16, 16};
 
     using Mapping = llama::mapping::SoA<ArrayDims, RecordDim>;
-    auto view = allocView(Mapping(viewSize), llama::bloballoc::Stack<16 * 16 * llama::sizeOf<RecordDim>>{});
+    auto view = llama::allocView(Mapping(viewSize), llama::bloballoc::Stack<16 * 16 * llama::sizeOf<RecordDim>>{});
 
     for(auto i : llama::ArrayDimsIndexRange{viewSize})
         view(i) = 42;
@@ -124,10 +124,7 @@ TEST_CASE("view.access")
 
     using Mapping = llama::mapping::SoA<ArrayDims, Particle>;
     Mapping mapping{arrayDims};
-    auto view = allocView(mapping);
-
-    zeroStorage(view);
-
+    auto view = llama::allocView(mapping);
     auto l = [](auto& view)
     {
         const ArrayDims pos{0, 0};
@@ -160,7 +157,7 @@ TEST_CASE("view.assign-one-record")
 
     using Mapping = llama::mapping::SoA<ArrayDims, Particle>;
     Mapping mapping{arrayDims};
-    auto view = allocView(mapping);
+    auto view = llama::allocView(mapping);
 
     llama::One<Particle> record;
     record(tag::Pos{}, tag::X{}) = 14.0f;
@@ -197,7 +194,7 @@ TEST_CASE("view.addresses")
 
     using Mapping = llama::mapping::SingleBlobSoA<ArrayDims, Particle>;
     Mapping mapping{arrayDims};
-    auto view = allocView(mapping);
+    auto view = llama::allocView(mapping);
 
     const ArrayDims pos{0, 0};
     auto& x = view(pos)(tag::Pos{}, tag::X{});
@@ -242,9 +239,7 @@ TEST_CASE("view.iteration-and-access")
 
     using Mapping = llama::mapping::SoA<ArrayDims, Particle>;
     Mapping mapping{arrayDims};
-    auto view = allocView(mapping);
-
-    zeroStorage(view);
+    auto view = llama::allocView(mapping);
 
     for(size_t x = 0; x < arrayDims[0]; ++x)
         for(size_t y = 0; y < arrayDims[1]; ++y)
@@ -269,9 +264,7 @@ TEST_CASE("view.record-access")
 
     using Mapping = llama::mapping::SoA<ArrayDims, Particle>;
     Mapping mapping{arrayDims};
-    auto view = allocView(mapping);
-
-    zeroStorage(view);
+    auto view = llama::allocView(mapping);
 
     for(size_t x = 0; x < arrayDims[0]; ++x)
         for(size_t y = 0; y < arrayDims[1]; ++y)

--- a/tests/virtualview.cpp
+++ b/tests/virtualview.cpp
@@ -18,7 +18,7 @@ TEST_CASE("virtual view CTAD")
 {
     using ArrayDims = llama::ArrayDims<2>;
     constexpr ArrayDims viewSize{10, 10};
-    auto view = allocView(llama::mapping::SoA<ArrayDims, Particle>(viewSize));
+    auto view = llama::allocViewUninitialized(llama::mapping::SoA<ArrayDims, Particle>(viewSize));
 
     llama::VirtualView virtualView{view, {2, 4}};
 }
@@ -29,7 +29,7 @@ TEST_CASE("fast virtual view")
     constexpr ArrayDims viewSize{10, 10};
 
     using Mapping = llama::mapping::SoA<ArrayDims, Particle>;
-    auto view = allocView(Mapping(viewSize));
+    auto view = llama::allocViewUninitialized(Mapping(viewSize));
 
     for(std::size_t x = 0; x < viewSize[0]; ++x)
         for(std::size_t y = 0; y < viewSize[1]; ++y)
@@ -52,7 +52,7 @@ TEST_CASE("virtual view")
     constexpr ArrayDims viewSize{32, 32};
     constexpr ArrayDims miniSize{8, 8};
     using Mapping = llama::mapping::SoA<ArrayDims, Particle>;
-    auto view = allocView(Mapping(viewSize));
+    auto view = llama::allocViewUninitialized(Mapping(viewSize));
 
     for(std::size_t x = 0; x < viewSize[0]; ++x)
         for(std::size_t y = 0; y < viewSize[1]; ++y)
@@ -72,7 +72,7 @@ TEST_CASE("virtual view")
             llama::VirtualView<decltype(view)> virtualView(view, {x * miniSize[0], y * miniSize[1]});
 
             using MiniMapping = llama::mapping::SoA<ArrayDims, Particle>;
-            auto miniView = allocView(
+            auto miniView = llama::allocViewUninitialized(
                 MiniMapping(miniSize),
                 llama::bloballoc::Stack<miniSize[0] * miniSize[1] * llama::sizeOf<Particle>>{});
 


### PR DESCRIPTION
This PR is motivated by the need to lift the restriction on field types to be trivially_constructible. It applies the following changes:

* allocView will run field constructors
* add allocViewUninitialized to still have uninitialized views
* add constructFields
* remove isAllowedFieldType
* add tree::Mapping::arrayDims()
* enable many unit tests relying on fields being initialized
* add tests for uninitialized views and for explicit construction