### PR TITLE
Include DumpMapping.hpp with llama.hpp

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -11,7 +11,7 @@ target_link_libraries(${PROJECT_NAME} INTERFACE Boost::headers)
 if (fmt_FOUND)
 	target_link_libraries(${PROJECT_NAME} INTERFACE fmt::fmt)
 else()
-	message("The fmt library was not found. You cannot use llama/DumpMapping.hpp")
+	message(WARNING "The fmt library was not found. You cannot use llama's dumping facilities.")
 endif()
 
 # llama::llama to make subdirectory projects work

--- a/docs/pages/install.rst
+++ b/docs/pages/install.rst
@@ -20,7 +20,7 @@ Dependencies
 ------------
 
  - Boost 1.66.0 or higher
- - libfmt 6.2.1 or higher (optional) for building some examples and LLAMA supporting to dump mappings as SVG/HTML
+ - libfmt 6.2.1 or higher (optional) for building the tests and examples and LLAMA supporting to dump mappings as SVG/HTML
  - `Alpaka <https://github.com/alpaka-group/alpaka>`_ (optional) for building some examples
  - `Vc <https://github.com/VcDevel/Vc>`_ (optional) for building some examples
 

--- a/docs/pages/mappings.rst
+++ b/docs/pages/mappings.rst
@@ -244,14 +244,11 @@ Dump visualizations
 -------------------
 
 Sometimes it is hard to image how data will be laid out in memory by a mapping.
-LLAMA can create a grafical representation of a mapping instance as SVG image or HTML document:
+LLAMA can create a graphical representation of a mapping instance as SVG image or HTML document:
 
 .. code-block:: C++
-
-    #include <llama/DumpMapping.hpp>
 
     std::ofstream{filename + ".svg" } << llama::toSvg (mapping);
     std::ofstream{filename + ".html"} << llama::toHtml(mapping);
 
-Since this feature is not often needed, it currently resides in a separate header :cpp:`llama/DumpMapping.hpp`
-and is not included as part of :cpp:`llama.hpp`.
+This feature requires to have libfmt installed.

--- a/examples/bufferguard/bufferguard.cpp
+++ b/examples/bufferguard/bufferguard.cpp
@@ -3,7 +3,6 @@
 #include <cstring>
 #include <fmt/core.h>
 #include <fstream>
-#include <llama/DumpMapping.hpp>
 #include <llama/llama.hpp>
 
 // clang-format off

--- a/examples/nbody/nbody.cpp
+++ b/examples/nbody/nbody.cpp
@@ -5,7 +5,6 @@
 #include <fstream>
 #include <iomanip>
 #include <iostream>
-#include <llama/DumpMapping.hpp>
 #include <llama/llama.hpp>
 #include <omp.h>
 #include <random>

--- a/include/llama/DumpMapping.hpp
+++ b/include/llama/DumpMapping.hpp
@@ -2,17 +2,14 @@
 
 #pragma once
 
-#if !__has_include(<fmt/format.h>)
-#    error DumpMapping.hpp requires the fmt library
-#endif
+#if __has_include(<fmt/format.h>)
+#    include "ArrayIndexRange.hpp"
+#    include "Core.hpp"
 
-#include "ArrayIndexRange.hpp"
-#include "Core.hpp"
-
-#include <boost/functional/hash.hpp>
-#include <fmt/format.h>
-#include <string>
-#include <vector>
+#    include <boost/functional/hash.hpp>
+#    include <fmt/format.h>
+#    include <string>
+#    include <vector>
 
 namespace llama
 {
@@ -312,3 +309,5 @@ namespace llama
         return html;
     }
 } // namespace llama
+
+#endif

--- a/include/llama/llama.hpp
+++ b/include/llama/llama.hpp
@@ -40,6 +40,7 @@
 #include "BlobAllocators.hpp"
 #include "Copy.hpp"
 #include "Core.hpp"
+#include "DumpMapping.hpp"
 #include "Meta.hpp"
 #include "Vector.hpp"
 #include "View.hpp"

--- a/tests/dump.cpp
+++ b/tests/dump.cpp
@@ -1,8 +1,6 @@
 #include "common.hpp"
 
-#include <fmt/core.h>
 #include <fstream>
-#include <llama/DumpMapping.hpp>
 #include <string>
 
 // AppleClang 13.0 on MacOS 11.0 crashes (segfault) when compiling any of these tests

--- a/tests/mapping.Split.cpp
+++ b/tests/mapping.Split.cpp
@@ -1,7 +1,6 @@
 #include "common.hpp"
 
 #include <fstream>
-#include <llama/DumpMapping.hpp>
 
 TEST_CASE("Split.partitionRecordDim.OneMemberRecord")
 {


### PR DESCRIPTION
Disable DumpMapping.hpp content when libfmt is not available.

Fixes #251.