### PR TITLE
Support compile time bit count for BitPacked mappings

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -6,6 +6,7 @@
 # -readability-misleading-indentation # many false positives because of constexpr if
 # -readability-static-accessed-through-instance # flags threadIdx/blockIdx in CUDA code
 # -cert-err58-cpp # errors in Catch2
+# -fuchsia-statically-constructed-objects # too much noise with Catch2
 Checks: >
     *,
     -bugprone-exception-escape,
@@ -48,7 +49,8 @@ Checks: >
     -altera-struct-pack-align,
     -misc-no-recursion,
     -llvm-header-guard,
-    -cppcoreguidelines-macro-usage
+    -cppcoreguidelines-macro-usage,
+    -fuchsia-statically-constructed-objects
 
 WarningsAsErrors: '*'
 HeaderFilterRegex: ''

--- a/examples/bitpackfloat/bitpackfloat.cpp
+++ b/examples/bitpackfloat/bitpackfloat.cpp
@@ -21,7 +21,7 @@ auto main() -> int
     constexpr auto exponentBits = 5;
     constexpr auto mantissaBits = 13;
     const auto mapping
-        = llama::mapping::BitPackedFloatSoA{exponentBits, mantissaBits, llama::ArrayExtents<llama::dyn>{N}, Vector{}};
+        = llama::mapping::BitPackedFloatSoA{llama::ArrayExtents<llama::dyn>{N}, exponentBits, mantissaBits, Vector{}};
 
     auto view = llama::allocView(mapping);
 

--- a/examples/bitpackint/bitpackint.cpp
+++ b/examples/bitpackint/bitpackint.cpp
@@ -21,7 +21,8 @@ auto main() -> int
 {
     constexpr auto N = 128;
     constexpr auto bits = 7;
-    const auto mapping = llama::mapping::BitPackedIntSoA<llama::ArrayExtentsDynamic<1>, Vector>{bits, {N}};
+    const auto mapping
+        = llama::mapping::BitPackedIntSoA<llama::ArrayExtentsDynamic<1>, Vector, llama::Constant<bits>>{{N}};
 
     auto view = llama::allocView(mapping);
 

--- a/examples/cuda/nbody/nbody.cu
+++ b/examples/cuda/nbody/nbody.cu
@@ -332,7 +332,6 @@ namespace manual
         return ai;
     }
 
-    // NOLINTNEXTLINE(fuchsia-statically-constructed-objects)
     __shared__ FP4 shPosition[SHARED_ELEMENTS_PER_BLOCK];
 
     __device__ auto tile_calculation(FP4 myPosition, FP3 accel) -> FP3

--- a/examples/daxpy/daxpy.cpp
+++ b/examples/daxpy/daxpy.cpp
@@ -116,9 +116,9 @@ $data << EOD
             llama::mapping::PreconfiguredAoS<>::type,
             boost::mp11::mp_list<boost::mp11::mp_list<double, float>>>{extents},
         plotFile);
-    daxpy_llama("Bitpack 52^{11}", llama::mapping::BitPackedFloatSoA{11, 52, extents, double{}}, plotFile);
-    daxpy_llama("Bitpack 23^{8}", llama::mapping::BitPackedFloatSoA{8, 23, extents, double{}}, plotFile);
-    daxpy_llama("Bitpack 10^{5}", llama::mapping::BitPackedFloatSoA{5, 10, extents, double{}}, plotFile);
+    daxpy_llama("Bitpack 52^{11}", llama::mapping::BitPackedFloatSoA{extents, 11, 52, double{}}, plotFile);
+    daxpy_llama("Bitpack 23^{8}", llama::mapping::BitPackedFloatSoA{extents, 8, 23, double{}}, plotFile);
+    daxpy_llama("Bitpack 10^{5}", llama::mapping::BitPackedFloatSoA{extents, 5, 10, double{}}, plotFile);
 
     plotFile << R"(EOD
 plot $data using 2:xtic(1)

--- a/examples/nbody/nbody.cpp
+++ b/examples/nbody/nbody.cpp
@@ -118,6 +118,8 @@ namespace usellama
                 return "ByteSplit SoA MB";
             if(m == 7)
                 return "BitPack SoA 11e4";
+            if(m == 8)
+                return "BitPack SoA 11e4 CT";
             std::abort();
         };
         auto title = "LLAMA " + mappingName(Mapping);
@@ -150,7 +152,10 @@ namespace usellama
                 return llama::mapping::Bytesplit<ArrayExtents, Particle, llama::mapping::PreconfiguredSoA<>::type>{
                     extents};
             if constexpr(Mapping == 7)
-                return llama::mapping::BitPackedFloatSoA<ArrayExtents, Particle>{4, 11, extents};
+                return llama::mapping::BitPackedFloatSoA<ArrayExtents, Particle>{extents, 4, 11};
+            if constexpr(Mapping == 8)
+                return llama::mapping::
+                    BitPackedFloatSoA<ArrayExtents, Particle, llama::Constant<4>, llama::Constant<11>>{extents};
         }();
         if constexpr(DUMP_MAPPING)
             std::ofstream(title + ".svg") << llama::toSvg(mapping);

--- a/tests/dump.cpp
+++ b/tests/dump.cpp
@@ -128,12 +128,12 @@ TEST_CASE("dump.Particle.BitPacked")
              llama::mapping::PreconfiguredSplit<
                  llama::RecordCoord<0>,
                  llama::mapping::BitPackedFloatSoA,
-                 llama::mapping::BitPackedIntSoA,
+                 llama::mapping::PreconfiguredBitPackedIntSoA<llama::Constant<1>>::type,
                  true>::type,
              true>::type,
          true>{
-        std::tuple{std::tuple{3, 3, extents}, std::tuple{extents}},
-        std::tuple{std::tuple{}, std::tuple{std::tuple{5, 5, extents}, std::tuple{1, extents}}}});
+        std::tuple{std::tuple{extents, 3, 3}, std::tuple{extents}},
+        std::tuple{std::tuple{}, std::tuple{std::tuple{extents, 5, 5}, std::tuple{extents}}}});
 }
 
 TEST_CASE("dump.ParticleUnaligned.AoS")

--- a/tests/mapping.BitPackedFloatSoA.cpp
+++ b/tests/mapping.BitPackedFloatSoA.cpp
@@ -10,7 +10,6 @@
         CHECK(view() == (out));                                                                                       \
     }
 
-// NOLINTNEXTLINE(fuchsia-statically-constructed-objects)
 TEMPLATE_TEST_CASE("mapping.BitPackedFloatSoA.exponent_only", "", float, double)
 {
     const auto inf = std::numeric_limits<float>::infinity();
@@ -49,7 +48,6 @@ TEMPLATE_TEST_CASE("mapping.BitPackedFloatSoA.exponent_only", "", float, double)
     STORE_LOAD_CHECK(-nan, -inf);
 }
 
-// NOLINTNEXTLINE(fuchsia-statically-constructed-objects)
 TEMPLATE_TEST_CASE("mapping.BitPackedFloatSoA", "", float, double)
 {
     const auto inf = std::numeric_limits<float>::infinity();

--- a/tests/mapping.BitPackedIntSoA.cpp
+++ b/tests/mapping.BitPackedIntSoA.cpp
@@ -143,7 +143,6 @@ namespace
     };
 } // namespace
 
-// NOLINTNEXTLINE(fuchsia-statically-constructed-objects)
 TEMPLATE_TEST_CASE("mapping.BitPackedIntSoA.Enum", "", Grades, GradesClass)
 {
     using Enum = TestType;

--- a/tests/mapping.BitPackedIntSoA.cpp
+++ b/tests/mapping.BitPackedIntSoA.cpp
@@ -13,25 +13,43 @@ using UInts = llama::Record<
     llama::Field<std::uint32_t, std::uint32_t>,
     llama::Field<std::uint64_t, std::uint64_t>>;
 
-TEST_CASE("mapping.BitPackedIntSoA.SInts")
+TEST_CASE("mapping.BitPackedIntSoA.Constant.SInts")
 {
     // 16 elements * 4 fields = 64 integers, iota produces [0;63], which fits int8_t and into 7 bits
-    auto view = llama::allocView(llama::mapping::BitPackedIntSoA<llama::ArrayExtentsDynamic<1>, SInts>{7, {16}});
+    auto view = llama::allocView(
+        llama::mapping::BitPackedIntSoA<llama::ArrayExtentsDynamic<1>, SInts, llama::Constant<7>>{{16}});
     iotaFillView(view);
     iotaCheckView(view);
 }
 
-TEST_CASE("mapping.BitPackedIntSoA.UInts")
+TEST_CASE("mapping.BitPackedIntSoA.Value.SInts")
+{
+    // 16 elements * 4 fields = 64 integers, iota produces [0;63], which fits int8_t and into 7 bits
+    auto view = llama::allocView(llama::mapping::BitPackedIntSoA<llama::ArrayExtentsDynamic<1>, SInts>{{16}, 7});
+    iotaFillView(view);
+    iotaCheckView(view);
+}
+
+TEST_CASE("mapping.BitPackedIntSoA.Constant.UInts")
 {
     // 32 elements * 4 fields = 128 integers, iota produces [0;127], which fits uint8_t and into 7 bits
-    auto view = llama::allocView(llama::mapping::BitPackedIntSoA<llama::ArrayExtentsDynamic<1>, UInts>{7, {32}});
+    auto view = llama::allocView(
+        llama::mapping::BitPackedIntSoA<llama::ArrayExtentsDynamic<1>, UInts, llama::Constant<7>>{{32}});
+    iotaFillView(view);
+    iotaCheckView(view);
+}
+
+TEST_CASE("mapping.BitPackedIntSoA.Value.UInts")
+{
+    // 32 elements * 4 fields = 128 integers, iota produces [0;127], which fits uint8_t and into 7 bits
+    auto view = llama::allocView(llama::mapping::BitPackedIntSoA<llama::ArrayExtentsDynamic<1>, UInts>{{32}, 7});
     iotaFillView(view);
     iotaCheckView(view);
 }
 
 TEST_CASE("mapping.BitPackedIntSoA.UInts.Cutoff")
 {
-    auto view = llama::allocView(llama::mapping::BitPackedIntSoA<llama::ArrayExtents<>, UInts>{3, {}});
+    auto view = llama::allocView(llama::mapping::BitPackedIntSoA<llama::ArrayExtents<>, UInts, llama::Constant<3>>{});
 
     for(auto i = 0; i < 8; i++)
     {
@@ -49,7 +67,7 @@ TEST_CASE("mapping.BitPackedIntSoA.UInts.Cutoff")
 
 TEST_CASE("mapping.BitPackedIntSoA.SInts.Cutoff")
 {
-    auto view = llama::allocView(llama::mapping::BitPackedIntSoA<llama::ArrayExtents<>, SInts>{4, {}});
+    auto view = llama::allocView(llama::mapping::BitPackedIntSoA<llama::ArrayExtents<>, SInts, llama::Constant<4>>{});
 
     for(auto i = 0; i < 8; i++)
     {
@@ -81,14 +99,15 @@ TEST_CASE("mapping.BitPackedIntSoA.SInts.Cutoff")
 TEST_CASE("mapping.BitPackedIntSoA.SInts.Roundtrip")
 {
     constexpr auto N = 1000;
-    auto view = llama::allocView(llama::mapping::AoS<llama::ArrayExtents<N>, Vec3I>{{}});
+    auto view = llama::allocView(llama::mapping::AoS<llama::ArrayExtents<N>, Vec3I>{});
     std::default_random_engine engine;
     std::uniform_int_distribution dist{-2000, 2000}; // fits into 12 bits
     for(auto i = 0; i < N; i++)
         view(i) = dist(engine);
 
     // copy into packed representation
-    auto packedView = llama::allocView(llama::mapping::BitPackedIntSoA<llama::ArrayExtents<N>, Vec3I>{12, {}});
+    auto packedView
+        = llama::allocView(llama::mapping::BitPackedIntSoA<llama::ArrayExtents<N>, Vec3I, llama::Constant<12>>{});
     llama::copy(view, packedView);
 
     // compute on packed representation
@@ -96,7 +115,7 @@ TEST_CASE("mapping.BitPackedIntSoA.SInts.Roundtrip")
         packedView(i) = packedView(i) + 1;
 
     // copy into normal representation
-    auto view2 = llama::allocView(llama::mapping::AoS<llama::ArrayExtents<N>, Vec3I>{{}});
+    auto view2 = llama::allocView(llama::mapping::AoS<llama::ArrayExtents<N>, Vec3I>{});
     llama::copy(packedView, view2);
 
     // compute on normal representation
@@ -111,7 +130,7 @@ TEST_CASE("mapping.BitPackedIntSoA.bool")
 {
     // pack 32 bools into 4 bytes
     const auto n = 32;
-    const auto mapping = llama::mapping::BitPackedIntSoA<llama::ArrayExtentsDynamic<1>, bool>{1, {n}};
+    const auto mapping = llama::mapping::BitPackedIntSoA<llama::ArrayExtentsDynamic<1>, bool, llama::Constant<1>>{{n}};
     CHECK(mapping.blobSize(0) == n / CHAR_BIT);
     auto view = llama::allocView(mapping);
     for(auto i = 0; i < n; i++)
@@ -151,7 +170,8 @@ TEMPLATE_TEST_CASE("mapping.BitPackedIntSoA.Enum", "", Grades, GradesClass)
         typename llama::mapping::internal::MakeUnsigned<llama::mapping::internal::LargestIntegral<Enum>>::type;
     STATIC_REQUIRE(std::is_same_v<StoredIntegral, unsigned>);
 
-    auto view = llama::allocView(llama::mapping::BitPackedIntSoA<llama::ArrayExtentsDynamic<1>, Enum>{3, {6}});
+    auto view = llama::allocView(
+        llama::mapping::BitPackedIntSoA<llama::ArrayExtentsDynamic<1>, Enum, llama::Constant<3>>{{6}});
     view(0) = Enum::A;
     view(1) = Enum::B;
     view(2) = Enum::C;
@@ -165,4 +185,11 @@ TEMPLATE_TEST_CASE("mapping.BitPackedIntSoA.Enum", "", Grades, GradesClass)
     CHECK(view(3) == Enum::D);
     CHECK(view(4) == Enum::E);
     CHECK(view(5) == Enum::F);
+}
+
+TEST_CASE("mapping.BitPackedIntSoA.Size")
+{
+    STATIC_REQUIRE(
+        std::is_empty_v<llama::mapping::BitPackedIntSoA<llama::ArrayExtents<16>, SInts, llama::Constant<7>>>);
+    STATIC_REQUIRE(sizeof(llama::mapping::BitPackedIntSoA<llama::ArrayExtents<16>, SInts>{{}, 7}) == sizeof(unsigned));
 }

--- a/tests/mapping.Bytesplit.cpp
+++ b/tests/mapping.Bytesplit.cpp
@@ -67,7 +67,7 @@ TEST_CASE("mapping.ByteSplit.Split.BitPackedIntSoA")
                                      llama::mapping::BitPackedIntSoA,
                                      llama::mapping::PreconfiguredAoS<>::type,
                                      true>::type>{
-        std::tuple{std::tuple{23, llama::ArrayExtents{128}}, std::tuple{llama::ArrayExtents{128}}}});
+        std::tuple{std::tuple{llama::ArrayExtents{128}, 23}, std::tuple{llama::ArrayExtents{128}}}});
     iotaFillView(view);
     iotaCheckView(view);
 }

--- a/tests/mapping.Split.cpp
+++ b/tests/mapping.Split.cpp
@@ -172,13 +172,13 @@ TEST_CASE("Split.BitPacked")
         ArrayExtents,
         Vec3I,
         llama::RecordCoord<0>,
-        llama::mapping::BitPackedIntSoA,
+        llama::mapping::PreconfiguredBitPackedIntSoA<llama::Constant<3>>::type,
         llama::mapping::PreconfiguredSplit<
             llama::RecordCoord<0>,
             llama::mapping::BitPackedIntSoA,
             llama::mapping::PackedAoS,
             true>::type,
-        true>{{3, extents}, {std::tuple{5, extents}, std::tuple{extents}}};
+        true>{{extents}, {std::tuple{extents, 5}, std::tuple{extents}}};
     CHECK(mapping.blobSize(0) == 12);
     CHECK(mapping.blobSize(1) == 20);
     CHECK(mapping.blobSize(2) == 128);

--- a/tests/proxyrefopmixin.cpp
+++ b/tests/proxyrefopmixin.cpp
@@ -238,13 +238,14 @@ TEST_CASE("proxyrefopmixin.Bytesplit")
 
 TEST_CASE("proxyrefopmixin.BitPackedIntSoA")
 {
-    auto view = llama::allocView(llama::mapping::BitPackedIntSoA<llama::ArrayExtents<4>, Vec3I>{12, {}});
+    auto view = llama::allocView(llama::mapping::BitPackedIntSoA<llama::ArrayExtents<4>, Vec3I>{{}, 12});
     testProxyRef(view(2)(tag::X{}));
 }
 
 TEST_CASE("proxyrefopmixin.BitPackedFloatSoA")
 {
-    auto view = llama::allocView(llama::mapping::BitPackedFloatSoA<llama::ArrayExtents<4>, Vec3D>{6, 20, {}});
+    auto view = llama::allocView(
+        llama::mapping::BitPackedFloatSoA<llama::ArrayExtents<4>, Vec3D, llama::Constant<6>, llama::Constant<20>>{});
     testProxyRef(view(2)(tag::X{}));
 }
 


### PR DESCRIPTION
This PR adds the ability to specify the bit count for the `BitPackedIntSoA` mapping and the exponent/mantissa bit counts for the `BitPackedFloatSoA` mappings at compile time.

It furthermore disables the clang-tidy check `fuchsia-statically-constructed-objects`, because it is too noisy in the unit test code.