### PR TITLE
Add ReplacePlaceholders

### DIFF
--- a/include/llama/Meta.hpp
+++ b/include/llama/Meta.hpp
@@ -65,5 +65,25 @@ namespace llama
 
         template<typename FromList, template<auto...> class ToList>
         using mp_unwrap_values_into = typename mp_unwrap_values_into_impl<FromList, ToList>::type;
+
+        template<typename E, typename... Args>
+        struct ReplacePlaceholdersImpl
+        {
+            using type = E;
+        };
+        template<std::size_t I, typename... Args>
+        struct ReplacePlaceholdersImpl<boost::mp11::mp_arg<I>, Args...>
+        {
+            using type = boost::mp11::mp_at_c<boost::mp11::mp_list<Args...>, I>;
+        };
+
+        template<template<typename...> typename E, typename... Ts, typename... Args>
+        struct ReplacePlaceholdersImpl<E<Ts...>, Args...>
+        {
+            using type = E<typename ReplacePlaceholdersImpl<Ts, Args...>::type...>;
+        };
     } // namespace internal
+
+    template<typename Expression, typename... Args>
+    using ReplacePlaceholders = typename internal::ReplacePlaceholdersImpl<Expression, Args...>::type;
 } // namespace llama

--- a/tests/meta.cpp
+++ b/tests/meta.cpp
@@ -1,0 +1,27 @@
+#include "common.hpp"
+
+TEST_CASE("ReplacePlaceholders")
+{
+    using namespace boost::mp11;
+    using namespace tag;
+
+    STATIC_REQUIRE(std::is_same_v<llama::ReplacePlaceholders<int, A, B, C>, int>);
+    STATIC_REQUIRE(std::is_same_v<llama::ReplacePlaceholders<std::string, A, B, C>, std::string>);
+    STATIC_REQUIRE(std::is_same_v<llama::ReplacePlaceholders<Particle, A, B, C>, Particle>);
+
+    STATIC_REQUIRE(std::is_same_v<llama::ReplacePlaceholders<_1, A, B, C>, A>);
+    STATIC_REQUIRE(std::is_same_v<llama::ReplacePlaceholders<_2, A, B, C>, B>);
+    STATIC_REQUIRE(std::is_same_v<llama::ReplacePlaceholders<_3, A, B, C>, C>);
+
+    STATIC_REQUIRE(std::is_same_v<llama::ReplacePlaceholders<mp_list<_1>, A, B, C>, mp_list<A>>);
+    STATIC_REQUIRE(std::is_same_v<llama::ReplacePlaceholders<mp_list<_1, _2>, A, B, C>, mp_list<A, B>>);
+    STATIC_REQUIRE(std::is_same_v<llama::ReplacePlaceholders<mp_list<_3, _1, _2>, A, B, C>, mp_list<C, A, B>>);
+
+    STATIC_REQUIRE(std::is_same_v<llama::ReplacePlaceholders<mp_list<_3, _1, _1>, A, B, C>, mp_list<C, A, A>>);
+    STATIC_REQUIRE(std::is_same_v<llama::ReplacePlaceholders<mp_list<_2, _2, _2>, A, B, C>, mp_list<B, B, B>>);
+
+    STATIC_REQUIRE(std::is_same_v<llama::ReplacePlaceholders<mp_list<mp_list<_2>>, A, B, C>, mp_list<mp_list<B>>>);
+    STATIC_REQUIRE(std::is_same_v<
+                   llama::ReplacePlaceholders<mp_list<mp_list<_2, _1>, _2, mp_list<_2, mp_list<_3>>>, A, B, C>,
+                   mp_list<mp_list<B, A>, B, mp_list<B, mp_list<C>>>>);
+}


### PR DESCRIPTION
This is a Mp11 based meta function that replaces placeholders inside a template instantiation.

E.g. `llama::ReplacePlaceholders<mp_list<mp_list<_2, _1>, _2, mp_list<_2, mp_list<_3>>>, A, B, C>` is an alias to `mp_list<mp_list<B, A>, B, mp_list<B, mp_list<C>>>>`.