### PR TITLE
Update documentation and fix spell errors

### DIFF
--- a/docs/pages/api.rst
+++ b/docs/pages/api.rst
@@ -53,7 +53,7 @@ Array dimensions
 .. doxygenstruct:: llama::ArrayIndexRange
    :members:
 
-.. doxygenfunction:: llama::forEachADCoord(ArrayExtents<Sizes...> extents, Func &&func)
+.. doxygenfunction:: llama::forEachADCoord(ArrayExtents<T, Sizes...> extents, Func &&func)
 
 Record dimension
 ----------------

--- a/docs/pages/blobs.rst
+++ b/docs/pages/blobs.rst
@@ -64,7 +64,7 @@ Creating a small view of :math:`4 \times 4` may look like this:
 
 .. code-block:: C++
 
-    using ArrayExtents = llama::ArrayExtents<4, 4>;
+    using ArrayExtents = llama::ArrayExtents<int, 4, 4>;
     constexpr ArrayExtents extents{};
 
     using Mapping = /* a simple mapping */;

--- a/docs/pages/copying.rst
+++ b/docs/pages/copying.rst
@@ -25,7 +25,7 @@ However, for every new mapping a new specialization is needed.
 The overhead is probably big, especially if no contiguous memory chunks are identified.
 
 3. A black box compile time analysis of the mapping function.
-All current LLAMA mappings are \lstinline{constexpr} and can thus be run at compile time.
+All current LLAMA mappings are :cpp:`constexpr` and can thus be run at compile time.
 This would allow to observe a mappings behavior from exhaustive sampling of the mapping function at compile time.
 
 4. A white box compile time analysis of the mapping function.
@@ -36,7 +36,7 @@ Copies between different address spaces, where elementary copy operations requir
 A good approach could use smaller intermediate views to shuffle a chunk from one mapping to the other and then perform a copy of that chunk into the other address space, potentially overlapping shuffles and copies in an asynchronous workflow.
 
 The `async copy example <https://github.com/alpaka-group/llama/blob/master/examples/asynccopy/asynccopy.cpp>`_ tries to show an asynchronous copy/shuffle/compute workflow.
-This example applies a bluring kernel to an RGB-image, but also may work only on two or one channel instead of all three.
+This example applies a blurring kernel to an RGB-image, but also may work only on two or one channel instead of all three.
 Not used channels are not allocated and especially not copied.
 
 

--- a/docs/pages/install.rst
+++ b/docs/pages/install.rst
@@ -19,10 +19,10 @@ Although LLAMA is a header-only library, it provides installation capabilities v
 Dependencies
 ------------
 
- - Boost 1.70.0 or higher
- - libfmt 6.2.1 or higher (optional) for building the tests and examples and LLAMA supporting to dump mappings as SVG/HTML
- - `Alpaka <https://github.com/alpaka-group/alpaka>`_ (optional) for building some examples
- - `Vc <https://github.com/VcDevel/Vc>`_ (optional) for building some examples
+	- Boost 1.70.0 or higher
+	- libfmt 6.2.1 or higher (optional) for building the tests and examples and LLAMA supporting to dump mappings as SVG/HTML
+	- `Alpaka <https://github.com/alpaka-group/alpaka>`_ (optional) for building some examples
+	- `Vc <https://github.com/VcDevel/Vc>`_ (optional) for building some examples
 
 
 Build tests and examples
@@ -38,7 +38,7 @@ As LLAMA is using CMake the tests and examples can be easily built with:
 	ccmake .. // optionally change configuration after first run of cmake
 	cmake --build .
 
-This will search for all depenencies and create a build system for your platform.
+This will search for all dependencies and create a build system for your platform.
 If Alpaka or Vc is not found, the corresponding examples will be disabled.
 After the initial call to `cmake`, `ccmake` can be used to add search paths for missing libraries and to deactivate building tests and examples.
 The tests can be disabled by setting `BUILD_TESTING` to `OFF` (default: `ON`).

--- a/docs/pages/introduction.rst
+++ b/docs/pages/introduction.rst
@@ -46,7 +46,7 @@ But there are more useful mappings than SoA and AoS, such as:
  * separating frequently accessed data from the rest (hot/cold data separation)
  * ...
 
-Moreover, software is often using various heterogenous memory architectures such as RAM, VRAM, caches, memory-mapped devices or files, etc.
+Moreover, software is often using various heterogeneous memory architectures such as RAM, VRAM, caches, memory-mapped devices or files, etc.
 A data layout optimized for a specific CPU may be inefficient on a GPU or only slowly transferable over network.
 A single layout -- not optimal for each architecture -- is very often a trade-off.
 An optimal layout is highly dependent on the architecture, the scaling of the problem and of course the chosen algorithm.
@@ -69,7 +69,7 @@ LLAMA tries to achieve the following goals:
   Deep copies are the focus, although LLAMA should include the possibility for zero copies and in-situ transformation of data layouts.
   Similar strategies could be adopted for message passing and copies between file systems and memory.
   (WIP)
-* To be compatible with many architectures, softwares, compilers and third party libraries, LLAMA tries to stay within C++17.
+* To be compatible with many architectures, other software packages, compilers and third party libraries, LLAMA tries to stay within C++17.
   No separate description files or language is used.
 * LLAMA should work well with auto vectorization approaches of modern compilers, but also support explicit vectorization on top of LLAMA.
 
@@ -81,7 +81,7 @@ Concept
 
 LLAMA separates the data structure access and physical memory layout by an opaque abstract data type called data space.
 The data space is an hypercubic index set described by the record dimension and one or more array dimensions.
-The record dimension consistes of a hierarchy of names and describes nested, structured data, much like a :cpp:`struct` in C++.
+The record dimension consists of a hierarchy of names and describes nested, structured data, much like a :cpp:`struct` in C++.
 The array dimensions are zero-based integral ranges.
 Programs are written against this abstract data space and thus formulated independent of the physical manifestation of the data space.
 Programs can refer to subparts of the data space via virtual records or real l-value references.

--- a/docs/pages/iteration.rst
+++ b/docs/pages/iteration.rst
@@ -32,7 +32,7 @@ Record dimension iteration
 The record dimension is iterated using :cpp:`llama::forEachLeafCoord`.
 It takes a record dimension as template argument and a callable with a generic parameter as argument.
 This function's :cpp:`operator()` is then called for each leaf of the record dimension tree with a record coord as argument.
-A polymorphic lambda is recommented to be used as a functor.
+A polymorphic lambda is recommended to be used as a functor.
 
 .. code-block:: C++
 
@@ -65,7 +65,7 @@ Iterators on views of any dimension are supported and open up the standard libra
 .. code-block:: C++
 
     using Pixel = ...;
-    using ArrayExtents = llama::ArrayExtents<llama::dyn>;
+    using ArrayExtents = llama::ArrayExtents<std::size_t, llama::dyn>;
     // ...
     auto view = llama::allocView(mapping);
     // ...

--- a/docs/pages/proxyreferences.rst
+++ b/docs/pages/proxyreferences.rst
@@ -43,7 +43,7 @@ it is advisable to use the corresponding :cpp:`reference` alias provided by them
     auto&&                    ref2 = obj[42]; // binds to T& for real references,
                                               // or proxy references returned by value
 
-Although :cpp:`std::vector<bool>` is notrious for this behavior of its references,
+Although :cpp:`std::vector<bool>` is notorious for this behavior of its references,
 more such data structures exist (e.g. :cpp:`std::bitset`) or started to appear in recent C++ standards and its proposals.
 E.g. in the area of `text encodings <https://thephd.dev/proxies-references-gsoc-2019>`_,
 or `the zip range adaptors <http://www.open-std.org/jtc1/sc22/wg21/docs/papers/2020/p2214r0.html#a-tuple-that-is-writable>`_.
@@ -56,7 +56,7 @@ A proxy reference is usually a value-type with reference semantic.
 Thus, a proxy reference can be freely created, copied, moved and destroyed.
 Their sole purpose is to give access to a value they refer to.
 They usually encapsulate a reference to some storage and computations to be performed when writing or reading through the proxy reference.
-Write access to a refered value of type :cpp:`T` is typically given via an assignment operator from :cpp:`T`.
+Write access to a referred value of type :cpp:`T` is typically given via an assignment operator from :cpp:`T`.
 Read access is given by a (non-explicit) conversion operator to :cpp:`T`.
 
 .. code-block:: C++
@@ -73,7 +73,7 @@ Read access is given by a (non-explicit) conversion operator to :cpp:`T`.
     for (auto&& element : v)
        bool b = element;
 
-Mind, that we explicitely state :cpp:`bool` as the type of the resulting value.
+Mind, that we explicitly state :cpp:`bool` as the type of the resulting value.
 If we use :cpp:`auto` instead, we would take a copy of the reference object, not the value.
 
 Proxy references in LLAMA
@@ -107,13 +107,13 @@ Thus, when you want to write truly generic code with LLAMA's views, please keep 
  * Each non-terminal access on a view returns a virtual record, which is a value-type with reference semantic.
  * Each terminal access on a view may return an l-value reference or a proxy reference.
    Thus use :cpp:`auto&&` to handle both cases.
- * Explicitely specify the type of copies of individual fields you want to make from references obtains from a LLAMA view.
-   This avoids accidentially coping a proxy reference.
+ * Explicitly specify the type of copies of individual fields you want to make from references obtains from a LLAMA view.
+   This avoids accidentally coping a proxy reference.
 
 Concept
 -------
 
-Proxy references in LLAMA fullfill the following concept:
+Proxy references in LLAMA fulfill the following concept:
 
 .. code-block:: C++
 
@@ -126,7 +126,7 @@ Proxy references in LLAMA fullfill the following concept:
 
 That is, the provide a member type :cpp:`value_type`,
 which indicates the type of the values which can be loaded and stored through the proxy reference.
-Furthmore, a proxy reference can be converted to its value type (thus calling :cpp:`operator value_type ()`)
+Furthermore, a proxy reference can be converted to its value type (thus calling :cpp:`operator value_type ()`)
 or assigned an instance of its value type.
 
 Arithmetic on proxy references and ProxyRefOpMixin

--- a/docs/pages/virtualrecord.rst
+++ b/docs/pages/virtualrecord.rst
@@ -28,7 +28,7 @@ This object is a :cpp:`llama::VirtualRecord`.
     float& g = vdColor(g{});
     g = 1.0;
 
-Supplying the array dimensions coordinate to a view access returns such a :cpp:`llama::VirtualRecord`, storing this array dimensions coordiante.
+Supplying the array dimensions coordinate to a view access returns such a :cpp:`llama::VirtualRecord`, storing this array dimensions coordinate.
 This object can be thought of like a record in the :math:`N`-dimensional array dimensions space,
 but as the fields of this record may not be contiguous in memory, it is not a real object in the C++ sense and thus called virtual.
 
@@ -59,8 +59,8 @@ Technically, :cpp:`llama::One` is a :cpp:`llama::VirtualRecord` which stores a s
 This also has the consequence that a :cpp:`llama::One` is now a value type with deep-copy semantic.
 
 
-Arithmetic and logical operatores
----------------------------------
+Arithmetic and logical operators
+--------------------------------
 
 :cpp:`llama::VirtualRecord` overloads several operators:
 
@@ -81,7 +81,7 @@ Arithmetic and logical operatores
         vr = 42;
     }
 
-The assignment operator ( :cpp:`=`) and the arithmetic, non-bitwise, compount assignment operators (:cpp:`=`, :cpp:`+=`, :cpp:`-=`, :cpp:`*=`, :cpp:`/=`, :cpp:`%=` ) are overloaded.
+The assignment operator ( :cpp:`=`) and the arithmetic, non-bitwise, compound assignment operators (:cpp:`=`, :cpp:`+=`, :cpp:`-=`, :cpp:`*=`, :cpp:`/=`, :cpp:`%=` ) are overloaded.
 These operators directly write into the corresponding view.
 Furthermore, the binary, non-bitwise, arithmetic operators ( :cpp:`+`, :cpp:`-`, :cpp:`*`, :cpp:`/`, :cpp:`%` ) are overloaded too,
 but they return a temporary object on the stack (i.e. a :cpp:`llama::One`).
@@ -168,7 +168,7 @@ Let's examine this deeper in an example:
     //result is true, because only the matching "x" matters
 
 A partial addressing of a virtual record like :cpp:`record1(color{}) *= 7.0` is also possible.
-:cpp:`record1(color{})` itself returns a new virtual record with the first record dimension coordiante (:cpp:`color`) being bound.
+:cpp:`record1(color{})` itself returns a new virtual record with the first record dimension coordinate (:cpp:`color`) being bound.
 This enables e.g. to easily add a velocity to a position like this:
 
 .. code-block:: C++
@@ -210,7 +210,7 @@ However, such dead address computations are eliminated by most compilers during 
     std::tuple<float&, float&, float&, char&> = record.asFlatTuple();
     auto [r, g, b, a] = record.asFlatTuple();
 
-Additionally, if the user already has types supporting the C++ tuple interface, :cpp:`llama::VirtualRecord` can integreate with these using the :cpp:`load()`, :cpp:`loadAs<T>()` and :cpp:`store(T)` functions.
+Additionally, if the user already has types supporting the C++ tuple interface, :cpp:`llama::VirtualRecord` can integrate with these using the :cpp:`load()`, :cpp:`loadAs<T>()` and :cpp:`store(T)` functions.
 
 .. code-block:: C++
 
@@ -238,7 +238,7 @@ Structured bindings
 
 WARNING: This is an experimental feature and might completely change in the future.
 
-A :cpp:`llama::VirtualRecord` implementes the C++ tuple interface itself to allow destructuring:
+A :cpp:`llama::VirtualRecord` implements the C++ tuple interface itself to allow destructuring:
 
 .. code-block:: C++
 

--- a/include/llama/Concepts.hpp
+++ b/include/llama/Concepts.hpp
@@ -19,7 +19,7 @@ namespace llama
         typename M::ArrayIndex;
         typename M::RecordDim;
         { m.extents() } -> std::same_as<typename M::ArrayExtents>;
-        { M::blobCount } -> std::convertible_to<std::size_t>;
+        { +M::blobCount } -> std::same_as<std::size_t>;
         Array<int, M::blobCount>{}; // validates constexpr-ness
         { m.blobSize(typename M::ArrayExtents::value_type{}) } -> std::same_as<typename M::ArrayExtents::value_type>;
     };


### PR DESCRIPTION
Update the documentation after recent changes to `ArrayExtents` with #488. This PR also fixes some spelling errors.