### PR TITLE
Support templates in `structName`

### DIFF
--- a/include/llama/Core.hpp
+++ b/include/llama/Core.hpp
@@ -520,12 +520,26 @@ namespace llama
     inline constexpr std::size_t offsetOf
         = flatOffsetOf<FlatRecordDim<RecordDim>, flatRecordCoord<RecordDim, RecordCoord>, Align>;
 
-    template<typename S>
-    auto structName(S = {}) -> std::string
+    template<typename T>
+    auto structName(T = {}) -> std::string
     {
-        auto s = boost::core::demangle(typeid(S).name());
+        auto s = boost::core::demangle(typeid(T).name());
         if(const auto pos = s.rfind(':'); pos != std::string::npos)
             s = s.substr(pos + 1);
+        return s;
+    }
+
+    template<template<typename...> typename L, typename T0, typename... T>
+    auto structName(L<T0, T...> = {}) -> std::string
+    {
+        auto s = boost::core::demangle(typeid(L<T0, T...>).name());
+        if(const auto pos = s.find('<'); pos != std::string::npos)
+            s = s.substr(0, pos);
+        if(const auto pos = s.rfind(':'); pos != std::string::npos)
+            s = s.substr(pos + 1);
+        s += "<" + structName(T0{});
+        ((s += "," + structName(T{})), ...);
+        s += ">";
         return s;
     }
 

--- a/tests/core.cpp
+++ b/tests/core.cpp
@@ -394,3 +394,15 @@ TEST_CASE("CopyConst")
     STATIC_REQUIRE(std::is_same_v<llama::CopyConst<int, const float>, const float>);
     STATIC_REQUIRE(std::is_same_v<llama::CopyConst<const int, const float>, const float>);
 }
+
+TEST_CASE("structName")
+{
+    CHECK(llama::structName<int>() == "int");
+    CHECK(llama::structName(int{}) == "int");
+    CHECK(llama::structName<tag::A>() == "A");
+    CHECK(llama::structName(tag::A{}) == "A");
+    CHECK(llama::structName<tag::Normal>() == "Normal");
+    CHECK(llama::structName(tag::Normal{}) == "Normal");
+    CHECK(llama::structName(std::string{}) == "basic_string<char,char_traits<char>,allocator<char>>");
+    CHECK(llama::structName(Vec3D{}) == "Record<Field<X,double>,Field<Y,double>,Field<Z,double>>");
+}


### PR DESCRIPTION
E.g.: `llama::structName(std::string{}) == "basic_string<char,char_traits<char>,allocator<char>>"`.