### PR TITLE
Refactor and add missing PreconfiguredMapping and isMapping

### DIFF
--- a/examples/bufferguard/bufferguard.cpp
+++ b/examples/bufferguard/bufferguard.cpp
@@ -264,9 +264,9 @@ void run(const std::string& mappingName)
 auto main() -> int
 try
 {
-    run<llama::mapping::PreconfiguredAoS<>::type>("AoS");
-    run<llama::mapping::PreconfiguredSoA<>::type>("SoA");
-    run<llama::mapping::PreconfiguredSoA<true>::type>("SoA_MB");
+    run<llama::mapping::BindAoS<>::fn>("AoS");
+    run<llama::mapping::BindSoA<>::fn>("SoA");
+    run<llama::mapping::BindSoA<true>::fn>("SoA_MB");
 }
 catch(const std::exception& e)
 {

--- a/examples/bytesplit/bytesplit.cpp
+++ b/examples/bytesplit/bytesplit.cpp
@@ -27,8 +27,7 @@ auto main() -> int
 {
     constexpr auto N = 128;
     using ArrayExtents = llama::ArrayExtentsDynamic<1>;
-    const auto mapping
-        = llama::mapping::Bytesplit<ArrayExtents, Data, llama::mapping::PreconfiguredSoA<false>::type>{{N}};
+    const auto mapping = llama::mapping::Bytesplit<ArrayExtents, Data, llama::mapping::BindSoA<false>::fn>{{N}};
 
     auto view = llama::allocView(mapping);
 

--- a/examples/daxpy/daxpy.cpp
+++ b/examples/daxpy/daxpy.cpp
@@ -119,15 +119,14 @@ $data << EOD
     daxpy_llama(
         "Bytesplit",
         plotFile,
-        llama::mapping::Bytesplit<llama::ArrayExtentsDynamic<1>, double, llama::mapping::PreconfiguredAoS<>::type>{
-            extents});
+        llama::mapping::Bytesplit<llama::ArrayExtentsDynamic<1>, double, llama::mapping::BindAoS<>::fn>{extents});
     daxpy_llama(
         "ChangeType D->F",
         plotFile,
         llama::mapping::ChangeType<
             llama::ArrayExtentsDynamic<1>,
             double,
-            llama::mapping::PreconfiguredAoS<>::type,
+            llama::mapping::BindAoS<>::fn,
             boost::mp11::mp_list<boost::mp11::mp_list<double, float>>>{extents});
     daxpy_llama("Bitpack 52^{11}", plotFile, llama::mapping::BitPackedFloatSoA{extents, 11, 52, double{}});
     daxpy_llama(

--- a/examples/nbody/nbody.cpp
+++ b/examples/nbody/nbody.cpp
@@ -142,15 +142,13 @@ namespace usellama
                     ArrayExtents,
                     Particle,
                     llama::RecordCoord<1>,
-                    llama::mapping::PreconfiguredSoA<>::type,
-                    llama::mapping::PreconfiguredSoA<>::type,
+                    llama::mapping::BindSoA<>::fn,
+                    llama::mapping::BindSoA<>::fn,
                     true>{extents};
             if constexpr(Mapping == 5)
-                return llama::mapping::Bytesplit<ArrayExtents, Particle, llama::mapping::PreconfiguredAoS<>::type>{
-                    extents};
+                return llama::mapping::Bytesplit<ArrayExtents, Particle, llama::mapping::BindAoS<>::fn>{extents};
             if constexpr(Mapping == 6)
-                return llama::mapping::Bytesplit<ArrayExtents, Particle, llama::mapping::PreconfiguredSoA<>::type>{
-                    extents};
+                return llama::mapping::Bytesplit<ArrayExtents, Particle, llama::mapping::BindSoA<>::fn>{extents};
             if constexpr(Mapping == 7)
                 return llama::mapping::BitPackedFloatSoA<ArrayExtents, Particle>{extents, 4, 11};
             if constexpr(Mapping == 8)

--- a/include/llama/mapping/AoS.hpp
+++ b/include/llama/mapping/AoS.hpp
@@ -84,11 +84,13 @@ namespace llama::mapping
     template<typename ArrayExtents, typename RecordDim, typename LinearizeArrayDimsFunctor = LinearizeArrayDimsCpp>
     using PackedAoS = AoS<ArrayExtents, RecordDim, false, LinearizeArrayDimsFunctor>;
 
+    /// Binds parameters to an \ref AoS mapping except for array and record dimension, producing a quoted meta
+    /// function accepting the latter two. Useful to to prepare this mapping for a meta mapping.
     template<bool AlignAndPad = true, typename LinearizeArrayDimsFunctor = LinearizeArrayDimsCpp>
-    struct PreconfiguredAoS
+    struct BindAoS
     {
         template<typename ArrayExtents, typename RecordDim>
-        using type = AoS<ArrayExtents, RecordDim, AlignAndPad, LinearizeArrayDimsFunctor>;
+        using fn = AoS<ArrayExtents, RecordDim, AlignAndPad, LinearizeArrayDimsFunctor>;
     };
 
     template<typename Mapping>

--- a/include/llama/mapping/AoSoA.hpp
+++ b/include/llama/mapping/AoSoA.hpp
@@ -83,11 +83,13 @@ namespace llama::mapping
         using Flattener = FlattenRecordDim<TRecordDim>;
     };
 
+    /// Binds parameters to an \ref AoSoA mapping except for array and record dimension, producing a quoted meta
+    /// function accepting the latter two. Useful to to prepare this mapping for a meta mapping.
     template<std::size_t Lanes, typename LinearizeArrayDimsFunctor = LinearizeArrayDimsCpp>
-    struct PreconfiguredAoSoA
+    struct BindAoSoA
     {
         template<typename ArrayExtents, typename RecordDim>
-        using type = AoSoA<ArrayExtents, RecordDim, Lanes, LinearizeArrayDimsFunctor>;
+        using fn = AoSoA<ArrayExtents, RecordDim, Lanes, LinearizeArrayDimsFunctor>;
     };
 
     template<typename Mapping>

--- a/include/llama/mapping/Bytesplit.hpp
+++ b/include/llama/mapping/Bytesplit.hpp
@@ -102,4 +102,19 @@ namespace llama::mapping
             return Reference<RecordCoord<RecordCoords...>, BlobArray>{*this, ai, blobs};
         }
     };
+
+    /// Binds parameters to a \ref Bytesplit mapping except for array and record dimension, producing a quoted
+    /// meta function accepting the latter two. Useful to to prepare this mapping for a meta mapping.
+    template<template<typename, typename> typename InnerMapping>
+    struct BindBytesplit
+    {
+        template<typename ArrayExtents, typename RecordDim>
+        using fn = Bytesplit<ArrayExtents, RecordDim, InnerMapping>;
+    };
+
+    template<typename Mapping>
+    inline constexpr bool isBytesplit = false;
+
+    template<typename TArrayExtents, typename TRecordDim, template<typename, typename> typename InnerMapping>
+    inline constexpr bool isBytesplit<Bytesplit<TArrayExtents, TRecordDim, InnerMapping>> = true;
 } // namespace llama::mapping

--- a/include/llama/mapping/ChangeType.hpp
+++ b/include/llama/mapping/ChangeType.hpp
@@ -114,10 +114,23 @@ namespace llama::mapping
         }
     };
 
+    /// Binds parameters to a \ref ChangeType mapping except for array and record dimension, producing a quoted
+    /// meta function accepting the latter two. Useful to to prepare this mapping for a meta mapping.
     template<template<typename, typename> typename InnerMapping, typename ReplacementMap>
-    struct PreconfiguredChangeType
+    struct BindChangeType
     {
         template<typename ArrayExtents, typename RecordDim>
-        using type = ChangeType<ArrayExtents, RecordDim, InnerMapping, ReplacementMap>;
+        using fn = ChangeType<ArrayExtents, RecordDim, InnerMapping, ReplacementMap>;
     };
+
+    template<typename Mapping>
+    inline constexpr bool isChangeType = false;
+
+    template<
+        typename TArrayExtents,
+        typename TRecordDim,
+        template<typename, typename>
+        typename InnerMapping,
+        typename ReplacementMap>
+    inline constexpr bool isChangeType<ChangeType<TArrayExtents, TRecordDim, InnerMapping, ReplacementMap>> = true;
 } // namespace llama::mapping

--- a/include/llama/mapping/Null.hpp
+++ b/include/llama/mapping/Null.hpp
@@ -67,4 +67,10 @@ namespace llama::mapping
             return internal::NullReference<FieldType>{};
         }
     };
+
+    template<typename Mapping>
+    inline constexpr bool isNull = false;
+
+    template<typename ArrayExtents, typename RecordDim>
+    inline constexpr bool isNull<Null<ArrayExtents, RecordDim>> = true;
 } // namespace llama::mapping

--- a/include/llama/mapping/One.hpp
+++ b/include/llama/mapping/One.hpp
@@ -78,6 +78,15 @@ namespace llama::mapping
     template<typename ArrayExtents, typename RecordDim>
     using PackedOne = One<ArrayExtents, RecordDim, false, FlattenRecordDimInOrder>;
 
+    /// Binds parameters to a \ref One mapping except for array and record dimension, producing a quoted
+    /// meta function accepting the latter two. Useful to to prepare this mapping for a meta mapping.
+    template<bool AlignAndPad, template<typename> typename FlattenRecordDim>
+    struct BindOne
+    {
+        template<typename ArrayExtents, typename RecordDim>
+        using fn = One<ArrayExtents, RecordDim, AlignAndPad, FlattenRecordDim>;
+    };
+
     template<typename Mapping>
     inline constexpr bool isOne = false;
 

--- a/include/llama/mapping/SoA.hpp
+++ b/include/llama/mapping/SoA.hpp
@@ -106,11 +106,13 @@ namespace llama::mapping
     template<typename ArrayExtents, typename RecordDim, typename LinearizeArrayDimsFunctor = LinearizeArrayDimsCpp>
     using MultiBlobSoA = SoA<ArrayExtents, RecordDim, true, LinearizeArrayDimsFunctor>;
 
+    /// Binds parameters to an \ref SoA mapping except for array and record dimension, producing a quoted
+    /// meta function accepting the latter two. Useful to to prepare this mapping for a meta mapping.
     template<bool SeparateBuffers = true, typename LinearizeArrayDimsFunctor = LinearizeArrayDimsCpp>
-    struct PreconfiguredSoA
+    struct BindSoA
     {
         template<typename ArrayExtents, typename RecordDim>
-        using type = SoA<ArrayExtents, RecordDim, SeparateBuffers, LinearizeArrayDimsFunctor>;
+        using fn = SoA<ArrayExtents, RecordDim, SeparateBuffers, LinearizeArrayDimsFunctor>;
     };
 
     template<typename Mapping>

--- a/include/llama/mapping/Split.hpp
+++ b/include/llama/mapping/Split.hpp
@@ -196,6 +196,8 @@ namespace llama::mapping
         Mapping2 mapping2;
     };
 
+    /// Binds parameters to a \ref Split mapping except for array and record dimension, producing a quoted
+    /// meta function accepting the latter two. Useful to to prepare this mapping for a meta mapping.
     template<
         typename RecordCoordsForMapping1,
         template<typename...>
@@ -203,10 +205,10 @@ namespace llama::mapping
         template<typename...>
         typename MappingTemplate2,
         bool SeparateBlobs = false>
-    struct PreconfiguredSplit
+    struct BindSplit
     {
         template<typename ArrayExtents, typename RecordDim>
-        using type = Split<
+        using fn = Split<
             ArrayExtents,
             RecordDim,
             RecordCoordsForMapping1,
@@ -214,4 +216,24 @@ namespace llama::mapping
             MappingTemplate2,
             SeparateBlobs>;
     };
+
+    template<typename Mapping>
+    inline constexpr bool isSplit = false;
+
+    template<
+        typename ArrayExtents,
+        typename RecordDim,
+        typename RecordCoordsForMapping1,
+        template<typename...>
+        typename MappingTemplate1,
+        template<typename...>
+        typename MappingTemplate2,
+        bool SeparateBlobs>
+    inline constexpr bool isSplit<Split<
+        ArrayExtents,
+        RecordDim,
+        RecordCoordsForMapping1,
+        MappingTemplate1,
+        MappingTemplate2,
+        SeparateBlobs>> = true;
 } // namespace llama::mapping

--- a/tests/dump.cpp
+++ b/tests/dump.cpp
@@ -83,10 +83,9 @@ TEST_CASE("dump.Particle.Split.AoSoA8.AoS.One")
          ArrayExtents,
          Particle,
          llama::RecordCoord<2>,
-         llama::mapping::PreconfiguredAoSoA<8>::type,
-         llama::mapping::
-             PreconfiguredSplit<llama::RecordCoord<1>, llama::mapping::PackedOne, llama::mapping::PackedAoS, true>::
-                 type,
+         llama::mapping::BindAoSoA<8>::fn,
+         llama::mapping::BindSplit<llama::RecordCoord<1>, llama::mapping::PackedOne, llama::mapping::PackedAoS, true>::
+             fn,
          true>{extents});
 }
 
@@ -98,16 +97,13 @@ TEST_CASE("dump.Particle.Split.AoSoA8.AoS.One.SoA")
          ArrayExtents,
          Particle,
          llama::RecordCoord<2>,
-         llama::mapping::PreconfiguredAoSoA<8>::type,
-         llama::mapping::PreconfiguredSplit<
+         llama::mapping::BindAoSoA<8>::fn,
+         llama::mapping::BindSplit<
              llama::RecordCoord<1>,
              llama::mapping::PackedOne,
-             llama::mapping::PreconfiguredSplit<
-                 llama::RecordCoord<0>,
-                 llama::mapping::PackedAoS,
-                 llama::mapping::SingleBlobSoA,
-                 true>::type,
-             true>::type,
+             llama::mapping::
+                 BindSplit<llama::RecordCoord<0>, llama::mapping::PackedAoS, llama::mapping::SingleBlobSoA, true>::fn,
+             true>::fn,
          true>{extents});
 }
 
@@ -117,20 +113,18 @@ TEST_CASE("dump.Particle.BitPacked")
          ArrayExtents,
          Particle,
          llama::RecordCoord<0>,
-         llama::mapping::PreconfiguredSplit<
-             llama::RecordCoord<0, 2>,
-             llama::mapping::BitPackedFloatSoA,
-             llama::mapping::PackedAoS,
-             true>::type,
-         llama::mapping::PreconfiguredSplit<
+         llama::mapping::
+             BindSplit<llama::RecordCoord<0, 2>, llama::mapping::BitPackedFloatSoA, llama::mapping::PackedAoS, true>::
+                 fn,
+         llama::mapping::BindSplit<
              llama::RecordCoord<0>,
              llama::mapping::PackedOne,
-             llama::mapping::PreconfiguredSplit<
+             llama::mapping::BindSplit<
                  llama::RecordCoord<0>,
                  llama::mapping::BitPackedFloatSoA,
-                 llama::mapping::PreconfiguredBitPackedIntSoA<llama::Constant<1>>::type,
-                 true>::type,
-             true>::type,
+                 llama::mapping::BindBitPackedIntSoA<llama::Constant<1>>::fn,
+                 true>::fn,
+             true>::fn,
          true>{
         std::tuple{std::tuple{extents, 3, 3}, std::tuple{extents}},
         std::tuple{std::tuple{}, std::tuple{std::tuple{extents, 5, 5}, std::tuple{extents}}}});
@@ -208,10 +202,9 @@ TEST_CASE("dump.ParticleUnaligned.Split.SoA_MB.AoS_Aligned.One")
          ArrayExtents,
          ParticleUnaligned,
          llama::RecordCoord<1>,
-         llama::mapping::PreconfiguredSoA<true>::type,
+         llama::mapping::BindSoA<true>::fn,
          llama::mapping::
-             PreconfiguredSplit<llama::RecordCoord<1>, llama::mapping::PackedOne, llama::mapping::AlignedAoS, true>::
-                 type,
+             BindSplit<llama::RecordCoord<1>, llama::mapping::PackedOne, llama::mapping::AlignedAoS, true>::fn,
          true>{extents});
 }
 
@@ -221,10 +214,9 @@ TEST_CASE("dump.ParticleUnaligned.Split.AoSoA8.AoS_Aligned.One")
          ArrayExtents,
          ParticleUnaligned,
          llama::RecordCoord<1>,
-         llama::mapping::PreconfiguredAoSoA<8>::type,
+         llama::mapping::BindAoSoA<8>::fn,
          llama::mapping::
-             PreconfiguredSplit<llama::RecordCoord<1>, llama::mapping::PackedOne, llama::mapping::AlignedAoS, true>::
-                 type,
+             BindSplit<llama::RecordCoord<1>, llama::mapping::PackedOne, llama::mapping::AlignedAoS, true>::fn,
          true>{extents});
 }
 
@@ -235,16 +227,13 @@ TEST_CASE("dump.ParticleUnaligned.Split.AoSoA8.SoA.One.AoS")
          ArrayExtents,
          ParticleUnaligned,
          llama::RecordCoord<1>,
-         llama::mapping::PreconfiguredAoSoA<8>::type,
-         llama::mapping::PreconfiguredSplit<
+         llama::mapping::BindAoSoA<8>::fn,
+         llama::mapping::BindSplit<
              llama::RecordCoord<1>,
              llama::mapping::PackedOne,
-             llama::mapping::PreconfiguredSplit<
-                 llama::RecordCoord<0>,
-                 llama::mapping::PreconfiguredSoA<>::type,
-                 llama::mapping::PackedAoS,
-                 true>::type,
-             true>::type,
+             llama::mapping::
+                 BindSplit<llama::RecordCoord<0>, llama::mapping::BindSoA<>::fn, llama::mapping::PackedAoS, true>::fn,
+             true>::fn,
          true>{extents});
 }
 
@@ -255,7 +244,7 @@ TEST_CASE("dump.ParticleUnaligned.Split.Multilist.SoA.One")
          ArrayExtents,
          Particle,
          boost::mp11::mp_list<llama::RecordCoord<0>, llama::RecordCoord<2>>,
-         llama::mapping::PreconfiguredSoA<>::type,
+         llama::mapping::BindSoA<>::fn,
          llama::mapping::AlignedOne,
          true>{extents});
 }

--- a/tests/mapping.Bytesplit.cpp
+++ b/tests/mapping.Bytesplit.cpp
@@ -5,8 +5,7 @@
 TEST_CASE("mapping.ByteSplit.AoS")
 {
     auto view = llama::allocView(
-        llama::mapping::Bytesplit<llama::ArrayExtentsDynamic<1>, Vec3I, llama::mapping::PreconfiguredAoS<>::type>{
-            {128}});
+        llama::mapping::Bytesplit<llama::ArrayExtentsDynamic<1>, Vec3I, llama::mapping::BindAoS<>::fn>{{128}});
     iotaFillView(view);
     iotaCheckView(view);
 }
@@ -14,8 +13,7 @@ TEST_CASE("mapping.ByteSplit.AoS")
 TEST_CASE("mapping.ByteSplit.SoA")
 {
     auto view = llama::allocView(
-        llama::mapping::Bytesplit<llama::ArrayExtentsDynamic<1>, Vec3I, llama::mapping::PreconfiguredSoA<>::type>{
-            {128}});
+        llama::mapping::Bytesplit<llama::ArrayExtentsDynamic<1>, Vec3I, llama::mapping::BindSoA<>::fn>{{128}});
     iotaFillView(view);
     iotaCheckView(view);
 }
@@ -23,8 +21,7 @@ TEST_CASE("mapping.ByteSplit.SoA")
 TEST_CASE("mapping.ByteSplit.AoSoA")
 {
     auto view = llama::allocView(
-        llama::mapping::Bytesplit<llama::ArrayExtentsDynamic<1>, Vec3I, llama::mapping::PreconfiguredAoSoA<16>::type>{
-            {128}});
+        llama::mapping::Bytesplit<llama::ArrayExtentsDynamic<1>, Vec3I, llama::mapping::BindAoSoA<16>::fn>{{128}});
     iotaFillView(view);
     iotaCheckView(view);
 }
@@ -34,9 +31,9 @@ TEST_CASE("mapping.ByteSplit.ChangeType.SoA")
     using Mapping = llama::mapping::Bytesplit<
         llama::ArrayExtentsDynamic<1>,
         Vec3I,
-        llama::mapping::PreconfiguredChangeType<
-            llama::mapping::PreconfiguredSoA<>::type,
-            boost::mp11::mp_list<boost::mp11::mp_list<std::byte, unsigned char>>>::type>;
+        llama::mapping::BindChangeType<
+            llama::mapping::BindSoA<>::fn,
+            boost::mp11::mp_list<boost::mp11::mp_list<std::byte, unsigned char>>>::fn>;
 
     STATIC_REQUIRE(std::is_same_v<Mapping::RecordDim, Vec3I>);
     STATIC_REQUIRE(std::is_same_v<
@@ -62,11 +59,11 @@ TEST_CASE("mapping.ByteSplit.Split.BitPackedIntSoA")
     auto view = llama::allocView(llama::mapping::Bytesplit<
                                  llama::ArrayExtentsDynamic<1>,
                                  Vec3I,
-                                 llama::mapping::PreconfiguredSplit<
+                                 llama::mapping::BindSplit<
                                      llama::RecordCoord<1>,
                                      llama::mapping::BitPackedIntSoA,
-                                     llama::mapping::PreconfiguredAoS<>::type,
-                                     true>::type>{
+                                     llama::mapping::BindAoS<>::fn,
+                                     true>::fn>{
         std::tuple{std::tuple{llama::ArrayExtents{128}, 23}, std::tuple{llama::ArrayExtents{128}}}});
     iotaFillView(view);
     iotaCheckView(view);
@@ -74,8 +71,7 @@ TEST_CASE("mapping.ByteSplit.Split.BitPackedIntSoA")
 
 TEST_CASE("mapping.ByteSplit.SoA.verify")
 {
-    using Mapping
-        = llama::mapping::Bytesplit<llama::ArrayExtentsDynamic<1>, Vec3I, llama::mapping::PreconfiguredSoA<>::type>;
+    using Mapping = llama::mapping::Bytesplit<llama::ArrayExtentsDynamic<1>, Vec3I, llama::mapping::BindSoA<>::fn>;
     auto view = llama::allocView(Mapping{{128}});
     for(auto i = 0; i < 128; i++)
         view(i) = i;

--- a/tests/mapping.ChangeType.cpp
+++ b/tests/mapping.ChangeType.cpp
@@ -4,11 +4,8 @@
 
 TEST_CASE("mapping.ChangeType.AoS")
 {
-    auto mapping = llama::mapping::ChangeType<
-        llama::ArrayExtents<128>,
-        Vec3D,
-        llama::mapping::PreconfiguredAoS<false>::type,
-        boost::mp11::mp_list<>>{{}};
+    auto mapping = llama::mapping::
+        ChangeType<llama::ArrayExtents<128>, Vec3D, llama::mapping::BindAoS<false>::fn, boost::mp11::mp_list<>>{{}};
     CHECK(mapping.blobSize(0) == 3072);
     auto view = llama::allocView(mapping);
     iotaFillView(view);
@@ -20,7 +17,7 @@ TEST_CASE("mapping.ChangeType.AoS.doubleToFloat")
     auto mapping = llama::mapping::ChangeType<
         llama::ArrayExtents<128>,
         Vec3D,
-        llama::mapping::PreconfiguredAoS<false>::type,
+        llama::mapping::BindAoS<false>::fn,
         boost::mp11::mp_list<boost::mp11::mp_list<double, float>>>{{}};
     CHECK(mapping.blobSize(0) == 1536);
     auto view = llama::allocView(mapping);
@@ -34,7 +31,7 @@ TEST_CASE("mapping.ChangeType.SoA.particle")
     auto mapping = llama::mapping::ChangeType<
         llama::ArrayExtents<128>,
         Particle,
-        llama::mapping::PreconfiguredAoS<false>::type,
+        llama::mapping::BindAoS<false>::fn,
         boost::mp11::mp_list<
             boost::mp11::mp_list<double, float>,
             boost::mp11::mp_list<float, std::int16_t>,

--- a/tests/mapping.Split.cpp
+++ b/tests/mapping.Split.cpp
@@ -83,16 +83,13 @@ TEST_CASE("Split.AoSoA8.AoS_Packed.One.SoA_SingleBlob.4Buffer")
         ArrayExtents,
         Particle,
         llama::RecordCoord<2>,
-        llama::mapping::PreconfiguredAoSoA<8>::type,
-        llama::mapping::PreconfiguredSplit<
+        llama::mapping::BindAoSoA<8>::fn,
+        llama::mapping::BindSplit<
             llama::RecordCoord<1>,
             llama::mapping::PackedOne,
-            llama::mapping::PreconfiguredSplit<
-                llama::RecordCoord<0>,
-                llama::mapping::PackedAoS,
-                llama::mapping::SingleBlobSoA,
-                true>::type,
-            true>::type,
+            llama::mapping::
+                BindSplit<llama::RecordCoord<0>, llama::mapping::PackedAoS, llama::mapping::SingleBlobSoA, true>::fn,
+            true>::fn,
         true>{extents};
 
     CHECK(mapping.blobNrAndOffset<0, 0>({0}) == llama::NrAndOffset{2, 0});
@@ -132,7 +129,7 @@ TEST_CASE("Split.Multilist.SoA.One")
         ArrayExtents,
         Particle,
         boost::mp11::mp_list<llama::RecordCoord<0>, llama::RecordCoord<2>>,
-        llama::mapping::PreconfiguredSoA<>::type,
+        llama::mapping::BindSoA<>::fn,
         llama::mapping::AlignedOne,
         true>{extents};
 
@@ -172,12 +169,9 @@ TEST_CASE("Split.BitPacked")
         ArrayExtents,
         Vec3I,
         llama::RecordCoord<0>,
-        llama::mapping::PreconfiguredBitPackedIntSoA<llama::Constant<3>>::type,
-        llama::mapping::PreconfiguredSplit<
-            llama::RecordCoord<0>,
-            llama::mapping::BitPackedIntSoA,
-            llama::mapping::PackedAoS,
-            true>::type,
+        llama::mapping::BindBitPackedIntSoA<llama::Constant<3>>::fn,
+        llama::mapping::
+            BindSplit<llama::RecordCoord<0>, llama::mapping::BitPackedIntSoA, llama::mapping::PackedAoS, true>::fn,
         true>{{extents}, {std::tuple{extents, 5}, std::tuple{extents}}};
     CHECK(mapping.blobSize(0) == 12);
     CHECK(mapping.blobSize(1) == 20);

--- a/tests/mapping.cpp
+++ b/tests/mapping.cpp
@@ -21,8 +21,7 @@ TEST_CASE("mapping.concepts")
 
     STATIC_REQUIRE(llama::FullyComputedMapping<llama::mapping::Null<llama::ArrayExtentsDynamic<2>, Particle>>);
     STATIC_REQUIRE(llama::FullyComputedMapping<
-                   llama::mapping::
-                       Bytesplit<llama::ArrayExtentsDynamic<2>, Particle, llama::mapping::PreconfiguredAoS<>::type>>);
+                   llama::mapping::Bytesplit<llama::ArrayExtentsDynamic<2>, Particle, llama::mapping::BindAoS<>::fn>>);
     STATIC_REQUIRE(llama::FullyComputedMapping<llama::mapping::BitPackedIntSoA<llama::ArrayExtentsDynamic<2>, Vec3I>>);
     STATIC_REQUIRE(
         llama::FullyComputedMapping<llama::mapping::BitPackedFloatSoA<llama::ArrayExtentsDynamic<2>, Vec3D>>);
@@ -30,7 +29,7 @@ TEST_CASE("mapping.concepts")
     STATIC_REQUIRE(llama::PartiallyComputedMapping<llama::mapping::ChangeType<
                        llama::ArrayExtentsDynamic<2>,
                        Particle,
-                       llama::mapping::PreconfiguredAoS<>::type,
+                       llama::mapping::BindAoS<>::fn,
                        boost::mp11::mp_list<boost::mp11::mp_list<bool, int>>>>);
 }
 #endif
@@ -44,12 +43,24 @@ TEST_CASE("mapping.traits")
     using AoAoS = llama::mapping::AoSoA<llama::ArrayExtentsDynamic<2>, Particle, 8>;
     using One = llama::mapping::One<llama::ArrayExtentsDynamic<2>, Particle>;
 
+    using Null = llama::mapping::Null<llama::ArrayExtentsDynamic<2>, Particle>;
+    using BS = llama::mapping::Bytesplit<llama::ArrayExtentsDynamic<2>, Particle, llama::mapping::BindAoS<>::fn>;
+    using CT = llama::mapping::
+        ChangeType<llama::ArrayExtentsDynamic<2>, Particle, llama::mapping::BindAoS<>::fn, boost::mp11::mp_list<>>;
+    using BPI = llama::mapping::BitPackedIntSoA<llama::ArrayExtentsDynamic<2>, Vec3I>;
+    using BPF = llama::mapping::BitPackedFloatSoA<llama::ArrayExtentsDynamic<2>, Vec3D>;
+
     STATIC_REQUIRE(llama::mapping::isAoS<AAoS>);
     STATIC_REQUIRE(llama::mapping::isAoS<PAoS>);
     STATIC_REQUIRE(!llama::mapping::isAoS<SBSoA>);
     STATIC_REQUIRE(!llama::mapping::isAoS<MBSoA>);
     STATIC_REQUIRE(!llama::mapping::isAoS<AoAoS>);
     STATIC_REQUIRE(!llama::mapping::isAoS<One>);
+    STATIC_REQUIRE(!llama::mapping::isAoS<Null>);
+    STATIC_REQUIRE(!llama::mapping::isAoS<BS>);
+    STATIC_REQUIRE(!llama::mapping::isAoS<CT>);
+    STATIC_REQUIRE(!llama::mapping::isAoS<BPI>);
+    STATIC_REQUIRE(!llama::mapping::isAoS<BPF>);
 
     STATIC_REQUIRE(!llama::mapping::isSoA<AAoS>);
     STATIC_REQUIRE(!llama::mapping::isSoA<PAoS>);
@@ -57,6 +68,11 @@ TEST_CASE("mapping.traits")
     STATIC_REQUIRE(llama::mapping::isSoA<MBSoA>);
     STATIC_REQUIRE(!llama::mapping::isSoA<AoAoS>);
     STATIC_REQUIRE(!llama::mapping::isSoA<One>);
+    STATIC_REQUIRE(!llama::mapping::isSoA<Null>);
+    STATIC_REQUIRE(!llama::mapping::isSoA<BS>);
+    STATIC_REQUIRE(!llama::mapping::isSoA<CT>);
+    STATIC_REQUIRE(!llama::mapping::isSoA<BPI>);
+    STATIC_REQUIRE(!llama::mapping::isSoA<BPF>);
 
     STATIC_REQUIRE(!llama::mapping::isAoSoA<AAoS>);
     STATIC_REQUIRE(!llama::mapping::isAoSoA<PAoS>);
@@ -64,6 +80,11 @@ TEST_CASE("mapping.traits")
     STATIC_REQUIRE(!llama::mapping::isAoSoA<MBSoA>);
     STATIC_REQUIRE(llama::mapping::isAoSoA<AoAoS>);
     STATIC_REQUIRE(!llama::mapping::isAoSoA<One>);
+    STATIC_REQUIRE(!llama::mapping::isAoSoA<Null>);
+    STATIC_REQUIRE(!llama::mapping::isAoSoA<BS>);
+    STATIC_REQUIRE(!llama::mapping::isAoSoA<CT>);
+    STATIC_REQUIRE(!llama::mapping::isAoSoA<BPI>);
+    STATIC_REQUIRE(!llama::mapping::isAoSoA<BPF>);
 
     STATIC_REQUIRE(!llama::mapping::isOne<AAoS>);
     STATIC_REQUIRE(!llama::mapping::isOne<PAoS>);
@@ -71,6 +92,71 @@ TEST_CASE("mapping.traits")
     STATIC_REQUIRE(!llama::mapping::isOne<MBSoA>);
     STATIC_REQUIRE(!llama::mapping::isOne<AoAoS>);
     STATIC_REQUIRE(llama::mapping::isOne<One>);
+    STATIC_REQUIRE(!llama::mapping::isOne<Null>);
+    STATIC_REQUIRE(!llama::mapping::isOne<BS>);
+    STATIC_REQUIRE(!llama::mapping::isOne<CT>);
+    STATIC_REQUIRE(!llama::mapping::isOne<BPI>);
+    STATIC_REQUIRE(!llama::mapping::isOne<BPF>);
+
+    STATIC_REQUIRE(!llama::mapping::isNull<AAoS>);
+    STATIC_REQUIRE(!llama::mapping::isNull<PAoS>);
+    STATIC_REQUIRE(!llama::mapping::isNull<SBSoA>);
+    STATIC_REQUIRE(!llama::mapping::isNull<MBSoA>);
+    STATIC_REQUIRE(!llama::mapping::isNull<AoAoS>);
+    STATIC_REQUIRE(!llama::mapping::isNull<One>);
+    STATIC_REQUIRE(llama::mapping::isNull<Null>);
+    STATIC_REQUIRE(!llama::mapping::isNull<BS>);
+    STATIC_REQUIRE(!llama::mapping::isNull<CT>);
+    STATIC_REQUIRE(!llama::mapping::isNull<BPI>);
+    STATIC_REQUIRE(!llama::mapping::isNull<BPF>);
+
+    STATIC_REQUIRE(!llama::mapping::isBytesplit<AAoS>);
+    STATIC_REQUIRE(!llama::mapping::isBytesplit<PAoS>);
+    STATIC_REQUIRE(!llama::mapping::isBytesplit<SBSoA>);
+    STATIC_REQUIRE(!llama::mapping::isBytesplit<MBSoA>);
+    STATIC_REQUIRE(!llama::mapping::isBytesplit<AoAoS>);
+    STATIC_REQUIRE(!llama::mapping::isBytesplit<One>);
+    STATIC_REQUIRE(!llama::mapping::isBytesplit<Null>);
+    STATIC_REQUIRE(llama::mapping::isBytesplit<BS>);
+    STATIC_REQUIRE(!llama::mapping::isBytesplit<CT>);
+    STATIC_REQUIRE(!llama::mapping::isBytesplit<BPI>);
+    STATIC_REQUIRE(!llama::mapping::isBytesplit<BPF>);
+
+    STATIC_REQUIRE(!llama::mapping::isChangeType<AAoS>);
+    STATIC_REQUIRE(!llama::mapping::isChangeType<PAoS>);
+    STATIC_REQUIRE(!llama::mapping::isChangeType<SBSoA>);
+    STATIC_REQUIRE(!llama::mapping::isChangeType<MBSoA>);
+    STATIC_REQUIRE(!llama::mapping::isChangeType<AoAoS>);
+    STATIC_REQUIRE(!llama::mapping::isChangeType<One>);
+    STATIC_REQUIRE(!llama::mapping::isChangeType<Null>);
+    STATIC_REQUIRE(!llama::mapping::isChangeType<BS>);
+    STATIC_REQUIRE(llama::mapping::isChangeType<CT>);
+    STATIC_REQUIRE(!llama::mapping::isChangeType<BPI>);
+    STATIC_REQUIRE(!llama::mapping::isChangeType<BPF>);
+
+    STATIC_REQUIRE(!llama::mapping::isBitPackedIntSoA<AAoS>);
+    STATIC_REQUIRE(!llama::mapping::isBitPackedIntSoA<PAoS>);
+    STATIC_REQUIRE(!llama::mapping::isBitPackedIntSoA<SBSoA>);
+    STATIC_REQUIRE(!llama::mapping::isBitPackedIntSoA<MBSoA>);
+    STATIC_REQUIRE(!llama::mapping::isBitPackedIntSoA<AoAoS>);
+    STATIC_REQUIRE(!llama::mapping::isBitPackedIntSoA<One>);
+    STATIC_REQUIRE(!llama::mapping::isBitPackedIntSoA<Null>);
+    STATIC_REQUIRE(!llama::mapping::isBitPackedIntSoA<BS>);
+    STATIC_REQUIRE(!llama::mapping::isBitPackedIntSoA<CT>);
+    STATIC_REQUIRE(llama::mapping::isBitPackedIntSoA<BPI>);
+    STATIC_REQUIRE(!llama::mapping::isBitPackedIntSoA<BPF>);
+
+    STATIC_REQUIRE(!llama::mapping::isBitPackedFloatSoA<AAoS>);
+    STATIC_REQUIRE(!llama::mapping::isBitPackedFloatSoA<PAoS>);
+    STATIC_REQUIRE(!llama::mapping::isBitPackedFloatSoA<SBSoA>);
+    STATIC_REQUIRE(!llama::mapping::isBitPackedFloatSoA<MBSoA>);
+    STATIC_REQUIRE(!llama::mapping::isBitPackedFloatSoA<AoAoS>);
+    STATIC_REQUIRE(!llama::mapping::isBitPackedFloatSoA<One>);
+    STATIC_REQUIRE(!llama::mapping::isBitPackedFloatSoA<Null>);
+    STATIC_REQUIRE(!llama::mapping::isBitPackedFloatSoA<BS>);
+    STATIC_REQUIRE(!llama::mapping::isBitPackedFloatSoA<CT>);
+    STATIC_REQUIRE(!llama::mapping::isBitPackedFloatSoA<BPI>);
+    STATIC_REQUIRE(llama::mapping::isBitPackedFloatSoA<BPF>);
 }
 
 TEST_CASE("mapping.LinearizeArrayDimsCpp.size")

--- a/tests/proxyrefopmixin.cpp
+++ b/tests/proxyrefopmixin.cpp
@@ -230,8 +230,8 @@ namespace
 
 TEST_CASE("proxyrefopmixin.Bytesplit")
 {
-    auto view = llama::allocView(
-        llama::mapping::Bytesplit<llama::ArrayExtents<4>, Vec3I, llama::mapping::PreconfiguredAoS<>::type>{
+    auto view
+        = llama::allocView(llama::mapping::Bytesplit<llama::ArrayExtents<4>, Vec3I, llama::mapping::BindAoS<>::fn>{
             llama::ArrayExtents<4>{}});
     testProxyRef(view(2)(tag::X{}));
 }
@@ -254,7 +254,7 @@ TEST_CASE("proxyrefopmixin.ChangeType")
     auto view = llama::allocView(llama::mapping::ChangeType<
                                  llama::ArrayExtents<4>,
                                  Vec3D,
-                                 llama::mapping::PreconfiguredAoS<false>::type,
+                                 llama::mapping::BindAoS<false>::fn,
                                  boost::mp11::mp_list<boost::mp11::mp_list<double, float>>>{{}});
     testProxyRef(view(2)(tag::X{}));
 }


### PR DESCRIPTION
Rename all meta functions `PreconfiguredX`, for all mappings `X` to `BindX`. Also rename the nested `type` alias template to `fn`. This makes LLAMA more coherent with other quoted meta functions.
This PR also adds missing `isX` detection functions for all mappings (except Trace/Heatmap) where missing.