### PR TITLE
Add missing include

### DIFF
--- a/include/llama/mapping/Split.hpp
+++ b/include/llama/mapping/Split.hpp
@@ -1,5 +1,6 @@
 #pragma once
 
+#include "../View.hpp"
 #include "Common.hpp"
 
 namespace llama::mapping


### PR DESCRIPTION
The Split mapping depends on a functionality from `View.hpp`. Not having the include made the amalgamated header not work.