### PR TITLE
Add transformBlobs() and shallowCopy()

### DIFF
--- a/docs/pages/blobs.rst
+++ b/docs/pages/blobs.rst
@@ -83,6 +83,33 @@ For :math:`N`-dimensional one-record views a shortcut exists, returning a view w
 
     auto tempView = llama::allocViewStack<N, RecordDim>();
 
+CudaMalloc
+^^^^^^^^^^
+
+:cpp:`llama::bloballoc::CudaMalloc` is a blob allocator for creating blobs of type :cpp:`std::unique_ptr<std::byte[], ...>`.
+The memory is allocated using :cpp:`cudaMalloc` and the unique ptr destroys it using :cpp:`cudaFree`.
+This allocator is automatically available if the :cpp:`<cuda_runtime.h>` header is available.
+
+
+AlpakaBuf
+^^^^^^^^^
+
+:cpp:`llama::bloballoc::AlpakaBuf` is a blob allocator for creating `alpaka <https://github.com/alpaka-group/alpaka>`_ buffers as blobs.
+This allocator is automatically available if the :cpp:`<alpaka/alpaka.hpp>` header is available.
+
+.. code-block:: C++
+
+    auto view = llama::allocView(mapping, llama::bloballoc::AlpakaBuf{alpakaDev});
+
+Using this blob allocator is essentially the same as:
+
+.. code-block:: C++
+
+    auto view = llama::allocView(mapping, [&alpakaDev](auto align, std::size_t size){
+        return alpaka::allocBuf<std::byte, std::size_t>(alpakaDev, size);
+    });
+
+You may want to use the latter version in case the buffer creation is more complex.
 
 Non-owning blobs
 ----------------
@@ -96,25 +123,61 @@ It is the responsibility of the user now to ensure that the blobs outlive the vi
 Alpaka
 ^^^^^^
 
-The following descriptions are for alpaka users.
-Without an understanding of alpaka they may hard to understand.
-
 LLAMA features some examples using `alpaka <https://github.com/alpaka-group/alpaka>`_ for the abstraction of computation parallelization.
 Alpaka has its own memory allocation functions for different memory regions (e.g. host, device and shared memory).
 Additionally there are some cuda-inherited rules which make e.g. sharing memory regions hard (e.g. no possibility to use a :cpp:`std::shared_ptr` on a GPU).
 
 Alpaka creates and manages memory using buffers.
-However, a pointer to the underlying storage can be obtained, which may be used for a view:
+A pointer to the underlying storage of a buffer can be obtained, which may be used for a LLAMA view:
 
 .. code-block:: C++
 
     auto buffer = alpaka::allocBuf<std::byte, std::size_t>(dev, size);
     auto view = llama::View<Mapping, std::byte*>{mapping, {alpaka::getPtrNative(buffer)}};
 
+This is an alternative to the :cpp:`llama::bloballoc::AlpakaBuf` blob allocator,
+if the user wants to decouple buffer allocation and view creation.
+
 Shared memory is created by alpaka using a special function returning a reference to a shared variable.
-To allocate storage for LLAMA, we can allocate a shared byte array using alpaka and then pass the address of the first element to a LLAMA view.
+To allocate storage for LLAMA, we can allocate a shared byte array using alpaka
+and then pass the address of the first element to a LLAMA view.
 
 .. code-block:: C++
 
     auto& sharedMem = alpaka::declareSharedVar<std::byte[sharedMemSize], __COUNTER__>(acc);
     auto view = llama::View<Mapping, std::byte*>{mapping, {&sharedMem[0]}};
+
+Shallow copy
+------------
+
+The type of a view's blobs determine part of the semantic of the view.
+It is sometimes useful to strip this type information from a view
+and create a new view reusing the same memory as the old one,
+but using a plain referrential blob type (e.g. a :cpp:`std::byte*`).
+This is what :cpp:`llama::shallowCopy` is for.
+
+.. code-block:: C++
+    auto view = llama::allocView(mapping, llama::bloballoc::Vector{});
+    auto copy = view;                        // full copy, blobs are independent std::vectors
+    auto shallow = llama::shallowCopy(view); // refers to same memory as view
+
+This is especially useful when passing views with more complicated blob types to accelerators.
+E.g. views using the :cpp:`llama::bloballoc::CudaMalloc` allocator:
+
+.. code-block:: C++
+    auto view = llama::allocView(mapping, llama::bloballoc::CudaMalloc{}); // blob type is a smart pointer
+    
+    kernel<<<...>>>(view);                     // would copy the smart pointer to the GPU
+                                               // compiler error when view copy in kernel is destroyed
+    kernel<<<...>>>(llama::shallowCopy(view)); // would copy a new view with just pointers to view's blobs to GPU
+
+E.g. views using alpaka buffers as blobs:
+
+.. code-block:: C++
+    auto view = llama::allocView(mapping, llama::bloballoc::AlpakaBuf{alpakaDev});
+
+    alpaka::exec<Acc>(queue, workdiv, kernel,
+        view); // compile error in kernel, alpaka buffer used on GPU
+
+    alpaka::exec<Acc>(queue, workdiv, kernel,
+        llama::shallowCopy(view)); // OK, kernel view contains just pointers

--- a/examples/alpaka/asyncblur/asyncblur.cpp
+++ b/examples/alpaka/asyncblur/asyncblur.cpp
@@ -342,8 +342,7 @@ try
                 alpaka::memcpy(
                     queue[chunkNr],
                     devOldView[chunkNr].storageBlobs[i],
-                    hostChunkView[chunkNr].storageBlobs[i],
-                    devMapping.blobSize(i));
+                    hostChunkView[chunkNr].storageBlobs[i]);
 
             alpaka::exec<Acc>(
                 queue[chunkNr],
@@ -356,8 +355,7 @@ try
                 alpaka::memcpy(
                     queue[chunkNr],
                     hostChunkView[chunkNr].storageBlobs[i],
-                    devNewView[chunkNr].storageBlobs[i],
-                    devMapping.blobSize(i));
+                    devNewView[chunkNr].storageBlobs[i]);
         }
 
     // Wait for not finished tasks on accelerator

--- a/examples/alpaka/daxpy/daxpy.cpp
+++ b/examples/alpaka/daxpy/daxpy.cpp
@@ -101,8 +101,8 @@ void daxpy_alpaka_llama(std::string mappingName, std::ofstream& plotFile, Mappin
     {
         auto vx = alpaka::createView(devHost, &x.storageBlobs[0][0], mapping.blobSize(i));
         auto vy = alpaka::createView(devHost, &y.storageBlobs[0][0], mapping.blobSize(i));
-        alpaka::memcpy(queue, viewX.storageBlobs[i], vx, mapping.blobSize(i));
-        alpaka::memcpy(queue, viewY.storageBlobs[i], vy, mapping.blobSize(i));
+        alpaka::memcpy(queue, viewX.storageBlobs[i], vx);
+        alpaka::memcpy(queue, viewY.storageBlobs[i], vy);
     }
     watch.printAndReset("copy H->D");
 
@@ -143,7 +143,7 @@ void daxpy_alpaka_llama(std::string mappingName, std::ofstream& plotFile, Mappin
     for(std::size_t i = 0; i < Mapping::blobCount; i++)
     {
         auto vz = alpaka::createView(devHost, &z.storageBlobs[0][0], mapping.blobSize(i));
-        alpaka::memcpy(queue, vz, viewZ.storageBlobs[i], mapping.blobSize(i));
+        alpaka::memcpy(queue, vz, viewZ.storageBlobs[i]);
     }
     watch.printAndReset("copy D->H");
 

--- a/examples/alpaka/nbody/nbody.cpp
+++ b/examples/alpaka/nbody/nbody.cpp
@@ -298,7 +298,7 @@ void run(std::ostream& plotFile)
     watch.printAndReset("init");
 
     for(std::size_t i = 0; i < mapping.blobCount; i++)
-        alpaka::memcpy(queue, accView.storageBlobs[i], hostView.storageBlobs[i], mapping.blobSize(0));
+        alpaka::memcpy(queue, accView.storageBlobs[i], hostView.storageBlobs[i]);
     watch.printAndReset("copy H->D");
 
     const auto workdiv = alpaka::WorkDivMembers<Dim, Size>{
@@ -321,7 +321,7 @@ void run(std::ostream& plotFile)
     plotFile << std::quoted(title) << "\t" << sumUpdate / STEPS << '\t' << sumMove / STEPS << '\n';
 
     for(std::size_t i = 0; i < mapping.blobCount; i++)
-        alpaka::memcpy(queue, hostView.storageBlobs[i], accView.storageBlobs[i], mapping.blobSize(0));
+        alpaka::memcpy(queue, hostView.storageBlobs[i], accView.storageBlobs[i]);
     watch.printAndReset("copy D->H");
 }
 

--- a/examples/alpaka/pic/pic.cpp
+++ b/examples/alpaka/pic/pic.cpp
@@ -360,10 +360,7 @@ auto setup(Queue& queue, const Dev& dev, const DevHost& devHost)
     }
     // std::shuffle(particlesHost.begin(), particlesHost.end(), engine);
     for(auto i = 0; i < decltype(particleMapping)::blobCount; i++)
-    {
-        const auto blobSize = particleMapping.blobSize(i);
-        alpaka::memcpy(queue, particles.storageBlobs[i], particlesHost.storageBlobs[i], blobSize);
-    }
+        alpaka::memcpy(queue, particles.storageBlobs[i], particlesHost.storageBlobs[i]);
 
     return std::tuple{E, B, J, particles};
 }
@@ -821,11 +818,7 @@ void run(std::ostream& plotFile)
                 auto copyBlobs = [&](auto& fieldView)
                 {
                     for(auto i = 0; i < fieldMapping.blobCount; i++)
-                        alpaka::memcpy(
-                            queue,
-                            hostFieldView.storageBlobs[i],
-                            fieldView.storageBlobs[i],
-                            fieldMapping.blobSize(i));
+                        alpaka::memcpy(queue, hostFieldView.storageBlobs[i], fieldView.storageBlobs[i]);
                 };
                 copyBlobs(E);
                 output(n, "E", hostFieldView);
@@ -838,11 +831,7 @@ void run(std::ostream& plotFile)
             const auto particlesMapping = particles.mapping();
             auto hostParticleView = llama::allocViewUninitialized(particlesMapping);
             for(auto i = 0; i < particlesMapping.blobCount; i++)
-                alpaka::memcpy(
-                    queue,
-                    hostParticleView.storageBlobs[i],
-                    particles.storageBlobs[i],
-                    particlesMapping.blobSize(i));
+                alpaka::memcpy(queue, hostParticleView.storageBlobs[i], particles.storageBlobs[i]);
             output(n, hostParticleView);
         }
     }

--- a/examples/alpaka/vectoradd/vectoradd.cpp
+++ b/examples/alpaka/vectoradd/vectoradd.cpp
@@ -125,8 +125,8 @@ try
     const auto blobCount = decltype(mapping)::blobCount;
     for(std::size_t i = 0; i < blobCount; i++)
     {
-        alpaka::memcpy(queue, devA.storageBlobs[i], hostA.storageBlobs[i], mapping.blobSize(i));
-        alpaka::memcpy(queue, devB.storageBlobs[i], hostB.storageBlobs[i], mapping.blobSize(i));
+        alpaka::memcpy(queue, devA.storageBlobs[i], hostA.storageBlobs[i]);
+        alpaka::memcpy(queue, devB.storageBlobs[i], hostB.storageBlobs[i]);
     }
     chrono.printAndReset("Copy H->D");
 
@@ -154,8 +154,8 @@ try
 
     for(std::size_t i = 0; i < blobCount; i++)
     {
-        alpaka::memcpy(queue, hostA.storageBlobs[i], devA.storageBlobs[i], mapping.blobSize(i));
-        alpaka::memcpy(queue, hostB.storageBlobs[i], devB.storageBlobs[i], mapping.blobSize(i));
+        alpaka::memcpy(queue, hostA.storageBlobs[i], devA.storageBlobs[i]);
+        alpaka::memcpy(queue, hostB.storageBlobs[i], devB.storageBlobs[i]);
     }
     chrono.printAndReset("Copy D->H");
 

--- a/include/llama/BlobAllocators.hpp
+++ b/include/llama/BlobAllocators.hpp
@@ -16,6 +16,9 @@
 #if __has_include(<cuda_runtime.h>)
 #    include <cuda_runtime.h>
 #endif
+#if __has_include(<alpaka/alpaka.hpp>)
+#    include <alpaka/alpaka.hpp>
+#endif
 
 namespace llama::bloballoc
 {
@@ -138,6 +141,20 @@ namespace llama::bloballoc
                     throw std::runtime_error(std::string{"cudaFree failed with code "} + cudaGetErrorString(code));
             };
             return std::unique_ptr<std::byte[], decltype(deleter)>(p, deleter);
+        }
+    };
+#endif
+
+#if __has_include(<alpaka/alpaka.hpp>)
+    template<typename Size, typename Dev>
+    struct AlpakaBuf
+    {
+        Dev& dev;
+
+        template<std::size_t Alignment>
+        inline auto operator()(std::integral_constant<std::size_t, Alignment>, std::size_t count) const
+        {
+            return alpaka::allocBuf<std::byte, Size>(dev, static_cast<Size>(count));
         }
     };
 #endif

--- a/include/llama/View.hpp
+++ b/include/llama/View.hpp
@@ -40,7 +40,7 @@ namespace llama
             [[maybe_unused]] constexpr auto alignment
                 = alignOf<typename Mapping::RecordDim>; // g++-12 warns that alignment is unsed
             return {alloc(std::integral_constant<std::size_t, alignment>{}, mapping.blobSize(Is))...};
-        }
+        } // NOLINT(clang-analyzer-cplusplus.NewDeleteLeaks)
     } // namespace internal
 
     /// Same as \ref allocView but does not run field constructors.


### PR DESCRIPTION
This PR adds a new utility function `shallowCopy`, which is based on the new `transformBlobs` utility function. Together with two new allocators, `CudaMalloc` and `AlpakaBuf`, this simplifies the usage of LLAMA with CUDA and alpaka.

- [x] Depends on #527
- [x] Document new features