### PR TITLE
Install boost 1.74 in CI

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -18,7 +18,8 @@ jobs:
 
   clang-tidy:
     runs-on: ubuntu-latest
-    env: {CXX: clang++-12}
+    env:
+      CXX: clang++-12
     steps:
     - uses: actions/checkout@v2
     - name: apt install boost and clang-12
@@ -102,92 +103,97 @@ jobs:
 
   build-ubuntu:
     runs-on: ubuntu-latest
-    env: ${{ matrix.env }}
+    env:
+      CXX: ${{ matrix.cxx }}
     name: ${{ matrix.name }}
     strategy:
       fail-fast: false
       matrix:
         include:
           - name: build-ubuntu-gcc9
-            env: {CXX: g++-9}
-          #- name: build-ubuntu-gcc9-cuda11.0
-          #  env: {CXX: g++-9, CUDA_URL: "https://developer.download.nvidia.com/compute/cuda/11.0.3/local_installers/cuda_11.0.3_450.51.06_linux.run"}
-          #  cuda: true
-          #- name: build-ubuntu-gcc9-cuda11.1
-          #  env: {CXX: g++-9, CUDA_URL: "https://developer.download.nvidia.com/compute/cuda/11.1.1/local_installers/cuda_11.1.1_455.32.00_linux.run"}
-          #  cuda: true
+            cxx: g++-9
           - name: build-ubuntu-gcc9-cuda11.2
-            env: {CXX: g++-9, CUDA_URL: "https://developer.download.nvidia.com/compute/cuda/11.2.1/local_installers/cuda_11.2.1_460.32.03_linux.run"}
-            cuda: true
+            cxx: g++-9
+            cuda_url: https://developer.download.nvidia.com/compute/cuda/11.2.1/local_installers/cuda_11.2.1_460.32.03_linux.run
           - name: build-ubuntu-gcc9-cuda11.3
-            env: {CXX: g++-9, CUDA_URL: "https://developer.download.nvidia.com/compute/cuda/11.3.1/local_installers/cuda_11.3.1_465.19.01_linux.run"}
-            cuda: true
+            cxx: g++-9
+            cuda_url: https://developer.download.nvidia.com/compute/cuda/11.3.1/local_installers/cuda_11.3.1_465.19.01_linux.run
           - name: build-ubuntu-gcc9-cuda11.4
-            env: {CXX: g++-9, CUDA_URL: "https://developer.download.nvidia.com/compute/cuda/11.4.1/local_installers/cuda_11.4.1_470.57.02_linux.run"}
-            cuda: true
+            cxx: g++-9
+            cuda_url: https://developer.download.nvidia.com/compute/cuda/11.4.1/local_installers/cuda_11.4.1_470.57.02_linux.run
           - name: build-ubuntu-gcc10
-            env: {CXX: g++-10}
+            cxx: g++-10
           - name: build-ubuntu-gcc11
-            env: {CXX: g++-11, INSTALL_EXTRA: g++-11}
-            add-toolchain-repo: true
+            cxx: g++-11
+            install_extra: g++-11
+            add_toolchain_repo: true
           - name: build-ubuntu-gcc11-cuda11.4
-            env: {CXX: g++-11, INSTALL_EXTRA: g++-11, CUDA_URL: "https://developer.download.nvidia.com/compute/cuda/11.4.1/local_installers/cuda_11.4.1_470.57.02_linux.run"}
-            add-toolchain-repo: true
-            cuda: true
+            cxx: g++-11
+            install_extra: g++-11
+            cuda_url: https://developer.download.nvidia.com/compute/cuda/11.4.1/local_installers/cuda_11.4.1_470.57.02_linux.run
+            add_toolchain_repo: true
           - name: build-ubuntu-gcc11-cuda11.5
-            env: {CXX: g++-11, INSTALL_EXTRA: g++-11, CUDA_URL: "https://developer.download.nvidia.com/compute/cuda/11.5.0/local_installers/cuda_11.5.0_495.29.05_linux.run"}
-            add-toolchain-repo: true
-            cuda: true
+            cxx: g++-11
+            install_extra: g++-11
+            cuda_url: https://developer.download.nvidia.com/compute/cuda/11.5.0/local_installers/cuda_11.5.0_495.29.05_linux.run
+            add_toolchain_repo: true
           - name: build-ubuntu-clang10
-            env: {CXX: clang++-10}
+            cxx: clang++-10
           - name: build-ubuntu-clang11
-            env: {CXX: clang++-11, INSTALL_EXTRA: clang-11}
+            cxx: clang++-11
+            install_extra: clang-11
           - name: build-ubuntu-clang12
-            env: {CXX: clang++-12, INSTALL_EXTRA: clang-12 libomp-12-dev}
-            add-llvm-repo: true
+            cxx: clang++-12
+            install_extra: clang-12 libomp-12-dev
+            add_llvm_repo: true
           - name: build-ubuntu-clang13
-            env: {CXX: clang++-13, INSTALL_EXTRA: clang-13 libomp-13-dev}
-            add-llvm-repo: true
+            cxx: clang++-13
+            install_extra: clang-13 libomp-13-dev
+            add_llvm_repo: true
           - name: build-ubuntu-icpx
-            env: {CXX: icpx}
-            intel: true
+            cxx: icpx
+            install_oneapi: true
 
     steps:
       - uses: actions/checkout@v2
       - name: add ubuntu toolchain repo
-        if: ${{ matrix.add-toolchain-repo }}
+        if: matrix.add_toolchain_repo
         run: |
           sudo add-apt-repository ppa:ubuntu-toolchain-r/test
       - name: add LLVM APT repo
-        if: ${{ matrix.add-llvm-repo }}
+        if: matrix.add_llvm_repo
         run: |
           wget -O - https://apt.llvm.org/llvm-snapshot.gpg.key|sudo apt-key add -
           sudo add-apt-repository 'deb http://apt.llvm.org/focal/ llvm-toolchain-focal main'
           sudo add-apt-repository 'deb http://apt.llvm.org/focal/ llvm-toolchain-focal-12 main'
           sudo add-apt-repository 'deb http://apt.llvm.org/focal/ llvm-toolchain-focal-13 main'
       - name: install OneAPI
-        if: ${{ matrix.intel }}
+        if: matrix.install_oneapi
         run: |
           wget https://apt.repos.intel.com/intel-gpg-keys/GPG-PUB-KEY-INTEL-SW-PRODUCTS.PUB
           sudo apt-key add GPG-PUB-KEY-INTEL-SW-PRODUCTS.PUB
           sudo add-apt-repository "deb https://apt.repos.intel.com/oneapi all main"
           sudo apt update
-          sudo apt install intel-oneapi-compiler-dpcpp-cpp-and-cpp-classic
+          sudo apt install intel-oneapi-compiler-dpcpp-cpp
       - name: install boost
         run: |
           sudo apt update
-          sudo apt install libboost-all-dev $INSTALL_EXTRA
+          sudo apt install libboost-all-dev
+      - name: install ${{ matrix.install_extra }}
+        if: matrix.install_extra
+        run: |
+          sudo apt install ${{ matrix.install_extra }}
       - name: vcpkg install dependencies
         run: |
           # vcpkg fails to build with Intel compilers
           if [ ${{ matrix.intel }} ]; then unset CXX; fi
           vcpkg install catch2 fmt vc tinyobjloader
       - name: download CUDA 11
-        if: ${{ matrix.cuda }}
+        if: matrix.cuda_url
         run: |
-          wget --no-verbose -O cuda_installer.run $CUDA_URL
+          wget --no-verbose -O cuda_installer.run ${{ matrix.cuda_url }}
       - name: install CUDA 11
-        if: ${{ matrix.cuda }}
+        if: matrix.cuda
         run: |
           sudo sh cuda_installer.run --silent --toolkit
       - name: install alpaka
@@ -197,7 +203,7 @@ jobs:
           mkdir alpaka/build
           cd alpaka/build
           cmake .. -DCMAKE_TOOLCHAIN_FILE=$VCPKG_INSTALLATION_ROOT/scripts/buildsystems/vcpkg.cmake
-          sudo cmake --build . --target install
+          sudo cmake --install .
       - name: cmake
         run: |
           if [ ${{ matrix.intel }} ]; then source /opt/intel/oneapi/setvars.sh; fi
@@ -246,7 +252,7 @@ jobs:
         mkdir alpaka/build
         cd alpaka/build
         cmake .. "-DCMAKE_TOOLCHAIN_FILE=$env:VCPKG_ROOT/scripts/buildsystems/vcpkg.cmake"
-        cmake --build . --target install --config $env:CONFIG
+        cmake --install . --config $env:CONFIG
     - name: cmake
       run: |
         mkdir build
@@ -267,7 +273,8 @@ jobs:
         include:
           - os: macos-10.15
           - os: macos-11
-    env: {CXX: clang++}
+    env:
+      CXX: clang++
     steps:
       - uses: actions/checkout@v2
       - name: brew install dependencies

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -4,6 +4,7 @@ on: [push, pull_request]
 env:
   THREADS: 4
   CONFIG: RelWithDebInfo
+  BOOST_ROOT: ${{ github.workspace }}/_boost
 
 jobs:
   clang-format:
@@ -22,12 +23,20 @@ jobs:
       CXX: clang++-12
     steps:
     - uses: actions/checkout@v2
-    - name: apt install boost and clang-12
+    - name: install boost
+      run: |
+          BOOST_VERSION=1.74.0
+          BOOST_ARCHIVE=boost_${BOOST_VERSION//./_}.tar.bz2
+          wget -q https://boostorg.jfrog.io/artifactory/main/release/$BOOST_VERSION/source/$BOOST_ARCHIVE
+          tar -xf $BOOST_ARCHIVE
+          rm $BOOST_ARCHIVE
+          mv boost_${BOOST_VERSION//./_} "${BOOST_ROOT}"
+    - name: install clang-12
       run: |
         wget -O - https://apt.llvm.org/llvm-snapshot.gpg.key|sudo apt-key add -
         sudo add-apt-repository 'deb http://apt.llvm.org/focal/ llvm-toolchain-focal-12 main'
         sudo apt update
-        sudo apt install libboost-all-dev clang-12 libomp-12-dev clang-tidy-12
+        sudo apt install clang-12 libomp-12-dev clang-tidy-12
     - name: vcpkg install dependencies
       run: |
         vcpkg install catch2 fmt vc tinyobjloader
@@ -177,16 +186,21 @@ jobs:
           sudo apt install intel-oneapi-compiler-dpcpp-cpp
       - name: install boost
         run: |
-          sudo apt update
-          sudo apt install libboost-all-dev
-      - name: install ${{ matrix.install_extra }}
-        if: matrix.install_extra
+          BOOST_VERSION=1.74.0
+          BOOST_ARCHIVE=boost_${BOOST_VERSION//./_}.tar.bz2
+          wget -q https://boostorg.jfrog.io/artifactory/main/release/$BOOST_VERSION/source/$BOOST_ARCHIVE
+          tar -xf $BOOST_ARCHIVE
+          rm $BOOST_ARCHIVE
+          mv boost_${BOOST_VERSION//./_} "${BOOST_ROOT}"
+      - name: install extras
+        if: ${{ matrix.install_extra }} 
         run: |
+          sudo apt update
           sudo apt install ${{ matrix.install_extra }}
       - name: vcpkg install dependencies
         run: |
           # vcpkg fails to build with Intel compilers
-          if [ ${{ matrix.intel }} ]; then unset CXX; fi
+          if [ ${{ matrix.install_oneapi }} ]; then unset CXX; fi
           vcpkg install catch2 fmt vc tinyobjloader
       - name: download CUDA 11
         if: matrix.cuda_url
@@ -198,7 +212,7 @@ jobs:
           sudo sh cuda_installer.run --silent --toolkit
       - name: install alpaka
         run: |
-          if [ ${{ matrix.intel }} ]; then source /opt/intel/oneapi/setvars.sh; fi
+          if [ ${{ matrix.install_oneapi }} ]; then source /opt/intel/oneapi/setvars.sh; fi
           git clone https://github.com/alpaka-group/alpaka.git
           mkdir alpaka/build
           cd alpaka/build
@@ -206,7 +220,7 @@ jobs:
           sudo cmake --install .
       - name: cmake
         run: |
-          if [ ${{ matrix.intel }} ]; then source /opt/intel/oneapi/setvars.sh; fi
+          if [ ${{ matrix.install_oneapi }} ]; then source /opt/intel/oneapi/setvars.sh; fi
           mkdir build
           cd build
           CUDACXX=(`echo /usr/local/cuda-*/bin/nvcc`)
@@ -217,18 +231,17 @@ jobs:
           cmake .. -DCMAKE_BUILD_TYPE=$CONFIG -DLLAMA_ENABLE_ASAN_FOR_TESTS=ON -DALPAKA_ACC_CPU_B_SEQ_T_SEQ_ENABLE=${{ !matrix.cuda }} -DALPAKA_ACC_GPU_CUDA_ENABLE=${{ matrix.cuda }} -DALPAKA_CXX_STANDARD=17 -DCMAKE_CUDA_COMPILER=$CUDACXX -DCMAKE_TOOLCHAIN_FILE=$VCPKG_INSTALLATION_ROOT/scripts/buildsystems/vcpkg.cmake
       - name: build tests + examples
         run: |
-          if [ ${{ matrix.intel }} ]; then source /opt/intel/oneapi/setvars.sh; fi
+          if [ ${{ matrix.install_oneapi }} ]; then source /opt/intel/oneapi/setvars.sh; fi
           cmake --build build -j $THREADS
       - name: run tests
         run: |
-          if [ ${{ matrix.intel }} ]; then source /opt/intel/oneapi/setvars.sh; fi
+          if [ ${{ matrix.install_oneapi }} ]; then source /opt/intel/oneapi/setvars.sh; fi
           build/tests
 
   build-windows:
     runs-on: windows-latest
     env:
       VCPKG_DEFAULT_TRIPLET: x64-windows
-      BOOST_ROOT: C:\hostedtoolcache\windows\Boost\1.75.0\x86_64
     steps:
     - uses: actions/checkout@v2
     - name: install vcpkg
@@ -239,7 +252,7 @@ jobs:
     - name: install boost
       run: |
         # From: https://github.com/actions/virtual-environments/issues/2667
-        $url = "https://sourceforge.net/projects/boost/files/boost-binaries/1.75.0/boost_1_75_0-msvc-14.1-64.exe"
+        $url = "https://sourceforge.net/projects/boost/files/boost-binaries/1.74.0/boost_1_74_0-msvc-14.1-64.exe"
         (New-Object System.Net.WebClient).DownloadFile($url, "$env:TEMP\boost.exe")
         Start-Process -Wait -FilePath "$env:TEMP\boost.exe" "/SILENT","/SP-","/SUPPRESSMSGBOXES","/DIR=$env:BOOST_ROOT"
     - name: vcpkg install dependencies


### PR DESCRIPTION
Since alpaka is needed for some of the examples tested in the CI, we need to upgrade the installed Boost version to alpaka's minimum.