### PR TITLE
Test macos-11 and macos-10.15 in CI

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -212,7 +212,14 @@ jobs:
         & build/$env:CONFIG/tests
 
   build-macos:
-    runs-on: macos-latest
+    runs-on: ${{ matrix.os }}
+    name: build-${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - os: macos-10.15
+          - os: macos-11
     env: {CXX: clang++}
     steps:
       - uses: actions/checkout@v2


### PR DESCRIPTION
This PR splits the macOS CI into 2, running on macOS 10.15 and macOS 11.

GitHub seems to have changed `macos-latest` to point to `macos-11`, where the compiler crashes at the moment. Since we don't have a corresponding machine to reproduce, I will make the macOS 11 CI optional for now.