### PR TITLE
Add daxpy example

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -86,6 +86,7 @@ if (LLAMA_BUILD_EXAMPLES)
 	add_subdirectory("examples/bytesplit")
 	add_subdirectory("examples/bitpackint")
 	add_subdirectory("examples/bitpackfloat")
+	add_subdirectory("examples/daxpy")
 
 	# alpaka examples
 	find_package(alpaka 0.7.0 QUIET)

--- a/examples/daxpy/CMakeLists.txt
+++ b/examples/daxpy/CMakeLists.txt
@@ -1,0 +1,18 @@
+cmake_minimum_required (VERSION 3.15)
+project(llama-daxpy CXX)
+
+#find_package(Vc QUIET)
+find_package(OpenMP REQUIRED)
+if (NOT TARGET llama::llama)
+	find_package(llama REQUIRED)
+endif()
+
+add_executable(${PROJECT_NAME} daxpy.cpp)
+target_compile_features(${PROJECT_NAME} PRIVATE cxx_std_17)
+target_link_libraries(${PROJECT_NAME} PRIVATE llama::llama OpenMP::OpenMP_CXX)
+
+if (MSVC)
+	target_compile_options(${PROJECT_NAME} PRIVATE /arch:AVX2 /fp:fast)
+elseif(MSVC)
+	target_compile_options(${PROJECT_NAME} PRIVATE -march=native -ffast-math)
+endif()

--- a/examples/daxpy/daxpy.cpp
+++ b/examples/daxpy/daxpy.cpp
@@ -1,0 +1,133 @@
+#include "../common/Stopwatch.hpp"
+#include "../common/hostname.hpp"
+
+#include <fmt/core.h>
+#include <fstream>
+#include <iomanip>
+#include <llama/llama.hpp>
+#include <omp.h>
+#include <random>
+#include <vector>
+
+constexpr auto PROBLEM_SIZE = 1024 * 1024 * 16;
+constexpr auto STEPS = 5;
+constexpr auto alpha = 3.14;
+
+void daxpy(std::ofstream& plotFile)
+{
+    Stopwatch watch;
+    auto x = std::vector<double>(PROBLEM_SIZE);
+    auto y = std::vector<double>(PROBLEM_SIZE);
+    auto z = std::vector<double>(PROBLEM_SIZE);
+    watch.printAndReset("alloc");
+
+    std::default_random_engine engine;
+    std::normal_distribution dist(0.0, 1.0);
+    for(std::size_t i = 0; i < PROBLEM_SIZE; ++i)
+    {
+        x[i] = dist(engine);
+        y[i] = dist(engine);
+    }
+    watch.printAndReset("init");
+
+    double sum = 0;
+    for(std::size_t s = 0; s < STEPS; ++s)
+    {
+#pragma omp parallel for
+        for(std::ptrdiff_t i = 0; i < PROBLEM_SIZE; i++)
+            z[i] = alpha * x[i] + y[i];
+        sum = watch.printAndReset("daxpy");
+    }
+    plotFile << "\"std::vector\"\t" << sum / STEPS << '\n';
+}
+
+template<typename Mapping>
+void daxpy_llama(std::string mappingName, Mapping mapping, std::ofstream& plotFile)
+{
+    auto title = "LLAMA " + std::move(mappingName);
+
+    Stopwatch watch;
+    auto x = llama::allocViewUninitialized(mapping);
+    auto y = llama::allocViewUninitialized(mapping);
+    auto z = llama::allocViewUninitialized(mapping);
+    watch.printAndReset("alloc");
+
+    std::default_random_engine engine;
+    std::normal_distribution dist(0.0, 1.0);
+    for(std::size_t i = 0; i < PROBLEM_SIZE; ++i)
+    {
+        x[i] = dist(engine);
+        y[i] = dist(engine);
+    }
+    watch.printAndReset("init");
+
+    double sum = 0;
+    for(std::size_t s = 0; s < STEPS; ++s)
+    {
+#pragma omp parallel for
+        for(std::ptrdiff_t i = 0; i < PROBLEM_SIZE; i++)
+            z[i] = alpha * x[i] + y[i];
+        sum = watch.printAndReset("daxpy");
+    }
+    plotFile << std::quoted(title) << "\t" << sum / STEPS << '\n';
+}
+
+auto main() -> int
+try
+{
+    const auto numThreads = static_cast<std::size_t>(omp_get_max_threads());
+    const char* affinity = std::getenv("GOMP_CPU_AFFINITY"); // NOLINT(concurrency-mt-unsafe)
+    affinity = affinity == nullptr ? "NONE - PLEASE PIN YOUR THREADS!" : affinity;
+
+    std::ofstream plotFile{"daxpy.sh"};
+    plotFile.exceptions(std::ios::badbit | std::ios::failbit);
+    plotFile << fmt::format(
+        R"(#!/usr/bin/gnuplot -p
+# threads: {} affinity: {}
+set title "daxpy CPU {}Mi doubles on {}"
+set style data histograms
+set style fill solid
+set xtics rotate by 45 right
+set key off
+set yrange [0:*]
+set ylabel "runtime [s]"
+$data << EOD
+)",
+        numThreads,
+        affinity,
+        PROBLEM_SIZE / 1024 / 1024,
+        common::hostname());
+
+    daxpy(plotFile);
+
+    const auto extents = llama::ArrayExtents{PROBLEM_SIZE};
+    daxpy_llama("AoS", llama::mapping::AoS{extents, double{}}, plotFile);
+    daxpy_llama("SoA", llama::mapping::SoA{extents, double{}}, plotFile);
+    daxpy_llama(
+        "Bytesplit",
+        llama::mapping::Bytesplit<llama::ArrayExtentsDynamic<1>, double, llama::mapping::PreconfiguredAoS<>::type>{
+            extents},
+        plotFile);
+    daxpy_llama(
+        "ChangeType D->F",
+        llama::mapping::ChangeType<
+            llama::ArrayExtentsDynamic<1>,
+            double,
+            llama::mapping::PreconfiguredAoS<>::type,
+            boost::mp11::mp_list<boost::mp11::mp_list<double, float>>>{extents},
+        plotFile);
+    daxpy_llama("Bitpack 52^{11}", llama::mapping::BitPackedFloatSoA{11, 52, extents, double{}}, plotFile);
+    daxpy_llama("Bitpack 23^{8}", llama::mapping::BitPackedFloatSoA{8, 23, extents, double{}}, plotFile);
+    daxpy_llama("Bitpack 10^{5}", llama::mapping::BitPackedFloatSoA{5, 10, extents, double{}}, plotFile);
+
+    plotFile << R"(EOD
+plot $data using 2:xtic(1)
+)";
+    std::cout << "Plot with: ./daxpy.sh\n";
+
+    return 0;
+}
+catch(const std::exception& e)
+{
+    std::cerr << "Exception: " << e.what() << '\n';
+}


### PR DESCRIPTION
Daxpy is a very simple kernel that is memory-bound. Since the data structure is basically a vector of `double` precision values, it let's as explore mappings that change the in-memory manifestation of a single datatype. This includes `BitPackedFloatSoA`, `Bytesplit`, `ChangeTyp`, etc.