### PR TITLE
Disable dump tests with AppleClang 13.0

### DIFF
--- a/tests/dump.cpp
+++ b/tests/dump.cpp
@@ -5,6 +5,8 @@
 #include <llama/DumpMapping.hpp>
 #include <string>
 
+// AppleClang 13.0 on MacOS 11.0 crashes (segfault) when compiling any of these tests
+#if !(defined(__APPLE__) && __clang_major__ == 13 && __clang_minor__ == 0)
 namespace
 {
     llama::ArrayExtentsDynamic<1> extents{32};
@@ -285,3 +287,4 @@ TEST_CASE("dump.ParticleAligned.PackedAoS")
 {
     dump(llama::mapping::PackedAoS<ArrayExtents, ParticleAligned>{extents});
 }
+#endif


### PR DESCRIPTION
This PR disables all dumping tests when they are compiled with AppleClang 13.0.

I had a look at the compiler crash but I could not come up with a quick workaround, so I decided to disable the tests.