### PR TITLE
Switch to 2 threads for building

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -2,7 +2,7 @@ name: CI
 on: [push, pull_request]
 
 env:
-  THREADS: 4
+  THREADS: 2
   CONFIG: RelWithDebInfo
 
 jobs:


### PR DESCRIPTION
GitHub runners seem to have 2 cores per job: https://docs.github.com/en/actions/using-github-hosted-runners/about-github-hosted-runners.