### PR TITLE
Refactor RecordCoord to string conversion

### DIFF
--- a/include/llama/DumpMapping.hpp
+++ b/include/llama/DumpMapping.hpp
@@ -105,6 +105,8 @@ namespace llama
         inline auto cssClass(std::string tags)
         {
             std::replace(begin(tags), end(tags), '.', '_');
+            std::replace(begin(tags), end(tags), '<', '_');
+            std::replace(begin(tags), end(tags), '>', '_');
             return tags;
         };
     } // namespace internal


### PR DESCRIPTION
Refactor RecordCoord to string conversion. Also replace chevrons by underscores when generating CSS class names when dumping HTML mappings.