### PR TITLE
Various mapping enhancements

### DIFF
--- a/include/llama/mapping/Bytesplit.hpp
+++ b/include/llama/mapping/Bytesplit.hpp
@@ -37,6 +37,12 @@ namespace llama::mapping
         {
         }
 
+        template<typename... Args>
+        LLAMA_FN_HOST_ACC_INLINE constexpr explicit Bytesplit(std::tuple<Args...> innerMappingArgs, TRecordDim = {})
+            : Inner(std::make_from_tuple<Inner>(innerMappingArgs))
+        {
+        }
+
         template<std::size_t... RecordCoords>
         static constexpr auto isComputed(RecordCoord<RecordCoords...>)
         {

--- a/include/llama/mapping/ChangeType.hpp
+++ b/include/llama/mapping/ChangeType.hpp
@@ -42,12 +42,12 @@ namespace llama::mapping
             // NOLINTNEXTLINE(google-explicit-constructor,hicpp-explicit-conversions)
             LLAMA_FN_HOST_ACC_INLINE constexpr operator UserT() const
             {
-                return storageRef;
+                return static_cast<UserT>(storageRef); // we could allow stronger casts here
             }
 
             LLAMA_FN_HOST_ACC_INLINE constexpr auto operator=(UserT v) -> ChangeTypeReference&
             {
-                storageRef = v;
+                storageRef = static_cast<StoredT>(v); // we could allow stronger casts here
                 return *this;
             }
         };

--- a/include/llama/mapping/ChangeType.hpp
+++ b/include/llama/mapping/ChangeType.hpp
@@ -12,6 +12,10 @@ namespace llama::mapping
         template<typename ReplacementMap>
         struct MakeReplacer
         {
+            static_assert(
+                boost::mp11::mp_is_map<ReplacementMap>::value,
+                "The Replacement map must be of the form: mp_list<mp_list<From, To>, ...>");
+
             template<typename UserT>
             using type = typename boost::mp11::mp_if<
                 boost::mp11::mp_map_contains<ReplacementMap, UserT>,

--- a/include/llama/mapping/ChangeType.hpp
+++ b/include/llama/mapping/ChangeType.hpp
@@ -100,4 +100,11 @@ namespace llama::mapping
                 reinterpret_cast<QualifiedStoredT&>(blobs[nr][offset])};
         }
     };
+
+    template<template<typename, typename> typename InnerMapping, typename ReplacementMap>
+    struct PreconfiguredChangeType
+    {
+        template<typename ArrayExtents, typename RecordDim>
+        using type = ChangeType<ArrayExtents, RecordDim, InnerMapping, ReplacementMap>;
+    };
 } // namespace llama::mapping

--- a/include/llama/mapping/ChangeType.hpp
+++ b/include/llama/mapping/ChangeType.hpp
@@ -103,6 +103,14 @@ namespace llama::mapping
             return internal::ChangeTypeReference<UserT, QualifiedStoredT>{
                 reinterpret_cast<QualifiedStoredT&>(blobs[nr][offset])};
         }
+
+        template<std::size_t... RecordCoords>
+        LLAMA_FN_HOST_ACC_INLINE constexpr auto blobNrAndOffset(ArrayIndex ai, RecordCoord<RecordCoords...> rc = {})
+            const -> NrAndOffset
+        {
+            static_assert(!isComputed(rc));
+            return Inner::blobNrAndOffset(ai, rc);
+        }
     };
 
     template<template<typename, typename> typename InnerMapping, typename ReplacementMap>

--- a/tests/mapping.BitPackedIntSoA.cpp
+++ b/tests/mapping.BitPackedIntSoA.cpp
@@ -119,3 +119,51 @@ TEST_CASE("mapping.BitPackedIntSoA.bool")
     for(auto i = 0; i < n; i++)
         CHECK(view(i) == (i % 2 == 0));
 }
+
+namespace
+{
+    enum Grades
+    {
+        A,
+        B,
+        C,
+        D,
+        E,
+        F
+    };
+
+    enum class GradesClass
+    {
+        A,
+        B,
+        C,
+        D,
+        E,
+        F
+    };
+} // namespace
+
+// NOLINTNEXTLINE(fuchsia-statically-constructed-objects)
+TEMPLATE_TEST_CASE("mapping.BitPackedIntSoA.Enum", "", Grades, GradesClass)
+{
+    using Enum = TestType;
+
+    using StoredIntegral =
+        typename llama::mapping::internal::MakeUnsigned<llama::mapping::internal::LargestIntegral<Enum>>::type;
+    STATIC_REQUIRE(std::is_same_v<StoredIntegral, unsigned>);
+
+    auto view = llama::allocView(llama::mapping::BitPackedIntSoA<llama::ArrayExtentsDynamic<1>, Enum>{3, {6}});
+    view(0) = Enum::A;
+    view(1) = Enum::B;
+    view(2) = Enum::C;
+    view(3) = Enum::D;
+    view(4) = Enum::E;
+    view(5) = Enum::F;
+
+    CHECK(view(0) == Enum::A);
+    CHECK(view(1) == Enum::B);
+    CHECK(view(2) == Enum::C);
+    CHECK(view(3) == Enum::D);
+    CHECK(view(4) == Enum::E);
+    CHECK(view(5) == Enum::F);
+}

--- a/tests/mapping.Bytesplit.cpp
+++ b/tests/mapping.Bytesplit.cpp
@@ -57,6 +57,21 @@ TEST_CASE("mapping.ByteSplit.ChangeType.SoA")
     iotaCheckView(view);
 }
 
+TEST_CASE("mapping.ByteSplit.Split.BitPackedIntSoA")
+{
+    auto view = llama::allocView(llama::mapping::Bytesplit<
+                                 llama::ArrayExtentsDynamic<1>,
+                                 Vec3I,
+                                 llama::mapping::PreconfiguredSplit<
+                                     llama::RecordCoord<1>,
+                                     llama::mapping::BitPackedIntSoA,
+                                     llama::mapping::PreconfiguredAoS<>::type,
+                                     true>::type>{
+        std::tuple{std::tuple{23, llama::ArrayExtents{128}}, std::tuple{llama::ArrayExtents{128}}}});
+    iotaFillView(view);
+    iotaCheckView(view);
+}
+
 TEST_CASE("mapping.ByteSplit.SoA.verify")
 {
     using Mapping

--- a/tests/mapping.Bytesplit.cpp
+++ b/tests/mapping.Bytesplit.cpp
@@ -29,6 +29,34 @@ TEST_CASE("mapping.ByteSplit.AoSoA")
     iotaCheckView(view);
 }
 
+TEST_CASE("mapping.ByteSplit.ChangeType.SoA")
+{
+    using Mapping = llama::mapping::Bytesplit<
+        llama::ArrayExtentsDynamic<1>,
+        Vec3I,
+        llama::mapping::PreconfiguredChangeType<
+            llama::mapping::PreconfiguredSoA<>::type,
+            boost::mp11::mp_list<boost::mp11::mp_list<std::byte, unsigned char>>>::type>;
+
+    STATIC_REQUIRE(std::is_same_v<Mapping::RecordDim, Vec3I>);
+    STATIC_REQUIRE(std::is_same_v<
+                   typename Mapping::Inner::RecordDim,
+                   llama::Record<
+                       llama::Field<tag::X, std::byte[4]>,
+                       llama::Field<tag::Y, std::byte[4]>,
+                       llama::Field<tag::Z, std::byte[4]>>>);
+    STATIC_REQUIRE(std::is_same_v<
+                   typename Mapping::Inner::Inner::RecordDim,
+                   llama::Record<
+                       llama::Field<tag::X, unsigned char[4]>,
+                       llama::Field<tag::Y, unsigned char[4]>,
+                       llama::Field<tag::Z, unsigned char[4]>>>);
+
+    auto view = llama::allocView(Mapping{{128}});
+    iotaFillView(view);
+    iotaCheckView(view);
+}
+
 TEST_CASE("mapping.ByteSplit.SoA.verify")
 {
     using Mapping

--- a/tests/proxyrefopmixin.cpp
+++ b/tests/proxyrefopmixin.cpp
@@ -231,7 +231,8 @@ namespace
 TEST_CASE("proxyrefopmixin.Bytesplit")
 {
     auto view = llama::allocView(
-        llama::mapping::Bytesplit<llama::ArrayExtents<4>, Vec3I, llama::mapping::PreconfiguredAoS<>::type>{{}});
+        llama::mapping::Bytesplit<llama::ArrayExtents<4>, Vec3I, llama::mapping::PreconfiguredAoS<>::type>{
+            llama::ArrayExtents<4>{}});
     testProxyRef(view(2)(tag::X{}));
 }
 

--- a/tests/view.cpp
+++ b/tests/view.cpp
@@ -73,7 +73,7 @@ TEST_CASE("view.non-memory-owning")
 
         for(auto i = 0u; i < 256u; i++)
         {
-            auto* v = reinterpret_cast<decltype(storage.get())>(&view(i)(tag::Value{}));
+            auto* v = reinterpret_cast<byte*>(&view(i)(tag::Value{}));
             CHECK(storage.get() <= v);
             CHECK(v <= storage.get() + blobSize);
         }


### PR DESCRIPTION
* support enums in BitPackedIntSoA
* add PreconfiguredChangeType to allow using ChangeType mapping as sub mapping
* some fixes for ChangeType mapping
* allow type conversion that require a cast in ChangeType mapping
* support computed mappings as submappings in Bytesplit mapping