### PR TITLE
Add Null mapping

### DIFF
--- a/include/llama/llama.hpp
+++ b/include/llama/llama.hpp
@@ -54,6 +54,7 @@
 #include "mapping/Bytesplit.hpp"
 #include "mapping/ChangeType.hpp"
 #include "mapping/Heatmap.hpp"
+#include "mapping/Null.hpp"
 #include "mapping/One.hpp"
 #include "mapping/SoA.hpp"
 #include "mapping/Split.hpp"

--- a/include/llama/mapping/Null.hpp
+++ b/include/llama/mapping/Null.hpp
@@ -1,0 +1,68 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#pragma once
+
+#include "../ProxyRefOpMixin.hpp"
+
+namespace llama::mapping
+{
+    namespace internal
+    {
+        template<typename T>
+        struct NullReference : ProxyRefOpMixin<NullReference<T>, T>
+        {
+            // NOLINTNEXTLINE(google-explicit-constructor,hicpp-explicit-conversions)
+            LLAMA_FN_HOST_ACC_INLINE constexpr operator T() const
+            {
+                return T{}; // this might not be the best design decision
+            }
+
+            LLAMA_FN_HOST_ACC_INLINE constexpr auto operator=(T) -> NullReference&
+            {
+                return *this;
+            }
+        };
+    } // namespace internal
+
+    /// The Null mappings maps all elements to nothing. Writing data through a reference obtained from the Null mapping
+    /// discards the value. Reading through such a reference returns a default constructed object.
+    template<typename TArrayExtents, typename TRecordDim>
+    struct Null : TArrayExtents
+    {
+        using ArrayExtents = TArrayExtents;
+        using ArrayIndex = typename ArrayExtents::Index;
+        using RecordDim = TRecordDim;
+        static constexpr std::size_t blobCount = 0;
+
+        constexpr Null() = default;
+
+        LLAMA_FN_HOST_ACC_INLINE
+        constexpr Null(ArrayExtents extents, RecordDim = {}) : ArrayExtents(extents)
+        {
+        }
+
+        LLAMA_FN_HOST_ACC_INLINE constexpr auto extents() const -> ArrayExtents
+        {
+            return *this; // NOLINT(cppcoreguidelines-slicing)
+        }
+
+        LLAMA_FN_HOST_ACC_INLINE
+        constexpr auto blobSize(std::size_t /*blobIndex*/) const -> std::size_t
+        {
+            return 0;
+        }
+
+        template<std::size_t... RecordCoords>
+        static constexpr auto isComputed(RecordCoord<RecordCoords...>)
+        {
+            return true;
+        }
+
+        template<std::size_t... RecordCoords, typename Blobs>
+        LLAMA_FN_HOST_ACC_INLINE constexpr auto compute(ArrayIndex, RecordCoord<RecordCoords...>, Blobs&) const
+        {
+            using FieldType = GetType<RecordDim, RecordCoord<RecordCoords...>>;
+            return internal::NullReference<FieldType>{};
+        }
+    };
+} // namespace llama::mapping

--- a/tests/mapping.Null.cpp
+++ b/tests/mapping.Null.cpp
@@ -1,0 +1,21 @@
+#include "common.hpp"
+
+#include <cstdint>
+
+TEST_CASE("mapping.Null")
+{
+    auto mapping = llama::mapping::Null<llama::ArrayExtents<128>, Particle>{{}};
+    STATIC_REQUIRE(decltype(mapping)::blobCount == 0);
+
+    auto view = llama::allocView(mapping);
+    iotaFillView(view);
+
+    for(auto ai : llama::ArrayIndexRange{view.mapping().extents()})
+        llama::forEachLeafCoord<Particle>(
+            [&](auto rc)
+            {
+                CAPTURE(ai, rc);
+                using Type = llama::GetType<Particle, decltype(rc)>;
+                CHECK(view(ai)(rc) == Type{});
+            });
+}


### PR DESCRIPTION
The Null mappings maps all elements to nothing. Writing data through a reference obtained from the Null mapping discards the value. Reading through such a reference returns a default constructed object.