### PR TITLE
Setup codecov

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -45,6 +45,42 @@ jobs:
         sed -i 's/\(-forward-unknown-to-host-compiler\|--generate-code=arch=[^ ]\+\|--expt-extended-lambda\|--expt-relaxed-constexpr\|--use_fast_math\)//g' compile_commands.json # remove NVCC specific flags which clang cannot handle
         run-clang-tidy-12 -header-filter='^((?!/thirdparty/).)*$' -extra-arg=--no-cuda-version-check -extra-arg=-nocudalib
 
+  coverage:
+    runs-on: ubuntu-latest
+    env:
+      CXX: g++
+    steps:
+    - uses: actions/checkout@v2
+      with:
+        fetch-depth: 1
+    - name: apt install boost and lcov
+      run: |
+        sudo apt install libboost-all-dev lcov
+    - name: vcpkg install dependencies
+      run: |
+        vcpkg install catch2 fmt
+    - name: cmake
+      run: |
+        mkdir build
+        cd build
+        cmake .. -DCMAKE_BUILD_TYPE=Debug -DLLAMA_ENABLE_COVERAGE_FOR_TESTS=ON -DLLAMA_BUILD_EXAMPLES=OFF -DCMAKE_TOOLCHAIN_FILE=/usr/local/share/vcpkg/scripts/buildsystems/vcpkg.cmake
+    - name: build tests
+      run: |
+        cmake --build build -j $THREADS
+    - name: run tests
+      run: |
+        build/tests
+    - name: generate coverage report
+      run: |
+        lcov --capture --directory build --output-file coverage.info
+        #lcov --remove coverage.info '/usr/*' --output-file coverage.info
+        #lcov --list coverage.info
+    - name: upload coverage report
+      run: |
+        curl -Os https://uploader.codecov.io/latest/linux/codecov
+        chmod +x codecov
+        ./codecov
+
   amalgamation:
     runs-on: ubuntu-latest
     steps:

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -60,6 +60,14 @@ if (BUILD_TESTING)
 			target_link_options   (tests PRIVATE /wholearchive:clang_rt.asan_dynamic-x86_64.lib /wholearchive:clang_rt.asan_dynamic_runtime_thunk-x86_64.lib)
 		endif()
 	endif()
+
+	option(LLAMA_ENABLE_COVERAGE_FOR_TESTS "Enables code coverage for tests" OFF)
+	if (LLAMA_ENABLE_COVERAGE_FOR_TESTS)
+		if (CMAKE_CXX_COMPILER_ID STREQUAL "GNU" OR CMAKE_CXX_COMPILER_ID STREQUAL "Clang")
+			target_compile_options(tests PRIVATE --coverage)
+			target_link_options(tests PRIVATE --coverage)
+		endif()
+	endif()
 endif()
 
 # examples


### PR DESCRIPTION
This PR adds a CMake option to enable code coverage analysis for LLAMA's unit tests. It also adds a CI build running a code coverage analysis of the unit tests and uploads the result to [Codecov](https://about.codecov.io/).