### PR TITLE
Disable ranges for MSVC 19.32

### DIFF
--- a/include/llama/HasRanges.hpp
+++ b/include/llama/HasRanges.hpp
@@ -9,7 +9,7 @@
 #if __has_include(<version>)
 #    include <version>
 #    if defined(__cpp_concepts) && defined(__cpp_lib_ranges) && (!defined(__clang__) || __clang_major__ >= 15)        \
-        && !defined(__INTEL_LLVM_COMPILER)
+        && !defined(__INTEL_LLVM_COMPILER) && (!defined(_MSC_VER) || _MSC_VER > 1932)
 #        undef CAN_USE_RANGES
 #        define CAN_USE_RANGES 1
 #    endif


### PR DESCRIPTION
It seems MSVC 19.32 is the first version satisfying the preconditions for the LLAMA ranges tests, but they are failing currently. Let's disable the tests for this version.