### PR TITLE
Remove macOS-10.15 from CI

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -308,7 +308,6 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - os: macos-10.15
           - os: macos-11
           - os: macos-12
     env:


### PR DESCRIPTION
This OS is deprecated by GitHub actions. See: https://github.com/actions/runner-images/issues/5583