### PR TITLE
Enforce identifier naming

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -66,11 +66,14 @@ User: ''
 CheckOptions:
   - { key: readability-identifier-naming.ClassCase, value: CamelCase}
   - { key: readability-identifier-naming.EnumCase, value: CamelCase}
+  - { key: readability-identifier-naming.FunctionCase, value: camelBack}
   - { key: readability-identifier-naming.StructCase, value: CamelCase}
   - { key: readability-identifier-naming.MacroDefinitionCase, value: UPPER_CASE}
+  - { key: readability-identifier-naming.NamespaceCase, value: camelBack}
 #  - { key: readability-identifier-naming.TemplateParameterCase, value: CamelCase} # bug in C++20: https://bugs.llvm.org/show_bug.cgi?id=46752
   - { key: readability-identifier-naming.TemplateTemplateParameterCase, value: CamelCase}
   - { key: readability-identifier-naming.TypedefCase, value: CamelCase}
 #  - { key: readability-identifier-naming.TypeTemplateParameterCase, value: CamelCase} # bug in C++20: https://bugs.llvm.org/show_bug.cgi?id=46752
   - { key: readability-identifier-naming.UnionCase, value: CamelCase}
   - { key: readability-identifier-naming.ValueTemplateParameterCase, value: CamelCase}
+  - { key: readability-identifier-naming.VariableCase, value: camelBack}

--- a/.clang-tidy
+++ b/.clang-tidy
@@ -2,7 +2,6 @@
 # -bugprone-forward-declaration-namespace # too many false positives in LLAMA
 # -cppcoreguidelines-macro-usage # too many macros flagged, which cannot be replaced by constexpr
 # -bugprone-exception-escape # bgruber is fine with exceptions escaping main we cannot add main as an exception
-# -cppcoreguidelines-pro-type-reinterpret-cast # we need some reinterpret casts in LLAMA
 # -readability-misleading-indentation # many false positives because of constexpr if
 # -readability-static-accessed-through-instance # flags threadIdx/blockIdx in CUDA code
 # -cert-err58-cpp # errors in Catch2
@@ -56,7 +55,12 @@ Checks: >
     -llvm-header-guard,
     -cppcoreguidelines-macro-usage,
     -fuchsia-statically-constructed-objects,
-    -cppcoreguidelines-pro-type-union-access
+    -cppcoreguidelines-pro-type-union-access,
+    -fuchsia-multiple-inheritance,
+    -hicpp-signed-bitwise,
+    -cppcoreguidelines-pro-bounds-array-to-pointer-decay,
+    -hicpp-no-array-decay,
+    -cppcoreguidelines-owning-memory
 
 WarningsAsErrors: '*'
 HeaderFilterRegex: ''

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -47,7 +47,7 @@ jobs:
         mkdir alpaka/build
         cd alpaka/build
         cmake .. -DCMAKE_TOOLCHAIN_FILE=/usr/local/share/vcpkg/scripts/buildsystems/vcpkg.cmake
-        sudo cmake --build . --target install
+        sudo cmake --install .
     - name: run clang-tidy
       run: |
         mkdir build

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -61,7 +61,7 @@ jobs:
     - name: run clang-tidy
       run: |
         cd build
-        sed -i 's/\(-forward-unknown-to-host-compiler\|--generate-code=arch=[^ ]\+\|--expt-extended-lambda\|--expt-relaxed-constexpr\|--use_fast_math\)//g' compile_commands.json # remove NVCC specific flags which clang cannot handle
+        sed -i 's/\(-forward-unknown-to-host-compiler\|--generate-code=arch=[^ ]\+\|--expt-extended-lambda\|--extended-lambda\|--expt-relaxed-constexpr\|--use_fast_math\)//g' compile_commands.json # remove NVCC specific flags which clang cannot handle
         run-clang-tidy-14 -header-filter='(tests|include/llama|examples)' -extra-arg=--no-cuda-version-check -extra-arg=-nocudalib -extra-arg=-Wno-unused-command-line-argument '^(?!.*'$PWD').*$'
 
   coverage:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -34,32 +34,33 @@ jobs:
     - uses: actions/checkout@v2
     - name: install clang-14
       run: |
-        wget -O - https://apt.llvm.org/llvm-snapshot.gpg.key|sudo apt-key add -
-        sudo add-apt-repository 'deb http://apt.llvm.org/jammy/ llvm-toolchain-jammy-14 main'
-        sudo apt update
         sudo apt install clang-14 libomp-14-dev clang-tidy-14
     - name: vcpkg install dependencies
       run: |
         eval $VCPKG_INSTALL
     - name: install alpaka
       run: |
-        git clone https://github.com/alpaka-group/alpaka.git
+        git clone --branch $ALPAKA_BRANCH --depth 1 https://github.com/alpaka-group/alpaka.git
         mkdir alpaka/build
         cd alpaka/build
-        cmake .. -DCMAKE_TOOLCHAIN_FILE=/usr/local/share/vcpkg/scripts/buildsystems/vcpkg.cmake
+        cmake .. -DCMAKE_TOOLCHAIN_FILE=$VCPKG_INSTALLATION_ROOT/scripts/buildsystems/vcpkg.cmake
         sudo cmake --install .
-    - name: run clang-tidy
+    - name: cmake
       run: |
         mkdir build
         cd build
         cmake .. -DCMAKE_BUILD_TYPE=$CONFIG \
                  -DBUILD_TESTING=ON \
                  -DLLAMA_BUILD_EXAMPLES=ON \
+                 -DCMAKE_BUILD_TYPE=$CONFIG \
                  -DCMAKE_EXPORT_COMPILE_COMMANDS=ON \
                  -Dalpaka_ACC_CPU_B_SEQ_T_SEQ_ENABLE=ON \
                  -Dalpaka_ACC_CPU_DISABLE_ATOMIC_REF=ON \
                  -Dalpaka_CXX_STANDARD=17 \
-                 -DCMAKE_TOOLCHAIN_FILE=/usr/local/share/vcpkg/scripts/buildsystems/vcpkg.cmake
+                 -DCMAKE_TOOLCHAIN_FILE=$VCPKG_INSTALLATION_ROOT/scripts/buildsystems/vcpkg.cmake
+    - name: run clang-tidy
+      run: |
+        cd build
         sed -i 's/\(-forward-unknown-to-host-compiler\|--generate-code=arch=[^ ]\+\|--expt-extended-lambda\|--expt-relaxed-constexpr\|--use_fast_math\)//g' compile_commands.json # remove NVCC specific flags which clang cannot handle
         run-clang-tidy-14 -header-filter='^((?!/thirdparty/).)*$' -extra-arg=--no-cuda-version-check -extra-arg=-nocudalib -extra-arg=-Wno-unused-command-line-argument '^(?!.*'$PWD').*$'
 

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -62,7 +62,7 @@ jobs:
       run: |
         cd build
         sed -i 's/\(-forward-unknown-to-host-compiler\|--generate-code=arch=[^ ]\+\|--expt-extended-lambda\|--expt-relaxed-constexpr\|--use_fast_math\)//g' compile_commands.json # remove NVCC specific flags which clang cannot handle
-        run-clang-tidy-14 -header-filter='^((?!/thirdparty/).)*$' -extra-arg=--no-cuda-version-check -extra-arg=-nocudalib -extra-arg=-Wno-unused-command-line-argument '^(?!.*'$PWD').*$'
+        run-clang-tidy-14 -header-filter='(tests|include/llama|examples)' -extra-arg=--no-cuda-version-check -extra-arg=-nocudalib -extra-arg=-Wno-unused-command-line-argument '^(?!.*'$PWD').*$'
 
   coverage:
     runs-on: ubuntu-22.04

--- a/docs/pages/api.rst
+++ b/docs/pages/api.rst
@@ -23,10 +23,10 @@ Array
 
 .. doxygenstruct:: llama::Array
    :members:
-.. doxygenfunction:: llama::push_front
-.. doxygenfunction:: llama::push_back
-.. doxygenfunction:: llama::pop_front([[maybe_unused]] Array<T, N> a)
-.. doxygenfunction:: llama::pop_back
+.. doxygenfunction:: llama::pushFront
+.. doxygenfunction:: llama::pushBack
+.. doxygenfunction:: llama::popFront([[maybe_unused]] Array<T, N> a)
+.. doxygenfunction:: llama::popBack
 .. doxygenfunction:: llama::product(Array<T, N> a)
 
 Tuple
@@ -38,7 +38,7 @@ Tuple
 .. doxygenfunction:: llama::tupleCat
 .. doxygenfunction:: llama::tupleReplace
 .. doxygenfunction:: llama::tupleTransform
-.. doxygenfunction:: llama::pop_front(const Tuple<Elements...> &tuple)
+.. doxygenfunction:: llama::popFront(const Tuple<Elements...> &tuple)
 
 Array dimensions
 ----------------
@@ -91,8 +91,8 @@ Record coordinates
 .. doxygentypedef:: llama::RecordCoordFromList
 .. doxygentypedef:: llama::Cat
 .. doxygentypedef:: llama::PopFront
-.. doxygenvariable:: llama::RecordCoordCommonPrefixIsBigger
-.. doxygenvariable:: llama::RecordCoordCommonPrefixIsSame
+.. doxygenvariable:: llama::recordCoordCommonPrefixIsBigger
+.. doxygenvariable:: llama::recordCoordCommonPrefixIsSame
 
 View creation
 -------------

--- a/examples/alpaka/asyncblur/asyncblur.cpp
+++ b/examples/alpaka/asyncblur/asyncblur.cpp
@@ -29,7 +29,7 @@
 constexpr auto async = true; ///< defines whether the data shall be processed asynchronously
 constexpr auto shared = true; ///< defines whether shared memory shall be used
 constexpr auto save = true; ///< defines whether the resultion image shall be saved
-constexpr auto chunkCount = 4;
+constexpr auto chunkCount = std::size_t{4};
 
 constexpr auto defaultImgX = 4096; /// width of the default image if no png is loaded
 constexpr auto defaultImgY = 4096; /// height of the default image if no png is loaded
@@ -159,7 +159,7 @@ try
     const DevHost devHost = alpaka::getDevByIdx<PltfHost>(0);
     std::vector<Queue> queue;
     queue.reserve(chunkCount);
-    for(int i = 0; i < chunkCount; ++i)
+    for(std::size_t i = 0; i < chunkCount; ++i)
         queue.emplace_back(devAcc);
 
     // ASYNCCOPY
@@ -209,8 +209,8 @@ try
     using DevMapping = std::decay_t<decltype(devMapping)>;
 
     std::size_t hostBufferSize = 0;
-    for(std::size_t i = 0; i < hostMapping.blobCount; i++)
-        hostBufferSize += hostMapping.blobSize(i);
+    for(int i = 0; i < hostMapping.blobCount; i++)
+        hostBufferSize += static_cast<std::size_t>(hostMapping.blobSize(i));
     std::cout << "Image size: " << imgX << ":" << imgY << '\n'
               << hostBufferSize * 2 / 1024 / 1024 << " MB on device\n";
 
@@ -226,7 +226,7 @@ try
     std::vector<AccChunkView> devOldView;
     std::vector<AccChunkView> devNewView;
 
-    for(int i = 0; i < chunkCount; ++i)
+    for(std::size_t i = 0; i < chunkCount; ++i)
     {
         hostChunkView.push_back(llama::allocView(devMapping, allocBlobHost));
         devOldView.push_back(llama::allocView(devMapping, allocBlobAcc));
@@ -294,7 +294,7 @@ try
             llama::VirtualView virtualHost(hostView, {chunkY * chunkSize, chunkX * chunkSize});
 
             // Find free chunk stream
-            int chunkNr = virtualHostList.size();
+            auto chunkNr = virtualHostList.size();
             if(virtualHostList.size() < chunkCount)
                 virtualHostList.push_back({virtualHost, validMiniSize});
             else

--- a/examples/alpaka/daxpy/daxpy.cpp
+++ b/examples/alpaka/daxpy/daxpy.cpp
@@ -10,7 +10,7 @@
 #include <omp.h>
 #include <vector>
 
-constexpr auto PROBLEM_SIZE = std::size_t{1024 * 1024 * 128};
+constexpr auto PROBLEM_SIZE = std::size_t{1024} * 1024 * 128;
 constexpr auto BLOCK_SIZE = std::size_t{256};
 constexpr auto WARMUP_STEPS = 1;
 constexpr auto STEPS = 5;

--- a/examples/alpaka/nbody/nbody.cpp
+++ b/examples/alpaka/nbody/nbody.cpp
@@ -286,17 +286,17 @@ void run(std::ostream& plotFile)
     watch.printAndReset("alloc views");
 
     std::mt19937_64 generator;
-    std::normal_distribution<FP> distribution(FP(0), FP(1));
+    std::normal_distribution<FP> distribution(FP{0}, FP{1});
     for(int i = 0; i < PROBLEM_SIZE; ++i)
     {
         llama::One<Particle> p;
         p(tag::Pos(), tag::X()) = distribution(generator);
         p(tag::Pos(), tag::Y()) = distribution(generator);
         p(tag::Pos(), tag::Z()) = distribution(generator);
-        p(tag::Vel(), tag::X()) = distribution(generator) / FP(10);
-        p(tag::Vel(), tag::Y()) = distribution(generator) / FP(10);
-        p(tag::Vel(), tag::Z()) = distribution(generator) / FP(10);
-        p(tag::Mass()) = distribution(generator) / FP(100);
+        p(tag::Vel(), tag::X()) = distribution(generator) / FP{10};
+        p(tag::Vel(), tag::Y()) = distribution(generator) / FP{10};
+        p(tag::Vel(), tag::Z()) = distribution(generator) / FP{10};
+        p(tag::Mass()) = distribution(generator) / FP{100};
         hostView(i) = p;
     }
     watch.printAndReset("init");

--- a/examples/alpaka/pic/pic.cpp
+++ b/examples/alpaka/pic/pic.cpp
@@ -254,10 +254,10 @@ void initFields(Queue& queue, FieldView E, FieldView B, FieldView J)
         llama::shallowCopy(J));
 }
 
-constexpr size_t numpart = 2 * ppc * R_ * L;
+constexpr size_t numpart = std::size_t{2} * ppc * R_ * L;
 
 template<int FieldMapping, int ParticleMapping, typename Acc, typename Queue, typename Dev, typename DevHost>
-auto setup(Queue& queue, const Dev& dev, const DevHost& devHost)
+auto setup(Queue& queue, const Dev& dev, const DevHost& /*devHost*/)
 {
     // std::cout << "dt = " << dt << '\n';
 
@@ -294,7 +294,7 @@ auto setup(Queue& queue, const Dev& dev, const DevHost& devHost)
     }();
 
     int i = 0;
-    auto alpakaBlobAlloc = [&](auto alignment, std::size_t count)
+    auto alpakaBlobAlloc = [&](auto /*alignment*/, std::size_t count)
     {
         fmt::print("Buffer #{}: {}MiB\n", i++, count / 1024 / 1024);
         return alpaka::allocBuf<std::byte, Size>(dev, count);

--- a/examples/alpaka/vectoradd/vectoradd.cpp
+++ b/examples/alpaka/vectoradd/vectoradd.cpp
@@ -112,7 +112,7 @@ try
     chrono.printAndReset("Alloc views");
 
     std::default_random_engine generator;
-    std::normal_distribution<FP> distribution(FP(0), FP(1));
+    std::normal_distribution<FP> distribution(FP{0}, FP{1});
     auto seed = distribution(generator);
     LLAMA_INDEPENDENT_DATA
     for(std::size_t i = 0; i < PROBLEM_SIZE; ++i)

--- a/examples/bitpackfloat/bitpackfloat.cpp
+++ b/examples/bitpackfloat/bitpackfloat.cpp
@@ -17,11 +17,11 @@ using Vector = llama::Record<
 
 auto main() -> int
 {
-    constexpr auto N = 100;
+    constexpr auto n = 100;
     constexpr auto exponentBits = 5;
     constexpr auto mantissaBits = 13;
     const auto mapping
-        = llama::mapping::BitPackedFloatSoA{llama::ArrayExtents{N}, exponentBits, mantissaBits, Vector{}};
+        = llama::mapping::BitPackedFloatSoA{llama::ArrayExtents{n}, exponentBits, mantissaBits, Vector{}};
 
     auto view = llama::allocView(mapping);
 
@@ -32,7 +32,7 @@ auto main() -> int
                 "Blob {}: {} bytes (uncompressed {} bytes)\n",
                 ic,
                 mapping.blobSize(ic),
-                N * sizeof(llama::GetType<Vector, llama::RecordCoord<decltype(ic)::value>>));
+                n * sizeof(llama::GetType<Vector, llama::RecordCoord<decltype(ic)::value>>));
         });
 
     std::default_random_engine engine;
@@ -42,7 +42,7 @@ auto main() -> int
     // float f = view(0)(tag::X{});
     // fmt::print("{}", f);
 
-    for(std::size_t i = 0; i < N; i++)
+    for(std::size_t i = 0; i < n; i++)
     {
         const auto v = dist(engine);
         view(i)(tag::X{}) = v;

--- a/examples/bytesplit/bytesplit.cpp
+++ b/examples/bytesplit/bytesplit.cpp
@@ -25,18 +25,18 @@ using Data = llama::Record<
 
 auto main() -> int
 {
-    constexpr auto N = 128;
+    constexpr auto n = 128;
     using ArrayExtents = llama::ArrayExtentsDynamic<std::size_t, 1>;
-    const auto mapping = llama::mapping::Bytesplit<ArrayExtents, Data, llama::mapping::BindSoA<false>::fn>{{N}};
+    const auto mapping = llama::mapping::Bytesplit<ArrayExtents, Data, llama::mapping::BindSoA<false>::fn>{{n}};
 
     auto view = llama::allocView(mapping);
 
     int value = 0;
-    for(std::size_t i = 0; i < N; i++)
+    for(std::size_t i = 0; i < n; i++)
         llama::forEachLeafCoord<Data>([&](auto rc) { view(i)(rc) = ++value; });
 
     value = 0;
-    for(std::size_t i = 0; i < N; i++)
+    for(std::size_t i = 0; i < n; i++)
         llama::forEachLeafCoord<Data>(
             [&](auto rc)
             {
@@ -47,20 +47,20 @@ auto main() -> int
             });
 
     // extract into a view of unsplit fields
-    auto viewExtracted = llama::allocViewUninitialized(llama::mapping::AoS<ArrayExtents, Data>{{N}});
+    auto viewExtracted = llama::allocViewUninitialized(llama::mapping::AoS<ArrayExtents, Data>{{n}});
     llama::copy(view, viewExtracted);
     if(!std::equal(view.begin(), view.end(), viewExtracted.begin(), viewExtracted.end()))
         fmt::print("ERROR: unsplit view is different\n");
 
     // compute something on the extracted view
-    for(std::size_t i = 0; i < N; i++)
+    for(std::size_t i = 0; i < n; i++)
         viewExtracted(i) *= 2;
 
     // rearrange back into split view
     llama::copy(viewExtracted, view);
 
     value = 0;
-    for(std::size_t i = 0; i < N; i++)
+    for(std::size_t i = 0; i < n; i++)
         llama::forEachLeafCoord<Data>(
             [&](auto rc)
             {
@@ -71,11 +71,11 @@ auto main() -> int
             });
 
     // compute something on the split view
-    for(std::size_t i = 0; i < N; i++)
+    for(std::size_t i = 0; i < n; i++)
         view(i) = view(i) * 2; // cannot do view(i) *= 2; with proxy references
 
     value = 0;
-    for(std::size_t i = 0; i < N; i++)
+    for(std::size_t i = 0; i < n; i++)
         llama::forEachLeafCoord<Data>(
             [&](auto rc)
             {

--- a/examples/common/alpakaHelpers.hpp
+++ b/examples/common/alpakaHelpers.hpp
@@ -13,35 +13,35 @@
 
 namespace common
 {
-    constexpr auto THREADELEMDIST_MIN_ELEM = 2;
+    constexpr auto threadElemDistMinElem = 2;
 
     /** Returns a good guess for an optimal number of threads and elements in a
      *  block based on the total number of elements in the block.
      */
-    template<typename T_Acc, std::size_t blockSize, std::size_t hardwareThreads>
+    template<typename T_Acc, std::size_t BlockSize, std::size_t HardwareThreads>
     struct ThreadsElemsDistribution
     {
         /// number of elements per thread
-        static constexpr std::size_t elemCount = blockSize;
+        static constexpr std::size_t elemCount = BlockSize;
         /// number of threads per block
         static constexpr std::size_t threadCount = 1u;
     };
 
 #ifdef ALPAKA_ACC_GPU_CUDA_ENABLED
-    template<std::size_t blockSize, std::size_t hardwareThreads, typename T_Dim, typename T_Size>
-    struct ThreadsElemsDistribution<alpaka::AccGpuCudaRt<T_Dim, T_Size>, blockSize, hardwareThreads>
+    template<std::size_t BlockSize, std::size_t HardwareThreads, typename Dim, typename Size>
+    struct ThreadsElemsDistribution<alpaka::AccGpuCudaRt<Dim, Size>, BlockSize, HardwareThreads>
     {
-        static constexpr std::size_t elemCount = THREADELEMDIST_MIN_ELEM;
-        static constexpr std::size_t threadCount = blockSize / THREADELEMDIST_MIN_ELEM;
+        static constexpr std::size_t elemCount = threadElemDistMinElem;
+        static constexpr std::size_t threadCount = BlockSize / threadElemDistMinElem;
     };
 #endif
 
 #ifdef ALPAKA_ACC_CPU_B_SEQ_T_OMP2_ENABLED
-    template<std::size_t blockSize, std::size_t hardwareThreads, typename T_Dim, typename T_Size>
-    struct ThreadsElemsDistribution<alpaka::AccCpuOmp2Threads<T_Dim, T_Size>, blockSize, hardwareThreads>
+    template<std::size_t BlockSize, std::size_t HardwareThreads, typename Dim, typename Size>
+    struct ThreadsElemsDistribution<alpaka::AccCpuOmp2Threads<Dim, Size>, BlockSize, HardwareThreads>
     {
-        static constexpr std::size_t elemCount = (blockSize + hardwareThreads - 1u) / hardwareThreads;
-        static constexpr std::size_t threadCount = hardwareThreads;
+        static constexpr std::size_t elemCount = (BlockSize + HardwareThreads - 1u) / HardwareThreads;
+        static constexpr std::size_t threadCount = HardwareThreads;
     };
 #endif
 

--- a/examples/common/ttjet_13tev_june2019.hpp
+++ b/examples/common/ttjet_13tev_june2019.hpp
@@ -10,6 +10,7 @@ using byte = unsigned char;
 using Index = std::uint64_t;
 
 // clang-format off
+// NOLINTBEGIN(readability-identifier-naming)
 struct run {};
 struct luminosityBlock {};
 struct event {};
@@ -1489,6 +1490,7 @@ struct L1_UnpairedBunchBptxMinus {};
 struct L1_UnpairedBunchBptxPlus {};
 struct L1_ZeroBias {};
 struct L1_ZeroBias_copy {};
+// NOLINTEND(readability-identifier-naming)
 
 using CorrT1METJet = llama::Record<
     llama::Field<CorrT1METJet_area, float>,

--- a/examples/raycast/raycast.cpp
+++ b/examples/raycast/raycast.cpp
@@ -483,17 +483,17 @@ namespace
         if(det > -epsilon && det < epsilon)
             return {};
 
-        const auto inv_det = 1.0f / det;
+        const auto invDet = 1.0f / det;
         const auto tvec = ray.origin - triangle.vertex0;
-        const auto u = dot(tvec, pvec) * inv_det;
+        const auto u = dot(tvec, pvec) * invDet;
         if(u < 0.0f || u > 1.0f)
             return {};
 
         const auto qvec = cross(tvec, triangle.edge1);
-        const auto v = dot(ray.direction, qvec) * inv_det;
+        const auto v = dot(ray.direction, qvec) * invDet;
         if(v < 0.0f || u + v >= 1.0f)
             return {};
-        const auto t = dot(triangle.edge2, qvec) * inv_det;
+        const auto t = dot(triangle.edge2, qvec) * invDet;
         if(t < 0)
             return {};
 
@@ -515,17 +515,17 @@ namespace
         if(det > -epsilon && det < epsilon)
             return {};
 
-        const auto inv_det = 1.0f / det;
+        const auto invDet = 1.0f / det;
         const auto tvec = ray.origin - triangle(Vertex0{}).template loadAs<VectorF>();
-        const auto u = dot(tvec, pvec) * inv_det;
+        const auto u = dot(tvec, pvec) * invDet;
         if(u < 0.0f || u > 1.0f)
             return {};
 
         const auto qvec = cross(tvec, edge1);
-        const auto v = dot(ray.direction, qvec) * inv_det;
+        const auto v = dot(ray.direction, qvec) * invDet;
         if(v < 0.0f || u + v >= 1.0f)
             return {};
-        const auto t = dot(edge2, qvec) * inv_det;
+        const auto t = dot(edge2, qvec) * invDet;
         if(t < 0)
             return {};
 

--- a/include/llama/Array.hpp
+++ b/include/llama/Array.hpp
@@ -14,10 +14,11 @@ namespace llama
     /// \tparam T type if array elements.
     /// \tparam N rank of the array.
     template<typename T, std::size_t N>
+    // NOLINTNEXTLINE(bugprone-reserved-identifier,cert-dcl37-c,cert-dcl51-cpp,readability-identifier-naming)
     struct Array
     {
         using value_type = T;
-        T element[N > 0 ? N : 1];
+        T element[N];
 
         LLAMA_FN_HOST_ACC_INLINE constexpr auto size() const
         {

--- a/include/llama/Array.hpp
+++ b/include/llama/Array.hpp
@@ -207,7 +207,7 @@ namespace llama
     }
 
     template<typename T, std::size_t N>
-    LLAMA_FN_HOST_ACC_INLINE constexpr auto push_front([[maybe_unused]] Array<T, N> a, T v) -> Array<T, N + 1>
+    LLAMA_FN_HOST_ACC_INLINE constexpr auto pushFront([[maybe_unused]] Array<T, N> a, T v) -> Array<T, N + 1>
     {
         Array<T, N + 1> r{};
         r[0] = v;
@@ -218,7 +218,7 @@ namespace llama
     }
 
     template<typename T, std::size_t N>
-    LLAMA_FN_HOST_ACC_INLINE constexpr auto push_back([[maybe_unused]] Array<T, N> a, T v) -> Array<T, N + 1>
+    LLAMA_FN_HOST_ACC_INLINE constexpr auto pushBack([[maybe_unused]] Array<T, N> a, T v) -> Array<T, N + 1>
     {
         Array<T, N + 1> r{};
         if constexpr(N > 0)
@@ -229,7 +229,7 @@ namespace llama
     }
 
     template<typename T, std::size_t N>
-    LLAMA_FN_HOST_ACC_INLINE constexpr auto pop_back([[maybe_unused]] Array<T, N> a)
+    LLAMA_FN_HOST_ACC_INLINE constexpr auto popBack([[maybe_unused]] Array<T, N> a)
     {
         static_assert(N > 0);
         Array<T, N - 1> r{};
@@ -240,7 +240,7 @@ namespace llama
     }
 
     template<typename T, std::size_t N>
-    LLAMA_FN_HOST_ACC_INLINE constexpr auto pop_front([[maybe_unused]] Array<T, N> a)
+    LLAMA_FN_HOST_ACC_INLINE constexpr auto popFront([[maybe_unused]] Array<T, N> a)
     {
         static_assert(N > 0);
         Array<T, N - 1> r{};

--- a/include/llama/ArrayExtents.hpp
+++ b/include/llama/ArrayExtents.hpp
@@ -82,7 +82,8 @@ namespace llama
     {
         struct Dyn
         {
-            template<typename T>
+            template<typename T, std::enable_if_t<std::is_integral_v<T>, int> = 0>
+            // NOLINTNEXTLINE(google-explicit-constructor,hicpp-explicit-conversions)
             constexpr operator T() const
             {
                 return static_cast<T>(-1);
@@ -160,11 +161,6 @@ namespace llama
         {
             return toArray(std::make_index_sequence<rank>{});
         }
-
-        LLAMA_FN_HOST_ACC_INLINE constexpr operator Index() const
-        {
-            return toArray();
-        }
     };
 
     template<typename T>
@@ -180,11 +176,6 @@ namespace llama
         LLAMA_FN_HOST_ACC_INLINE constexpr auto toArray() const -> Index
         {
             return {};
-        }
-
-        LLAMA_FN_HOST_ACC_INLINE constexpr operator Index() const
-        {
-            return toArray();
         }
     };
 

--- a/include/llama/ArrayExtents.hpp
+++ b/include/llama/ArrayExtents.hpp
@@ -124,8 +124,8 @@ namespace llama
     struct ArrayExtents : Array<T, ((Sizes == dyn) + ... + 0)>
     {
         static constexpr std::size_t rank = sizeof...(Sizes);
-        static constexpr auto rank_dynamic = ((Sizes == dyn) + ... + 0);
-        static constexpr auto rank_static = rank - rank_dynamic;
+        static constexpr auto rankDynamic = ((Sizes == dyn) + ... + 0);
+        static constexpr auto rankStatic = rank - rankDynamic;
 
         using Index = ArrayIndex<T, rank>;
         using value_type = T;
@@ -139,7 +139,7 @@ namespace llama
             if constexpr(extent != dyn)
                 return extent;
             else
-                return static_cast<const Array<value_type, rank_dynamic>&>(
+                return static_cast<const Array<value_type, rankDynamic>&>(
                     *this)[+mp_count<mp_take_c<TypeList, I>, std::integral_constant<T, dyn>>::value];
         }
 
@@ -171,8 +171,8 @@ namespace llama
     struct ArrayExtents<T>
     {
         static constexpr std::size_t rank = 0;
-        static constexpr auto rank_dynamic = 0;
-        static constexpr auto rank_static = 0;
+        static constexpr auto rankDynamic = 0;
+        static constexpr auto rankStatic = 0;
 
         using Index = ArrayIndex<T, 0>;
         using value_type = T;
@@ -247,7 +247,7 @@ namespace llama
         if constexpr(Dim > 0)
             for(SizeType i = 0; i < adSize[0]; i++)
                 forEachADCoord(
-                    ArrayIndex<SizeType, Dim - 1>{pop_front(adSize)},
+                    ArrayIndex<SizeType, Dim - 1>{popFront(adSize)},
                     std::forward<Func>(func),
                     outerIndices...,
                     i);

--- a/include/llama/Concepts.hpp
+++ b/include/llama/Concepts.hpp
@@ -37,11 +37,11 @@ namespace llama
     };
 
     template<typename M>
-    inline constexpr bool AllFieldsArePhysical
+    inline constexpr bool allFieldsArePhysical
         = boost::mp11::mp_all_of<LeafRecordCoords<typename M::RecordDim>, MakeIsPhysical<M>::template type>::value;
 
     template <typename M>
-    concept PhysicalMapping = Mapping<M> && AllFieldsArePhysical<M>;
+    concept PhysicalMapping = Mapping<M> && allFieldsArePhysical<M>;
 
     template <typename R>
     concept LValueReference = std::is_lvalue_reference_v<R>;
@@ -69,25 +69,25 @@ namespace llama
     };
 
     template<typename M>
-    inline constexpr bool AllFieldsAreComputed
+    inline constexpr bool allFieldsAreComputed
         = boost::mp11::mp_all_of<LeafRecordCoords<typename M::RecordDim>, MakeIsComputed<M>::template type>::value;
 
     template <typename M>
-    concept FullyComputedMapping = Mapping<M> && AllFieldsAreComputed<M>;
+    concept FullyComputedMapping = Mapping<M> && allFieldsAreComputed<M>;
 
     template<
         typename M,
         typename LeafCoords = LeafRecordCoords<typename M::RecordDim>,
         std::size_t PhysicalCount = boost::mp11::mp_count_if<LeafCoords, MakeIsPhysical<M>::template type>::value,
         std::size_t ComputedCount = boost::mp11::mp_count_if<LeafCoords, MakeIsComputed<M>::template type>::value>
-    inline constexpr bool AllFieldsArePhysicalOrComputed
+    inline constexpr bool allFieldsArePhysicalOrComputed
         = (PhysicalCount + ComputedCount) >= boost::mp11::mp_size<LeafCoords>::value&& PhysicalCount > 0
         && ComputedCount > 0; // == instead of >= would be better, but it's not easy to count correctly,
                               // because we cannot check whether the call to blobNrOrOffset()
                               // or compute() is actually valid
 
     template <typename M>
-    concept PartiallyComputedMapping = Mapping<M> && AllFieldsArePhysicalOrComputed<M>;
+    concept PartiallyComputedMapping = Mapping<M> && allFieldsArePhysicalOrComputed<M>;
 
     template<typename B>
     concept Blob = requires(B b, std::size_t i) {

--- a/include/llama/Core.hpp
+++ b/include/llama/Core.hpp
@@ -304,7 +304,7 @@ namespace llama
     {
         // adapted from boost::mp11, but with LLAMA_FN_HOST_ACC_INLINE
         template<template<typename...> typename L, typename... T, typename F>
-        LLAMA_FN_HOST_ACC_INLINE constexpr void mp_for_each_inlined(L<T...>, F&& f)
+        LLAMA_FN_HOST_ACC_INLINE constexpr void mpForEachInlined(L<T...>, F&& f)
         {
             using A = int[sizeof...(T)];
             (void) A{((void) f(T{}), 0)...};
@@ -320,7 +320,7 @@ namespace llama
     LLAMA_FN_HOST_ACC_INLINE constexpr void forEachLeafCoord(Functor&& functor, RecordCoord<Coords...> baseCoord)
     {
         LLAMA_FORCE_INLINE_RECURSIVE
-        internal::mp_for_each_inlined(
+        internal::mpForEachInlined(
             LeafRecordCoords<GetType<RecordDim, RecordCoord<Coords...>>>{},
             [&](auto innerCoord) LLAMA_LAMBDA_INLINE_WITH_SPECIFIERS(constexpr)
             { std::forward<Functor>(functor)(cat(baseCoord, innerCoord)); });
@@ -656,13 +656,13 @@ namespace llama
             typename... FieldsA,
             typename FieldB,
             typename... FieldsB,
-            auto pos = FindFieldByTag<Record<FieldsA...>, GetFieldTag<FieldB>>::value>
+            auto Pos = FindFieldByTag<Record<FieldsA...>, GetFieldTag<FieldB>>::value>
         auto mergeRecordDimsImpl(
             boost::mp11::mp_identity<Record<FieldsA...>>,
             boost::mp11::mp_identity<Record<FieldB, FieldsB...>>)
         {
             using namespace boost::mp11;
-            if constexpr(pos == sizeof...(FieldsA))
+            if constexpr(Pos == sizeof...(FieldsA))
             {
                 return mergeRecordDimsImpl(
                     mp_identity<Record<FieldsA..., FieldB>>{},
@@ -670,13 +670,13 @@ namespace llama
             }
             else
             {
-                using OldFieldA = mp_at_c<Record<FieldsA...>, pos>;
+                using OldFieldA = mp_at_c<Record<FieldsA...>, Pos>;
                 using NewFieldA = Field<
                     GetFieldTag<OldFieldA>,
                     typename decltype(mergeRecordDimsImpl(
                         mp_identity<GetFieldType<OldFieldA>>{},
                         mp_identity<GetFieldType<FieldB>>{}))::type>;
-                using NewRecordA = mp_replace_at_c<Record<FieldsA...>, pos, NewFieldA>;
+                using NewRecordA = mp_replace_at_c<Record<FieldsA...>, Pos, NewFieldA>;
                 return mergeRecordDimsImpl(mp_identity<NewRecordA>{}, mp_identity<Record<FieldsB...>>{});
             }
         }

--- a/include/llama/Core.hpp
+++ b/include/llama/Core.hpp
@@ -624,8 +624,8 @@ namespace llama
 
     namespace internal
     {
-        // TODO: we might implement this better by expanding a record dim into a list of tag lists and then computing a
-        // real set union of the two tag list lists
+        // TODO(bgruber): we might implement this better by expanding a record dim into a list of tag lists and then
+        // computing a real set union of the two tag list lists
 
         template<typename A, typename B>
         auto mergeRecordDimsImpl(boost::mp11::mp_identity<A> a, boost::mp11::mp_identity<B>)
@@ -707,6 +707,7 @@ namespace llama
             BoxedValue() = default;
 
             // we don't make this ctor explicit so a Value appearing in a ctor list can just be created by passing a T
+            // NOLINTNEXTLINE(google-explicit-constructor,hicpp-explicit-conversions)
             LLAMA_FN_HOST_ACC_INLINE BoxedValue(T value) : val(value)
             {
             }
@@ -726,6 +727,7 @@ namespace llama
             BoxedValue() = default;
 
             // we don't make this ctor explicit so a Value appearing in a ctor list can just be created by passing a T
+            // NOLINTNEXTLINE(google-explicit-constructor,hicpp-explicit-conversions)
             LLAMA_FN_HOST_ACC_INLINE BoxedValue(Constant<V>)
             {
             }

--- a/include/llama/DumpMapping.hpp
+++ b/include/llama/DumpMapping.hpp
@@ -34,8 +34,8 @@ namespace llama
 
         inline auto color(const std::vector<std::size_t>& recordCoord) -> std::size_t
         {
-            auto c = boost::hash<std::vector<std::size_t>>{}(recordCoord) &0xFFFFFF;
-            c |= 0x404040; // ensure color per channel is at least 0x40.
+            auto c = boost::hash<std::vector<std::size_t>>{}(recordCoord) &std::size_t{0xFFFFFF};
+            c |= std::size_t{0x404040}; // ensure color per channel is at least 0x40.
             return c;
         }
 
@@ -59,6 +59,7 @@ namespace llama
         }
 
         template<typename ArrayIndex>
+        // NOLINTNEXTLINE(cppcoreguidelines-pro-type-member-init,hicpp-member-init)
         struct FieldBox
         {
             ArrayIndex arrayIndex;
@@ -101,7 +102,7 @@ namespace llama
                 auto address = reinterpret_cast<std::intptr_t>(&ref);
                 for(std::size_t i = 0; i < blobs.size(); i++)
                 {
-                    // TODO: this is UB, because we are comparing pointers from unrelated
+                    // TODO(bgruber): this is UB, because we are comparing pointers from unrelated
                     // allocations
                     const auto front = reinterpret_cast<std::intptr_t>(&blobs[i][0]);
                     const auto back = reinterpret_cast<std::intptr_t>(&blobs[i][view.mapping().blobSize(i) - 1]);
@@ -282,12 +283,10 @@ namespace llama
             {
                 if(info.nrAndOffset.nr < Mapping::blobCount)
                     return info.nrAndOffset.offset;
-                else
-                {
-                    const auto offset = computedSizeSoFar;
-                    computedSizeSoFar += info.size;
-                    return offset;
-                }
+
+                const auto offset = computedSizeSoFar;
+                computedSizeSoFar += info.size;
+                return offset;
             }();
             auto x = (offset % wrapByteCount) * byteSizeInPixel + blobBlockWidth;
             auto y = (offset / wrapByteCount) * byteSizeInPixel + blobY;
@@ -301,8 +300,8 @@ namespace llama
                 const auto& nextInfo = (&info)[1];
                 if(nextInfo.nrAndOffset.nr < Mapping::blobCount)
                     return nextInfo.nrAndOffset.offset;
-                else
-                    return std::numeric_limits<std::size_t>::max();
+
+                return std::numeric_limits<std::size_t>::max();
             }();
             const auto isOverlapped = offset < usedBytesInBlobSoFar || nextOffset < offset + info.size;
             usedBytesInBlobSoFar = offset + info.size;

--- a/include/llama/Proofs.hpp
+++ b/include/llama/Proofs.hpp
@@ -15,7 +15,7 @@ namespace llama
         }
     } // namespace internal
 
-// FIXME: this test is actually not correct, because __cpp_constexpr_dynamic_alloc only guarantees constexpr
+// FIXME(bgruber): this test is actually not correct, because __cpp_constexpr_dynamic_alloc only guarantees constexpr
 // std::allocator
 #ifdef __cpp_constexpr_dynamic_alloc
     namespace internal
@@ -25,10 +25,14 @@ namespace llama
         {
             constexpr DynArray() = default;
 
-            constexpr DynArray(std::size_t n)
+            constexpr explicit DynArray(std::size_t n) : data(new T[n]{})
             {
-                data = new T[n]{};
             }
+
+            DynArray(const DynArray&) = delete;
+            DynArray(DynArray&&) = delete;
+            auto operator=(const DynArray&) -> DynArray& = delete;
+            auto operator=(DynArray&&) -> DynArray& = delete;
 
             constexpr ~DynArray()
             {
@@ -41,7 +45,7 @@ namespace llama
                 data = new T[n]{};
             }
 
-            T* data = nullptr;
+            T* data = nullptr; // TODO(bgruber): replace by std::unique_ptr in C++23
         };
     } // namespace internal
 

--- a/include/llama/RecordCoord.hpp
+++ b/include/llama/RecordCoord.hpp
@@ -136,7 +136,7 @@ namespace llama
 
     /// Checks wether the first RecordCoord is bigger than the second.
     template<typename First, typename Second>
-    inline constexpr auto RecordCoordCommonPrefixIsBigger
+    inline constexpr auto recordCoordCommonPrefixIsBigger
         = internal::recordCoordCommonPrefixIsBiggerImpl(First{}, Second{});
 
     namespace internal
@@ -156,6 +156,6 @@ namespace llama
 
     /// Checks whether two \ref RecordCoord%s are the same or one is the prefix of the other.
     template<typename First, typename Second>
-    inline constexpr auto RecordCoordCommonPrefixIsSame
+    inline constexpr auto recordCoordCommonPrefixIsSame
         = internal::recordCoordCommonPrefixIsSameImpl(First{}, Second{});
 } // namespace llama

--- a/include/llama/RecordRef.hpp
+++ b/include/llama/RecordRef.hpp
@@ -18,10 +18,10 @@ namespace llama
     struct RecordRef;
 
     template<typename View>
-    inline constexpr auto is_RecordRef = false;
+    inline constexpr auto isRecordRef = false;
 
     template<typename View, typename BoundRecordCoord, bool OwnView>
-    inline constexpr auto is_RecordRef<RecordRef<View, BoundRecordCoord, OwnView>> = true;
+    inline constexpr auto isRecordRef<RecordRef<View, BoundRecordCoord, OwnView>> = true;
 
     /// Returns a \ref One with the same record dimension as the given record ref, with values copyied from rr.
     template<typename View, typename BoundRecordCoord, bool OwnView>
@@ -197,7 +197,7 @@ namespace llama
 
         template<typename TWithOptionalConst, typename T>
         LLAMA_FN_HOST_ACC_INLINE auto asTupleImpl(TWithOptionalConst& leaf, T) -> std::
-            enable_if_t<!is_RecordRef<std::decay_t<TWithOptionalConst>>, std::reference_wrapper<TWithOptionalConst>>
+            enable_if_t<!isRecordRef<std::decay_t<TWithOptionalConst>>, std::reference_wrapper<TWithOptionalConst>>
         {
             return leaf;
         }
@@ -222,7 +222,7 @@ namespace llama
 
         template<typename TWithOptionalConst, typename T>
         LLAMA_FN_HOST_ACC_INLINE auto asFlatTupleImpl(TWithOptionalConst& leaf, T)
-            -> std::enable_if_t<!is_RecordRef<std::decay_t<TWithOptionalConst>>, std::tuple<TWithOptionalConst&>>
+            -> std::enable_if_t<!isRecordRef<std::decay_t<TWithOptionalConst>>, std::tuple<TWithOptionalConst&>>
         {
             return {leaf};
         }
@@ -385,7 +385,7 @@ namespace llama
 
         // TODO(bgruber): unify with previous in C++20 and use explicit(cond)
         /// Create a RecordRef from a scalar. Only available for if the view is owned. Used by llama::One.
-        template<typename T, typename = std::enable_if_t<!is_RecordRef<T>>>
+        template<typename T, typename = std::enable_if_t<!isRecordRef<T>>>
         LLAMA_FN_HOST_ACC_INLINE explicit RecordRef(const T& scalar)
             /* requires(OwnView) */
             : RecordRef()
@@ -499,7 +499,7 @@ namespace llama
             return copyRecord(vd) += t;
         }
 
-        template<typename T, typename = std::enable_if_t<!is_RecordRef<T>>>
+        template<typename T, typename = std::enable_if_t<!isRecordRef<T>>>
         LLAMA_FN_HOST_ACC_INLINE friend auto operator+(const T& t, const RecordRef& vd)
         {
             return vd + t;
@@ -517,7 +517,7 @@ namespace llama
             return copyRecord(vd) *= t;
         }
 
-        template<typename T, typename = std::enable_if_t<!is_RecordRef<T>>>
+        template<typename T, typename = std::enable_if_t<!isRecordRef<T>>>
         LLAMA_FN_HOST_ACC_INLINE friend auto operator*(const T& t, const RecordRef& vd)
         {
             return vd * t;
@@ -541,7 +541,7 @@ namespace llama
             return internal::recordRefRelOperator<std::equal_to<>>(vd, t);
         }
 
-        template<typename T, typename = std::enable_if_t<!is_RecordRef<T>>>
+        template<typename T, typename = std::enable_if_t<!isRecordRef<T>>>
         LLAMA_FN_HOST_ACC_INLINE friend auto operator==(const T& t, const RecordRef& vd) -> bool
         {
             return vd == t;
@@ -553,7 +553,7 @@ namespace llama
             return internal::recordRefRelOperator<std::not_equal_to<>>(vd, t);
         }
 
-        template<typename T, typename = std::enable_if_t<!is_RecordRef<T>>>
+        template<typename T, typename = std::enable_if_t<!isRecordRef<T>>>
         LLAMA_FN_HOST_ACC_INLINE friend auto operator!=(const T& t, const RecordRef& vd) -> bool
         {
             return vd != t;
@@ -565,7 +565,7 @@ namespace llama
             return internal::recordRefRelOperator<std::less<>>(vd, t);
         }
 
-        template<typename T, typename = std::enable_if_t<!is_RecordRef<T>>>
+        template<typename T, typename = std::enable_if_t<!isRecordRef<T>>>
         LLAMA_FN_HOST_ACC_INLINE friend auto operator<(const T& t, const RecordRef& vd) -> bool
         {
             return vd > t;
@@ -577,7 +577,7 @@ namespace llama
             return internal::recordRefRelOperator<std::less_equal<>>(vd, t);
         }
 
-        template<typename T, typename = std::enable_if_t<!is_RecordRef<T>>>
+        template<typename T, typename = std::enable_if_t<!isRecordRef<T>>>
         LLAMA_FN_HOST_ACC_INLINE friend auto operator<=(const T& t, const RecordRef& vd) -> bool
         {
             return vd >= t;
@@ -589,7 +589,7 @@ namespace llama
             return internal::recordRefRelOperator<std::greater<>>(vd, t);
         }
 
-        template<typename T, typename = std::enable_if_t<!is_RecordRef<T>>>
+        template<typename T, typename = std::enable_if_t<!isRecordRef<T>>>
         LLAMA_FN_HOST_ACC_INLINE friend auto operator>(const T& t, const RecordRef& vd) -> bool
         {
             return vd < t;
@@ -601,7 +601,7 @@ namespace llama
             return internal::recordRefRelOperator<std::greater_equal<>>(vd, t);
         }
 
-        template<typename T, typename = std::enable_if_t<!is_RecordRef<T>>>
+        template<typename T, typename = std::enable_if_t<!isRecordRef<T>>>
         LLAMA_FN_HOST_ACC_INLINE friend auto operator>=(const T& t, const RecordRef& vd) -> bool
         {
             return vd <= t;
@@ -796,7 +796,7 @@ namespace llama
         };
 
         template<typename T>
-        struct ValueOf<T, std::enable_if_t<is_RecordRef<T>>>
+        struct ValueOf<T, std::enable_if_t<isRecordRef<T>>>
         {
             using type = One<typename T::AccessibleRecordDim>;
         };
@@ -925,7 +925,7 @@ namespace llama
         };
 
         template<typename T>
-        struct ReferenceTo<T, std::enable_if_t<is_RecordRef<T> && !is_One<T>>>
+        struct ReferenceTo<T, std::enable_if_t<isRecordRef<T> && !isOne<T>>>
         {
             using type = T;
         };

--- a/include/llama/RecordRef.hpp
+++ b/include/llama/RecordRef.hpp
@@ -364,7 +364,7 @@ namespace llama
 
         LLAMA_FN_HOST_ACC_INLINE constexpr auto arrayIndex() const -> ArrayIndex
         {
-            return *this;
+            return static_cast<const ArrayIndex&>(*this);
         }
 
         /// Create a RecordRef from a different RecordRef. Only available for if the view is owned. Used by
@@ -828,7 +828,7 @@ namespace llama
         using value_type = typename internal::ValueOf<Reference>::type;
 
         /// Loads a copy of the value referenced by r. Stores r and the loaded value.
-        LLAMA_FN_HOST_ACC_INLINE ScopedUpdate(Reference r) : value_type(r), ref(r)
+        LLAMA_FN_HOST_ACC_INLINE explicit ScopedUpdate(Reference r) : value_type(r), ref(r)
         {
         }
 
@@ -870,7 +870,7 @@ namespace llama
     {
         using value_type = typename internal::ValueOf<Reference>::type;
 
-        LLAMA_FN_HOST_ACC_INLINE ScopedUpdate(Reference r) : value(r), ref(r)
+        LLAMA_FN_HOST_ACC_INLINE explicit ScopedUpdate(Reference r) : value(r), ref(r)
         {
         }
 
@@ -890,11 +890,13 @@ namespace llama
             return value;
         }
 
+        // NOLINTNEXTLINE(google-explicit-constructor,hicpp-explicit-conversions)
         LLAMA_FN_HOST_ACC_INLINE operator const value_type&() const
         {
             return value;
         }
 
+        // NOLINTNEXTLINE(google-explicit-constructor,hicpp-explicit-conversions)
         LLAMA_FN_HOST_ACC_INLINE operator value_type&()
         {
             return value;

--- a/include/llama/StructName.hpp
+++ b/include/llama/StructName.hpp
@@ -12,7 +12,7 @@ namespace llama
     {
         // TODO(bgruber): just use std::copy which became constexpr in C++20
         template<typename In, typename Out>
-        constexpr auto constexpr_copy(In f, In l, Out d)
+        constexpr auto constexprCopy(In f, In l, Out d)
         {
             while(f != l)
                 *d++ = *f++;
@@ -22,18 +22,18 @@ namespace llama
         // TODO(bgruber): just use std::search which became constexpr in C++20
         // from: https://en.cppreference.com/w/cpp/algorithm/search
         template<class ForwardIt1, class ForwardIt2>
-        constexpr ForwardIt1 constexpr_search(ForwardIt1 first, ForwardIt1 last, ForwardIt2 s_first, ForwardIt2 s_last)
+        constexpr ForwardIt1 constexprSearch(ForwardIt1 first, ForwardIt1 last, ForwardIt2 sFirst, ForwardIt2 sLast)
         {
             while(1)
             {
                 ForwardIt1 it = first;
-                for(ForwardIt2 s_it = s_first;; ++it, ++s_it)
+                for(ForwardIt2 sIt = sFirst;; ++it, ++sIt)
                 {
-                    if(s_it == s_last)
+                    if(sIt == sLast)
                         return first;
                     if(it == last)
                         return last;
-                    if(!(*it == *s_it))
+                    if(!(*it == *sIt))
                         break;
                 }
                 ++first;
@@ -43,7 +43,7 @@ namespace llama
         // TODO(bgruber): just use std::remove_copy which became constexpr in C++20
         // from: https://en.cppreference.com/w/cpp/algorithm/remove_copy
         template<class InputIt, class OutputIt, class T>
-        constexpr OutputIt constexpr_remove_copy(InputIt first, InputIt last, OutputIt d_first, const T& value)
+        constexpr OutputIt constexprRemoveCopy(InputIt first, InputIt last, OutputIt d_first, const T& value)
         {
             for(; first != last; ++first)
             {
@@ -58,7 +58,7 @@ namespace llama
         // TODO(bgruber): just use std::count which became constexpr in C++20
         // from: https://en.cppreference.com/w/cpp/algorithm/count
         template<class InputIt, class T>
-        typename std::iterator_traits<InputIt>::difference_type constexpr_count(
+        typename std::iterator_traits<InputIt>::difference_type constexprCount(
             InputIt first,
             InputIt last,
             const T& value)
@@ -132,7 +132,7 @@ namespace llama
             constexpr auto arrAndSize = [&]() constexpr
             {
                 Array<char, name.size()> nameArray{};
-                constexpr_copy(name.begin(), name.end(), nameArray.begin());
+                constexprCopy(name.begin(), name.end(), nameArray.begin());
 
 #ifdef _MSC_VER
                 // MSVC 19.32 runs into a syntax error if we just capture nameArray. Passing it as argument is a
@@ -144,10 +144,10 @@ namespace llama
                     auto e = nameArray.begin() + size;
                     while(true)
                     {
-                        auto it = constexpr_search(nameArray.begin(), e, str.begin(), str.end());
+                        auto it = constexprSearch(nameArray.begin(), e, str.begin(), str.end());
                         if(it == e)
                             break;
-                        constexpr_copy(it + str.size(), e, it);
+                        constexprCopy(it + str.size(), e, it);
                         e -= str.size();
                     }
                     return e - nameArray.begin();
@@ -167,7 +167,7 @@ namespace llama
                     {
                         if((b[0] == '>' && b[1] == ' ' && b[2] == '>') || (b[0] == ',' && b[1] == ' '))
                         {
-                            constexpr_copy(b + 2, e, b + 1);
+                            constexprCopy(b + 2, e, b + 1);
                             e--;
                         }
                     }
@@ -180,7 +180,7 @@ namespace llama
             ();
 
             Array<char, arrAndSize.second> a{};
-            constexpr_copy(arrAndSize.first.begin(), arrAndSize.first.begin() + arrAndSize.second, a.begin());
+            constexprCopy(arrAndSize.first.begin(), arrAndSize.first.begin() + arrAndSize.second, a.begin());
             return a;
         }
 
@@ -235,7 +235,7 @@ namespace llama
                         f--;
 
                     // cut out [f:l[
-                    constexpr_copy(l, e, f);
+                    constexprCopy(l, e, f);
                     e -= (l - f);
                     b = f;
                 }
@@ -245,7 +245,7 @@ namespace llama
             ();
 
             Array<char, arrAndSize.second> a{};
-            constexpr_copy(arrAndSize.first.begin(), arrAndSize.first.begin() + arrAndSize.second, a.begin());
+            constexprCopy(arrAndSize.first.begin(), arrAndSize.first.begin() + arrAndSize.second, a.begin());
             return a;
         }
         ();
@@ -320,7 +320,7 @@ namespace llama
                 else
                 {
                     constexpr auto sn = structName(tag);
-                    constexpr_copy(sn.begin(), sn.end(), w);
+                    constexprCopy(sn.begin(), sn.end(), w);
                     w += sn.size();
                 }
             });

--- a/include/llama/StructName.hpp
+++ b/include/llama/StructName.hpp
@@ -12,7 +12,7 @@ namespace llama
     {
         // TODO(bgruber): just use std::copy which became constexpr in C++20
         template<typename In, typename Out>
-        constexpr auto constexprCopy(In f, In l, Out d)
+        constexpr auto constexprCopy(In f, In l, Out d) -> Out
         {
             while(f != l)
                 *d++ = *f++;
@@ -22,9 +22,10 @@ namespace llama
         // TODO(bgruber): just use std::search which became constexpr in C++20
         // from: https://en.cppreference.com/w/cpp/algorithm/search
         template<class ForwardIt1, class ForwardIt2>
-        constexpr ForwardIt1 constexprSearch(ForwardIt1 first, ForwardIt1 last, ForwardIt2 sFirst, ForwardIt2 sLast)
+        constexpr auto constexprSearch(ForwardIt1 first, ForwardIt1 last, ForwardIt2 sFirst, ForwardIt2 sLast)
+            -> ForwardIt1
         {
-            while(1)
+            while(true)
             {
                 ForwardIt1 it = first;
                 for(ForwardIt2 sIt = sFirst;; ++it, ++sIt)
@@ -43,7 +44,7 @@ namespace llama
         // TODO(bgruber): just use std::remove_copy which became constexpr in C++20
         // from: https://en.cppreference.com/w/cpp/algorithm/remove_copy
         template<class InputIt, class OutputIt, class T>
-        constexpr OutputIt constexprRemoveCopy(InputIt first, InputIt last, OutputIt d_first, const T& value)
+        constexpr auto constexprRemoveCopy(InputIt first, InputIt last, OutputIt d_first, const T& value) -> OutputIt
         {
             for(; first != last; ++first)
             {
@@ -58,10 +59,8 @@ namespace llama
         // TODO(bgruber): just use std::count which became constexpr in C++20
         // from: https://en.cppreference.com/w/cpp/algorithm/count
         template<class InputIt, class T>
-        typename std::iterator_traits<InputIt>::difference_type constexprCount(
-            InputIt first,
-            InputIt last,
-            const T& value)
+        auto constexprCount(InputIt first, InputIt last, const T& value) ->
+            typename std::iterator_traits<InputIt>::difference_type
         {
             typename std::iterator_traits<InputIt>::difference_type ret = 0;
             for(; first != last; ++first)

--- a/include/llama/Tuple.hpp
+++ b/include/llama/Tuple.hpp
@@ -254,7 +254,7 @@ namespace llama
 
     /// Returns a copy of the tuple without the first element.
     template<typename... Elements>
-    LLAMA_FN_HOST_ACC_INLINE constexpr auto pop_front(const Tuple<Elements...>& tuple)
+    LLAMA_FN_HOST_ACC_INLINE constexpr auto popFront(const Tuple<Elements...>& tuple)
     {
         return tuple.rest();
     }

--- a/include/llama/Tuple.hpp
+++ b/include/llama/Tuple.hpp
@@ -31,7 +31,7 @@ namespace llama
         {
             static_assert(!std::is_reference_v<T>, "llama::Tuple cannot store references to stateless types");
 
-            LLAMA_FN_HOST_ACC_INLINE constexpr TupleLeaf(T)
+            LLAMA_FN_HOST_ACC_INLINE constexpr explicit TupleLeaf(T)
             {
             }
 
@@ -79,7 +79,7 @@ namespace llama
                     && std::is_constructible_v<FirstElement, T> && (std::is_constructible_v<RestElements, Ts> && ...),
                 int> = 0>
         LLAMA_FN_HOST_ACC_INLINE constexpr explicit Tuple(T&& firstArg, Ts&&... restArgs)
-            : Leaf{FirstElement(std::forward<T>(firstArg))}
+            : Leaf{static_cast<FirstElement>(std::forward<T>(firstArg))}
             , RestTuple(std::forward<Ts>(restArgs)...)
         {
         }

--- a/include/llama/Vector.hpp
+++ b/include/llama/Vector.hpp
@@ -175,6 +175,7 @@ namespace llama
             return m_view.mapping().extents()[0];
         }
 
+        // NOLINTNEXTLINE(readability-identifier-naming)
         LLAMA_FN_HOST_ACC_INLINE void shrink_to_fit()
         {
             changeCapacity(m_size);
@@ -213,6 +214,7 @@ namespace llama
         // TODO(bgruber): T here is probably a RecordRef. We could also allow any struct that is storable to the
         // view via RecordRef::store().
         template<typename T>
+        // NOLINTNEXTLINE(readability-identifier-naming)
         LLAMA_FN_HOST_ACC_INLINE void push_back(T&& t)
         {
             if(const auto cap = capacity(); m_size == cap)
@@ -223,6 +225,7 @@ namespace llama
 
         // TODO(bgruber): emplace_back
 
+        // NOLINTNEXTLINE(readability-identifier-naming)
         LLAMA_FN_HOST_ACC_INLINE void pop_back()
         {
             m_size--;

--- a/include/llama/View.hpp
+++ b/include/llama/View.hpp
@@ -134,10 +134,10 @@ namespace llama
 
     /// Is true, if T is an instance of \ref One.
     template<typename T>
-    inline constexpr bool is_One = false;
+    inline constexpr bool isOne = false;
 
     template<typename View, typename BoundRecordCoord>
-    inline constexpr bool is_One<RecordRef<View, BoundRecordCoord, true>> = true;
+    inline constexpr bool isOne<RecordRef<View, BoundRecordCoord, true>> = true;
 
     // TODO(bgruber): Higher dimensional iterators might not have good codegen. Multiple nested loops seem to be
     // superior to a single iterator over multiple dimensions. At least compilers are able to produce better code.
@@ -559,10 +559,10 @@ namespace llama
     }
 
     template<typename View>
-    inline constexpr auto IsView = false;
+    inline constexpr auto isView = false;
 
     template<typename Mapping, typename BlobType>
-    inline constexpr auto IsView<View<Mapping, BlobType>> = true;
+    inline constexpr auto isView<View<Mapping, BlobType>> = true;
 
     /// Like a \ref View, but array indices are shifted.
     /// @tparam TStoredParentView Type of the underlying view. May be cv qualified and/or a reference type.

--- a/include/llama/View.hpp
+++ b/include/llama/View.hpp
@@ -364,6 +364,8 @@ namespace llama
             "Mapping::ArrayExtents must not be const qualified or a reference. Are you using decltype(...) as mapping "
             "template argument?");
 
+        /// Performs default initialization of the blob array.
+        // NOLINTNEXTLINE(cppcoreguidelines-pro-type-member-init,hicpp-member-init)
         View() = default;
 
         LLAMA_FN_HOST_ACC_INLINE

--- a/include/llama/mapping/BitPackedFloatSoA.hpp
+++ b/include/llama/mapping/BitPackedFloatSoA.hpp
@@ -80,7 +80,7 @@ namespace llama::mapping
             return outFloat;
         }
 
-        // TODO: Boost.Hana generalizes these sorts of computations on mixed constants and values
+        // TODO(bgruber): Boost.Hana generalizes these sorts of computations on mixed constants and values
         template<typename E, typename M>
         LLAMA_FN_HOST_ACC_INLINE auto integBits(E e, M m)
         {
@@ -255,8 +255,8 @@ namespace llama::mapping
             return internal::BitPackedFloatRef<DstType, QualifiedStoredIntegral*, VHExp, VHMan, size_type>{
                 reinterpret_cast<QualifiedStoredIntegral*>(&blobs[blob][0]),
                 bitOffset,
-                static_cast<VHExp>(*this),
-                static_cast<VHMan>(*this)
+                static_cast<const VHExp&>(*this),
+                static_cast<const VHMan&>(*this)
 #ifndef NDEBUG
                     ,
                 reinterpret_cast<QualifiedStoredIntegral*>(&blobs[blob][0] + blobSize(blob))

--- a/include/llama/mapping/BitPackedIntSoA.hpp
+++ b/include/llama/mapping/BitPackedIntSoA.hpp
@@ -38,6 +38,7 @@ namespace llama::mapping
             StoredIntegralPointer endPtr;
 #endif
 
+            // NOLINTNEXTLINE(bugprone-misplaced-widening-cast)
             static constexpr auto bitsPerStoredIntegral = static_cast<SizeType>(sizeof(StoredIntegral) * CHAR_BIT);
 
         public:
@@ -94,6 +95,7 @@ namespace llama::mapping
 
             LLAMA_FN_HOST_ACC_INLINE constexpr auto operator=(Integral value) -> BitPackedIntRef&
             {
+                // NOLINTNEXTLINE(bugprone-signed-char-misuse,cert-str34-c)
                 const auto unsignedValue = static_cast<StoredIntegral>(value);
                 const auto mask = (StoredIntegral{1} << VHBits::value()) - 1u;
                 StoredIntegral valueBits;
@@ -191,7 +193,10 @@ namespace llama::mapping
 
         using Base::Base;
 
-        LLAMA_FN_HOST_ACC_INLINE constexpr BitPackedIntSoA(TArrayExtents extents, Bits bits = {}, TRecordDim = {})
+        LLAMA_FN_HOST_ACC_INLINE constexpr explicit BitPackedIntSoA(
+            TArrayExtents extents,
+            Bits bits = {},
+            TRecordDim = {})
             : Base(extents)
             , VHBits{bits}
         {
@@ -228,7 +233,7 @@ namespace llama::mapping
             return internal::BitPackedIntRef<DstType, QualifiedStoredIntegral*, VHBits, size_type>{
                 reinterpret_cast<QualifiedStoredIntegral*>(&blobs[blob][0]),
                 bitOffset,
-                static_cast<VHBits>(*this)
+                static_cast<const VHBits&>(*this)
 #ifndef NDEBUG
                     ,
                 reinterpret_cast<QualifiedStoredIntegral*>(&blobs[blob][0] + blobSize(blob))

--- a/include/llama/mapping/ChangeType.hpp
+++ b/include/llama/mapping/ChangeType.hpp
@@ -44,7 +44,8 @@ namespace llama::mapping
         public:
             using value_type = UserT;
 
-            LLAMA_FN_HOST_ACC_INLINE constexpr ChangeTypeReference(StoredT& storageRef) : storageRef{storageRef}
+            LLAMA_FN_HOST_ACC_INLINE constexpr explicit ChangeTypeReference(StoredT& storageRef)
+                : storageRef{storageRef}
             {
             }
 

--- a/include/llama/mapping/Common.hpp
+++ b/include/llama/mapping/Common.hpp
@@ -112,7 +112,7 @@ namespace llama::mapping
                 auto longest = extents[0];
                 for(int i = 1; i < static_cast<int>(ArrayExtents::rank); i++)
                     longest = std::max(longest, extents[i]);
-                const auto longestPO2 = bit_ceil(longest);
+                const auto longestPO2 = bitCeil(longest);
                 return intPow(longestPO2, static_cast<typename ArrayExtents::value_type>(ArrayExtents::rank));
             }
         }
@@ -136,7 +136,7 @@ namespace llama::mapping
 
     private:
         template<typename T>
-        LLAMA_FN_HOST_ACC_INLINE static constexpr auto bit_ceil(T n) -> T
+        LLAMA_FN_HOST_ACC_INLINE static constexpr auto bitCeil(T n) -> T
         {
             T r = 1u;
             while(r < n)

--- a/include/llama/mapping/Common.hpp
+++ b/include/llama/mapping/Common.hpp
@@ -26,7 +26,7 @@ namespace llama::mapping
 
         LLAMA_FN_HOST_ACC_INLINE constexpr auto extents() const -> ArrayExtents
         {
-            return *this;
+            return static_cast<const ArrayExtents&>(*this);
         }
     };
 

--- a/include/llama/mapping/Split.hpp
+++ b/include/llama/mapping/Split.hpp
@@ -60,7 +60,7 @@ namespace llama::mapping
         };
 
         template<typename RC, typename RecordCoordForMapping1>
-        inline constexpr bool isSelected = RecordCoordCommonPrefixIsSame<RecordCoordForMapping1, RC>;
+        inline constexpr bool isSelected = recordCoordCommonPrefixIsSame<RecordCoordForMapping1, RC>;
 
         template<typename RC>
         struct IsSelectedPredicate

--- a/include/llama/mapping/Trace.hpp
+++ b/include/llama/mapping/Trace.hpp
@@ -176,7 +176,7 @@ namespace llama::mapping
                     const size_type i = flatRecordCoord<RecordDim, decltype(rc)>;
                     constexpr auto fieldName = recordCoordTags<RecordDim>(rc);
                     char fieldNameZT[fieldName.size() + 1]{}; // nvcc does not handle the %*.*s parameter correctly
-                    llama::internal::constexpr_copy(fieldName.begin(), fieldName.end(), fieldNameZT);
+                    llama::internal::constexprCopy(fieldName.begin(), fieldName.end(), fieldNameZT);
                     if constexpr(MyCodeHandlesProxyReferences)
                         printf(
                             "%*.s %*lu %*lu\n",

--- a/include/llama/mapping/tree/Functors.hpp
+++ b/include/llama/mapping/tree/Functors.hpp
@@ -226,7 +226,7 @@ namespace llama::mapping::tree::functor
                         + basicCoord.rest().first().arrayIndex;
                     auto rt1Child = TreeCoordElement<BasicCoord::FirstElement::childIndex>{rt1};
                     auto rt2Child = TreeCoordElement<BasicCoord::RestTuple::FirstElement::childIndex>{rt2};
-                    return tupleCat(Tuple{rt1Child}, tupleCat(Tuple{rt2Child}, pop_front(basicCoord.rest())));
+                    return tupleCat(Tuple{rt1Child}, tupleCat(Tuple{rt2Child}, popFront(basicCoord.rest())));
                 }
             }
             else
@@ -236,7 +236,7 @@ namespace llama::mapping::tree::functor
                 else
                 {
                     auto rest = basicCoordToResultCoordImpl<typename InternalTreeCoord::RestTuple>(
-                        pop_front(basicCoord),
+                        popFront(basicCoord),
                         get<BasicCoord::FirstElement::childIndex>(tree.childs));
                     return tupleCat(Tuple{basicCoord.first()}, rest);
                 }

--- a/include/llama/mapping/tree/Mapping.hpp
+++ b/include/llama/mapping/tree/Mapping.hpp
@@ -33,7 +33,7 @@ namespace llama::mapping::tree
             MergeFunctors(const Tree& tree, const Tuple<Operations...>& treeOperationList)
                 : operation(treeOperationList.first())
                 , treeAfterOp(operation.basicToResult(tree))
-                , next(treeAfterOp, pop_front(treeOperationList))
+                , next(treeAfterOp, popFront(treeOperationList))
             {
             }
 

--- a/include/llama/mapping/tree/Mapping.hpp
+++ b/include/llama/mapping/tree/Mapping.hpp
@@ -202,7 +202,7 @@ namespace llama::mapping::tree
 
         LLAMA_FN_HOST_ACC_INLINE auto extents() const -> ArrayExtents
         {
-            return ArrayExtents{*this};
+            return static_cast<const ArrayExtents&>(*this);
         }
 
         LLAMA_FN_HOST_ACC_INLINE

--- a/include/llama/mapping/tree/TreeFromDimensions.hpp
+++ b/include/llama/mapping/tree/TreeFromDimensions.hpp
@@ -151,8 +151,8 @@ namespace llama::mapping::tree
             RecordCoord<FirstRecordCoord, RecordCoords...>)
         {
             return Tuple{
-                TreeCoordElement<(ADIndices == ArrayIndex::rank - 1 ? FirstRecordCoord : 0)>{
-                    (std::size_t) ai[ADIndices]}..., // TODO
+                TreeCoordElement<(ADIndices == ArrayIndex::rank - 1 ? FirstRecordCoord : 0)>{static_cast<std::size_t>(
+                    ai[ADIndices])}..., // TODO(bgruber): we should keep the integer type from the array index
                 TreeCoordElement<RecordCoords, boost::mp11::mp_size_t<0>>{}...,
                 TreeCoordElement<0, boost::mp11::mp_size_t<0>>{}};
         }

--- a/include/llama/mapping/tree/toString.hpp
+++ b/include/llama/mapping/tree/toString.hpp
@@ -38,7 +38,7 @@ namespace llama::mapping::tree
 
     namespace internal
     {
-        inline void replace_all(std::string& str, const std::string& search, const std::string& replace)
+        inline void replaceAll(std::string& str, const std::string& search, const std::string& replace)
         {
             std::string::size_type i = 0;
             while((i = str.find(search, i)) != std::string::npos)
@@ -72,10 +72,10 @@ namespace llama::mapping::tree
     {
         auto raw = std::string{llama::structName<Type>()};
 #ifdef _MSC_VER
-        internal::replace_all(raw, " __cdecl(void)", "");
+        internal::replaceAll(raw, " __cdecl(void)", "");
 #endif
 #ifdef __GNUG__
-        internal::replace_all(raw, " ()", "");
+        internal::replaceAll(raw, " ()", "");
 #endif
         return internal::countAndIdentToString(leaf) + "(" + raw + ")";
     }

--- a/tests/array.cpp
+++ b/tests/array.cpp
@@ -77,34 +77,34 @@ TEST_CASE("Array.operator<<")
     CHECK(put(llama::Array{1.1, 2.2, 3.3}) == "Array{1.1, 2.2, 3.3}");
 }
 
-TEST_CASE("Array.push_front")
+TEST_CASE("Array.pushFront")
 {
-    STATIC_REQUIRE(push_front(llama::Array<int, 0>{}, 1) == llama::Array{1});
-    STATIC_REQUIRE(push_front(llama::Array{1}, 42) == llama::Array{42, 1});
-    STATIC_REQUIRE(push_front(llama::Array{1, 2}, 42) == llama::Array{42, 1, 2});
-    STATIC_REQUIRE(push_front(llama::Array{1, 2, 3}, 42) == llama::Array{42, 1, 2, 3});
+    STATIC_REQUIRE(pushFront(llama::Array<int, 0>{}, 1) == llama::Array{1});
+    STATIC_REQUIRE(pushFront(llama::Array{1}, 42) == llama::Array{42, 1});
+    STATIC_REQUIRE(pushFront(llama::Array{1, 2}, 42) == llama::Array{42, 1, 2});
+    STATIC_REQUIRE(pushFront(llama::Array{1, 2, 3}, 42) == llama::Array{42, 1, 2, 3});
 }
 
-TEST_CASE("Array.push_back")
+TEST_CASE("Array.pushBack")
 {
-    STATIC_REQUIRE(push_back(llama::Array<int, 0>{}, 1) == llama::Array{1});
-    STATIC_REQUIRE(push_back(llama::Array{1}, 42) == llama::Array{1, 42});
-    STATIC_REQUIRE(push_back(llama::Array{1, 2}, 42) == llama::Array{1, 2, 42});
-    STATIC_REQUIRE(push_back(llama::Array{1, 2, 3}, 42) == llama::Array{1, 2, 3, 42});
+    STATIC_REQUIRE(pushBack(llama::Array<int, 0>{}, 1) == llama::Array{1});
+    STATIC_REQUIRE(pushBack(llama::Array{1}, 42) == llama::Array{1, 42});
+    STATIC_REQUIRE(pushBack(llama::Array{1, 2}, 42) == llama::Array{1, 2, 42});
+    STATIC_REQUIRE(pushBack(llama::Array{1, 2, 3}, 42) == llama::Array{1, 2, 3, 42});
 }
 
-TEST_CASE("Array.pop_front")
+TEST_CASE("Array.popFront")
 {
-    STATIC_REQUIRE(pop_front(llama::Array{1}) == llama::Array<int, 0>{});
-    STATIC_REQUIRE(pop_front(llama::Array{1, 2}) == llama::Array{2});
-    STATIC_REQUIRE(pop_front(llama::Array{3, 2, 1}) == llama::Array{2, 1});
+    STATIC_REQUIRE(popFront(llama::Array{1}) == llama::Array<int, 0>{});
+    STATIC_REQUIRE(popFront(llama::Array{1, 2}) == llama::Array{2});
+    STATIC_REQUIRE(popFront(llama::Array{3, 2, 1}) == llama::Array{2, 1});
 }
 
-TEST_CASE("Array.pop_back")
+TEST_CASE("Array.popBack")
 {
-    STATIC_REQUIRE(pop_back(llama::Array{1}) == llama::Array<int, 0>{});
-    STATIC_REQUIRE(pop_back(llama::Array{1, 2}) == llama::Array{1});
-    STATIC_REQUIRE(pop_back(llama::Array{3, 2, 1}) == llama::Array{3, 2});
+    STATIC_REQUIRE(popBack(llama::Array{1}) == llama::Array<int, 0>{});
+    STATIC_REQUIRE(popBack(llama::Array{1, 2}) == llama::Array{1});
+    STATIC_REQUIRE(popBack(llama::Array{3, 2, 1}) == llama::Array{3, 2});
 }
 
 TEST_CASE("Array.product")

--- a/tests/common.hpp
+++ b/tests/common.hpp
@@ -9,6 +9,7 @@
 #include <string>
 #include <typeinfo>
 
+// NOLINTNEXTLINE(google-runtime-int)
 using SizeTypes = boost::mp11::mp_list<int, unsigned, long, unsigned long, long long, unsigned long long>;
 static_assert(boost::mp11::mp_contains<SizeTypes, std::size_t>::value);
 
@@ -64,7 +65,7 @@ using ParticleUnaligned = llama::Record<
 >;
 // clang-format on
 
-// TODO: replace by boost::core::type_name<T>() once released and available
+// TODO(bgruber): replace by boost::core::type_name<T>() once released and available
 template<typename T>
 auto prettyPrintType(const T& t = {}) -> std::string
 {

--- a/tests/common.hpp
+++ b/tests/common.hpp
@@ -68,12 +68,12 @@ using ParticleUnaligned = llama::Record<
 template<typename T>
 auto prettyPrintType(const T& t = {}) -> std::string
 {
-    using llama::mapping::tree::internal::replace_all;
+    using llama::mapping::tree::internal::replaceAll;
 
     auto raw = boost::core::demangle(typeid(t).name());
 #ifdef _MSC_VER
     // remove clutter in MSVC
-    replace_all(raw, "struct ", "");
+    replaceAll(raw, "struct ", "");
 #endif
 #ifdef __GNUG__
     // remove clutter in g++
@@ -81,14 +81,14 @@ auto prettyPrintType(const T& t = {}) -> std::string
     raw = std::regex_replace(raw, ulLiteral, "$1");
 #endif
 
-    replace_all(raw, "<", "<\n");
+    replaceAll(raw, "<", "<\n");
 #ifdef _MSC_VER
-    replace_all(raw, ",", ",\n");
+    replaceAll(raw, ",", ",\n");
 #else
-    replace_all(raw, ", ", ",\n");
+    replaceAll(raw, ", ", ",\n");
 #endif
-    replace_all(raw, " >", ">");
-    replace_all(raw, ">", "\n>");
+    replaceAll(raw, " >", ">");
+    replaceAll(raw, ">", "\n>");
 
     std::stringstream rawSS(raw);
     std::string token;

--- a/tests/computedprop.cpp
+++ b/tests/computedprop.cpp
@@ -22,7 +22,7 @@ namespace
         template<std::size_t... RecordCoords>
         static constexpr auto isComputed(llama::RecordCoord<RecordCoords...>)
         {
-            return llama::RecordCoordCommonPrefixIsSame<llama::RecordCoord<RecordCoords...>, llama::RecordCoord<3>>;
+            return llama::recordCoordCommonPrefixIsSame<llama::RecordCoord<RecordCoords...>, llama::RecordCoord<3>>;
         }
 
         template<std::size_t... RecordCoords, typename Blob>

--- a/tests/core.cpp
+++ b/tests/core.cpp
@@ -4,7 +4,7 @@ TEST_CASE("prettyPrintType")
 {
     auto str = prettyPrintType<Particle>();
 #ifdef _WIN32
-    llama::mapping::tree::internal::replace_all(str, "__int64", "long");
+    llama::mapping::tree::internal::replaceAll(str, "__int64", "long");
 #endif
     const auto* const ref = R"(llama::Record<
     llama::Field<

--- a/tests/iterator.cpp
+++ b/tests/iterator.cpp
@@ -252,8 +252,8 @@ TEST_CASE("ranges")
 
 TEST_CASE("iterator.sort")
 {
-    constexpr auto N = 10;
-    auto view = llama::allocViewUninitialized(llama::mapping::AoS{llama::ArrayExtents<std::size_t, N>{}, Position{}});
+    constexpr auto n = 10;
+    auto view = llama::allocViewUninitialized(llama::mapping::AoS{llama::ArrayExtents<std::size_t, n>{}, Position{}});
 
     std::default_random_engine e{};
     std::uniform_int_distribution<int> d{0, 1000};
@@ -263,10 +263,10 @@ TEST_CASE("iterator.sort")
         vd(tag::Y{}) = d(e);
         vd(tag::Z{}) = d(e);
     }
-    auto manhattan_less = [](auto a, auto b)
+    auto manhattanLess = [](auto a, auto b)
     { return a(tag::X{}) + a(tag::Y{}) + a(tag::Z{}) < b(tag::X{}) + b(tag::Y{}) + b(tag::Z{}); };
-    std::sort(begin(view), end(view), manhattan_less);
+    std::sort(begin(view), end(view), manhattanLess);
 
-    for(auto i = 1; i < N; i++)
-        CHECK(manhattan_less(view[i - 1], view[i]));
+    for(auto i = 1; i < n; i++)
+        CHECK(manhattanLess(view[i - 1], view[i]));
 }

--- a/tests/mapping.BitPackedFloatSoA.cpp
+++ b/tests/mapping.BitPackedFloatSoA.cpp
@@ -132,11 +132,11 @@ TEMPLATE_TEST_CASE("mapping.BitPackedFloatSoA", "", float, double)
 
 TEST_CASE("mapping.BitPackedFloatSoA.ReducedPrecisionComputation")
 {
-    constexpr auto N = 1000;
-    auto view = llama::allocView(llama::mapping::AoS<llama::ArrayExtents<std::size_t, N>, Vec3D>{{}});
+    constexpr auto n = 1000;
+    auto view = llama::allocView(llama::mapping::AoS<llama::ArrayExtents<std::size_t, n>, Vec3D>{{}});
     std::default_random_engine engine;
     std::uniform_real_distribution dist{0.0f, 1e20f};
-    for(auto i = 0; i < N; i++)
+    for(auto i = 0; i < n; i++)
     {
         auto v = dist(engine);
         view(i) = v;
@@ -145,7 +145,7 @@ TEST_CASE("mapping.BitPackedFloatSoA.ReducedPrecisionComputation")
 
     // copy into packed representation
     auto packedView = llama::allocView(llama::mapping::BitPackedFloatSoA<
-                                       llama::ArrayExtents<std::size_t, N>,
+                                       llama::ArrayExtents<std::size_t, n>,
                                        Vec3D,
                                        llama::Constant<8>,
                                        llama::Constant<23>>{}); // basically
@@ -153,20 +153,20 @@ TEST_CASE("mapping.BitPackedFloatSoA.ReducedPrecisionComputation")
     llama::copy(view, packedView);
 
     // compute on original representation
-    for(auto i = 0; i < N; i++)
+    for(auto i = 0; i < n; i++)
     {
         auto&& z = view(i)(tag::Z{});
         z = std::sqrt(z);
     }
 
     // compute on packed representation
-    for(auto i = 0; i < N; i++)
+    for(auto i = 0; i < n; i++)
     {
         auto&& z = packedView(i)(tag::Z{});
         z = std::sqrt(z);
     }
 
-    for(auto i = 0; i < N; i++)
+    for(auto i = 0; i < n; i++)
         CHECK(view(i)(tag::Z{}) == Catch::Approx(packedView(i)(tag::Z{})));
 }
 

--- a/tests/mapping.BitPackedIntSoA.cpp
+++ b/tests/mapping.BitPackedIntSoA.cpp
@@ -100,31 +100,31 @@ TEST_CASE("mapping.BitPackedIntSoA.SInts.Cutoff")
 
 TEST_CASE("mapping.BitPackedIntSoA.SInts.Roundtrip")
 {
-    constexpr auto N = 1000;
-    auto view = llama::allocView(llama::mapping::AoS<llama::ArrayExtents<std::size_t, N>, Vec3I>{});
+    constexpr auto n = 1000;
+    auto view = llama::allocView(llama::mapping::AoS<llama::ArrayExtents<std::size_t, n>, Vec3I>{});
     std::default_random_engine engine;
     std::uniform_int_distribution dist{-2000, 2000}; // fits into 12 bits
-    for(auto i = 0; i < N; i++)
+    for(auto i = 0; i < n; i++)
         view(i) = dist(engine);
 
     // copy into packed representation
     auto packedView = llama::allocView(
-        llama::mapping::BitPackedIntSoA<llama::ArrayExtents<std::size_t, N>, Vec3I, llama::Constant<12>>{});
+        llama::mapping::BitPackedIntSoA<llama::ArrayExtents<std::size_t, n>, Vec3I, llama::Constant<12>>{});
     llama::copy(view, packedView);
 
     // compute on packed representation
-    for(auto i = 0; i < N; i++)
+    for(auto i = 0; i < n; i++)
         packedView(i) = packedView(i) + 1;
 
     // copy into normal representation
-    auto view2 = llama::allocView(llama::mapping::AoS<llama::ArrayExtents<std::size_t, N>, Vec3I>{});
+    auto view2 = llama::allocView(llama::mapping::AoS<llama::ArrayExtents<std::size_t, n>, Vec3I>{});
     llama::copy(packedView, view2);
 
     // compute on normal representation
-    for(auto i = 0; i < N; i++)
+    for(auto i = 0; i < n; i++)
         view2(i) = view2(i) - 1;
 
-    for(auto i = 0; i < N; i++)
+    for(auto i = 0; i < n; i++)
         CHECK(view(i) == view2(i));
 }
 

--- a/tests/mapping.HeatmapTrace.cpp
+++ b/tests/mapping.HeatmapTrace.cpp
@@ -6,31 +6,31 @@
 
 namespace
 {
-    constexpr auto N = 100;
+    constexpr auto n = 100;
 
     template<typename View>
     auto updateAndMove(View& particles)
     {
-        constexpr float TIMESTEP = 0.0001f;
-        constexpr float EPS2 = 0.01f;
-        for(std::size_t i = 0; i < N; i++)
+        constexpr float timestep = 0.0001f;
+        constexpr float epS2 = 0.01f;
+        for(std::size_t i = 0; i < n; i++)
         {
             llama::One<ParticleHeatmap> pi = particles(i);
-            for(std::size_t j = 0; j < N; ++j)
+            for(std::size_t j = 0; j < n; ++j)
             {
                 auto pj = particles(j);
                 auto dist = pi(tag::Pos{}) - pj(tag::Pos{});
                 dist *= dist;
-                const float distSqr = EPS2 + dist(tag::X{}) + dist(tag::Y{}) + dist(tag::Z{});
+                const float distSqr = epS2 + dist(tag::X{}) + dist(tag::Y{}) + dist(tag::Z{});
                 const float distSixth = distSqr * distSqr * distSqr;
                 const float invDistCube = 1.0f / std::sqrt(distSixth);
-                const float sts = pj(tag::Mass{}) * invDistCube * TIMESTEP;
+                const float sts = pj(tag::Mass{}) * invDistCube * timestep;
                 pi(tag::Vel{}) += dist * sts;
             }
             particles(i) = pi;
         }
-        for(std::size_t i = 0; i < N; i++)
-            particles(i)(tag::Pos{}) += particles(i)(tag::Vel{}) * TIMESTEP;
+        for(std::size_t i = 0; i < n; i++)
+            particles(i)(tag::Pos{}) += particles(i)(tag::Vel{}) * timestep;
     }
 
     extern std::string_view heatmapAlignedAoS;
@@ -51,10 +51,10 @@ TEST_CASE("Heatmap.nbody")
     };
     run("AlignedAoS",
         heatmapAlignedAoS,
-        llama::mapping::AlignedAoS<llama::ArrayExtents<std::size_t, N>, ParticleHeatmap>{});
+        llama::mapping::AlignedAoS<llama::ArrayExtents<std::size_t, n>, ParticleHeatmap>{});
     run("SingleBlobSoA",
         heatmapSingleBlobSoA,
-        llama::mapping::PackedSingleBlobSoA<llama::ArrayExtents<std::size_t, N>, ParticleHeatmap>{});
+        llama::mapping::PackedSingleBlobSoA<llama::ArrayExtents<std::size_t, n>, ParticleHeatmap>{});
 }
 
 TEST_CASE("Trace.ctor")
@@ -106,8 +106,8 @@ Vel.Z             300
 Mass            10200
 )");
     };
-    run(llama::mapping::AlignedAoS<llama::ArrayExtents<std::size_t, N>, ParticleHeatmap>{});
-    run(llama::mapping::PackedSingleBlobSoA<llama::ArrayExtents<std::size_t, N>, ParticleHeatmap>{});
+    run(llama::mapping::AlignedAoS<llama::ArrayExtents<std::size_t, n>, ParticleHeatmap>{});
+    run(llama::mapping::PackedSingleBlobSoA<llama::ArrayExtents<std::size_t, n>, ParticleHeatmap>{});
 }
 
 TEMPLATE_LIST_TEST_CASE("Trace.nbody.reads_writes", "", SizeTypes)
@@ -147,8 +147,8 @@ Vel.Z             200        100
 Mass            10100        100
 )");
     };
-    run(llama::mapping::AlignedAoS<llama::ArrayExtents<std::size_t, N>, ParticleHeatmap>{});
-    run(llama::mapping::PackedSingleBlobSoA<llama::ArrayExtents<std::size_t, N>, ParticleHeatmap>{});
+    run(llama::mapping::AlignedAoS<llama::ArrayExtents<std::size_t, n>, ParticleHeatmap>{});
+    run(llama::mapping::PackedSingleBlobSoA<llama::ArrayExtents<std::size_t, n>, ParticleHeatmap>{});
 }
 
 TEST_CASE("Trace.assign_ref_to_ref")

--- a/tests/mapping.Split.cpp
+++ b/tests/mapping.Split.cpp
@@ -190,7 +190,7 @@ TEST_CASE("mapping.Split.BitPacked")
         llama::mapping::BindBitPackedIntSoA<llama::Constant<3>>::fn,
         llama::mapping::
             BindSplit<llama::RecordCoord<0>, llama::mapping::BitPackedIntSoA, llama::mapping::PackedAoS, true>::fn,
-        true>{{extents}, {std::tuple{extents, 5}, std::tuple{extents}}};
+        true>{std::tuple{extents}, std::tuple{std::tuple{extents, 5}, std::tuple{extents}}};
 
     STATIC_REQUIRE(mapping.blobCount == 3);
     CHECK(mapping.blobSize(0) == 12);

--- a/tests/mapping.Tree.cpp
+++ b/tests/mapping.Tree.cpp
@@ -779,10 +779,10 @@ TEST_CASE("mapping.Tree")
 #ifndef __NVCOMPILER
     auto raw = prettyPrintType(mapping.basicTree);
 #    ifdef _WIN32
-    tree::internal::replace_all(raw, "__int64", "long");
+    tree::internal::replaceAll(raw, "__int64", "long");
 #    endif
 #    ifdef _LIBCPP_VERSION
-    tree::internal::replace_all(raw, "std::__1::", "std::");
+    tree::internal::replaceAll(raw, "std::__1::", "std::");
 #    endif
     const auto* const ref = R"(llama::mapping::tree::Node<
     llama::NoName,
@@ -924,10 +924,10 @@ TEST_CASE("mapping.Tree")
 
     auto raw2 = prettyPrintType(mapping.resultTree);
 #ifdef _WIN32
-    tree::internal::replace_all(raw2, "__int64", "long");
+    tree::internal::replaceAll(raw2, "__int64", "long");
 #endif
 #ifdef _LIBCPP_VERSION
-    tree::internal::replace_all(raw2, "std::__1::", "std::");
+    tree::internal::replaceAll(raw2, "std::__1::", "std::");
 #endif
     const auto* const ref2 = R"(llama::mapping::tree::Node<
     llama::NoName,

--- a/tests/proofs.cpp
+++ b/tests/proofs.cpp
@@ -128,7 +128,8 @@ TEST_CASE("mapsNonOverlappingly.ModulusMapping")
 
 TEST_CASE("maps.ModulusMapping")
 {
-    constexpr auto extents = llama::ArrayExtentsDynamic<std::size_t, 1>{128};
+    using Extents = llama::ArrayExtentsDynamic<std::size_t, 1>;
+    constexpr auto extents = Extents{128};
     STATIC_REQUIRE(llama::mapsPiecewiseContiguous<1>(llama::mapping::AoS{extents, Particle{}}));
     STATIC_REQUIRE(!llama::mapsPiecewiseContiguous<8>(llama::mapping::AoS{extents, Particle{}}));
     STATIC_REQUIRE(!llama::mapsPiecewiseContiguous<16>(llama::mapping::AoS{extents, Particle{}}));
@@ -137,9 +138,9 @@ TEST_CASE("maps.ModulusMapping")
     STATIC_REQUIRE(llama::mapsPiecewiseContiguous<8>(llama::mapping::SoA{extents, Particle{}}));
     STATIC_REQUIRE(llama::mapsPiecewiseContiguous<16>(llama::mapping::SoA{extents, Particle{}}));
 
-    STATIC_REQUIRE(llama::mapsPiecewiseContiguous<1>(llama::mapping::AoSoA<decltype(extents), Particle, 8>{extents}));
+    STATIC_REQUIRE(llama::mapsPiecewiseContiguous<1>(llama::mapping::AoSoA<Extents, Particle, 8>{extents}));
     STATIC_REQUIRE(
-        llama::mapsPiecewiseContiguous<8>(llama::mapping::AoSoA<decltype(extents), Particle, 8>{extents, Particle{}}));
-    STATIC_REQUIRE(!llama::mapsPiecewiseContiguous<16>(
-        llama::mapping::AoSoA<decltype(extents), Particle, 8>{extents, Particle{}}));
+        llama::mapsPiecewiseContiguous<8>(llama::mapping::AoSoA<Extents, Particle, 8>{extents, Particle{}}));
+    STATIC_REQUIRE(
+        !llama::mapsPiecewiseContiguous<16>(llama::mapping::AoSoA<Extents, Particle, 8>{extents, Particle{}}));
 }

--- a/tests/recordcoord.cpp
+++ b/tests/recordcoord.cpp
@@ -92,30 +92,30 @@ TEST_CASE("cat")
         == llama::RecordCoord<1, 2, 3, 4, 5, 6, 7>{});
 }
 
-TEST_CASE("RecordCoordCommonPrefixIsBigger")
+TEST_CASE("recordCoordCommonPrefixIsBigger")
 {
     // clang-format off
-    STATIC_REQUIRE( llama::RecordCoordCommonPrefixIsBigger<llama::RecordCoord<1, 0, 0>, llama::RecordCoord<0, 0, 0>>);
-    STATIC_REQUIRE( llama::RecordCoordCommonPrefixIsBigger<llama::RecordCoord<0, 1, 0>, llama::RecordCoord<0, 0, 0>>);
-    STATIC_REQUIRE( llama::RecordCoordCommonPrefixIsBigger<llama::RecordCoord<0, 0, 1>, llama::RecordCoord<0, 0, 0>>);
+    STATIC_REQUIRE( llama::recordCoordCommonPrefixIsBigger<llama::RecordCoord<1, 0, 0>, llama::RecordCoord<0, 0, 0>>);
+    STATIC_REQUIRE( llama::recordCoordCommonPrefixIsBigger<llama::RecordCoord<0, 1, 0>, llama::RecordCoord<0, 0, 0>>);
+    STATIC_REQUIRE( llama::recordCoordCommonPrefixIsBigger<llama::RecordCoord<0, 0, 1>, llama::RecordCoord<0, 0, 0>>);
 
-    STATIC_REQUIRE( llama::RecordCoordCommonPrefixIsBigger<llama::RecordCoord<1, 0, 0>, llama::RecordCoord<0, 0   >>);
-    STATIC_REQUIRE( llama::RecordCoordCommonPrefixIsBigger<llama::RecordCoord<1, 0, 0>, llama::RecordCoord<0      >>);
-    STATIC_REQUIRE( llama::RecordCoordCommonPrefixIsBigger<llama::RecordCoord<1, 0   >, llama::RecordCoord<0, 0, 0>>);
-    STATIC_REQUIRE( llama::RecordCoordCommonPrefixIsBigger<llama::RecordCoord<1      >, llama::RecordCoord<0, 0, 0>>);
+    STATIC_REQUIRE( llama::recordCoordCommonPrefixIsBigger<llama::RecordCoord<1, 0, 0>, llama::RecordCoord<0, 0   >>);
+    STATIC_REQUIRE( llama::recordCoordCommonPrefixIsBigger<llama::RecordCoord<1, 0, 0>, llama::RecordCoord<0      >>);
+    STATIC_REQUIRE( llama::recordCoordCommonPrefixIsBigger<llama::RecordCoord<1, 0   >, llama::RecordCoord<0, 0, 0>>);
+    STATIC_REQUIRE( llama::recordCoordCommonPrefixIsBigger<llama::RecordCoord<1      >, llama::RecordCoord<0, 0, 0>>);
 
-    STATIC_REQUIRE(!llama::RecordCoordCommonPrefixIsBigger<llama::RecordCoord<0, 0, 0>, llama::RecordCoord<0, 0, 0>>);
-    STATIC_REQUIRE(!llama::RecordCoordCommonPrefixIsBigger<llama::RecordCoord<0, 0, 0>, llama::RecordCoord<0, 0, 0>>);
-    STATIC_REQUIRE(!llama::RecordCoordCommonPrefixIsBigger<llama::RecordCoord<0, 0, 0>, llama::RecordCoord<1, 0, 0>>);
-    STATIC_REQUIRE(!llama::RecordCoordCommonPrefixIsBigger<llama::RecordCoord<0, 0, 0>, llama::RecordCoord<0, 1, 0>>);
-    STATIC_REQUIRE(!llama::RecordCoordCommonPrefixIsBigger<llama::RecordCoord<0, 0, 0>, llama::RecordCoord<0, 0, 1>>);
+    STATIC_REQUIRE(!llama::recordCoordCommonPrefixIsBigger<llama::RecordCoord<0, 0, 0>, llama::RecordCoord<0, 0, 0>>);
+    STATIC_REQUIRE(!llama::recordCoordCommonPrefixIsBigger<llama::RecordCoord<0, 0, 0>, llama::RecordCoord<0, 0, 0>>);
+    STATIC_REQUIRE(!llama::recordCoordCommonPrefixIsBigger<llama::RecordCoord<0, 0, 0>, llama::RecordCoord<1, 0, 0>>);
+    STATIC_REQUIRE(!llama::recordCoordCommonPrefixIsBigger<llama::RecordCoord<0, 0, 0>, llama::RecordCoord<0, 1, 0>>);
+    STATIC_REQUIRE(!llama::recordCoordCommonPrefixIsBigger<llama::RecordCoord<0, 0, 0>, llama::RecordCoord<0, 0, 1>>);
 
-    STATIC_REQUIRE(!llama::RecordCoordCommonPrefixIsBigger<llama::RecordCoord<1      >, llama::RecordCoord<1, 0, 0>>);
-    STATIC_REQUIRE(!llama::RecordCoordCommonPrefixIsBigger<llama::RecordCoord<1      >, llama::RecordCoord<1, 1, 0>>);
-    STATIC_REQUIRE(!llama::RecordCoordCommonPrefixIsBigger<llama::RecordCoord<1      >, llama::RecordCoord<1, 1, 1>>);
+    STATIC_REQUIRE(!llama::recordCoordCommonPrefixIsBigger<llama::RecordCoord<1      >, llama::RecordCoord<1, 0, 0>>);
+    STATIC_REQUIRE(!llama::recordCoordCommonPrefixIsBigger<llama::RecordCoord<1      >, llama::RecordCoord<1, 1, 0>>);
+    STATIC_REQUIRE(!llama::recordCoordCommonPrefixIsBigger<llama::RecordCoord<1      >, llama::RecordCoord<1, 1, 1>>);
 
-    STATIC_REQUIRE(!llama::RecordCoordCommonPrefixIsBigger<llama::RecordCoord<0, 0   >, llama::RecordCoord<0, 0, 1>>);
-    STATIC_REQUIRE(!llama::RecordCoordCommonPrefixIsBigger<llama::RecordCoord<0      >, llama::RecordCoord<0, 0, 1>>);
+    STATIC_REQUIRE(!llama::recordCoordCommonPrefixIsBigger<llama::RecordCoord<0, 0   >, llama::RecordCoord<0, 0, 1>>);
+    STATIC_REQUIRE(!llama::recordCoordCommonPrefixIsBigger<llama::RecordCoord<0      >, llama::RecordCoord<0, 0, 1>>);
     // clang-format on
 }
 

--- a/tests/recordref.cpp
+++ b/tests/recordref.cpp
@@ -1163,7 +1163,7 @@ TEST_CASE("ScopedUpdate.RecordRef")
         llama::forEachLeaf(v, [i = 0](auto& field) mutable { field = ++i; });
         {
             llama::ScopedUpdate u(v);
-            if constexpr(llama::is_One<std::remove_reference_t<decltype(v)>>)
+            if constexpr(llama::isOne<std::remove_reference_t<decltype(v)>>)
             {
                 STATIC_REQUIRE(
                     std::is_same_v<decltype(u), llama::ScopedUpdate<std::remove_reference_t<decltype(v)>&>>);

--- a/tests/tuple.cpp
+++ b/tests/tuple.cpp
@@ -139,9 +139,9 @@ TEST_CASE("Tuple.tupleTransform")
     STATIC_REQUIRE(llama::tupleTransform(llama::Tuple{1, 1.0f}, f) == llama::Tuple{2, 2.0f});
 }
 
-TEST_CASE("Tuple.pop_front")
+TEST_CASE("Tuple.popFront")
 {
-    STATIC_REQUIRE(llama::pop_front(llama::Tuple{1}) == llama::Tuple{});
-    STATIC_REQUIRE(llama::pop_front(llama::Tuple{1, 1.0f}) == llama::Tuple{1.0f});
-    STATIC_REQUIRE(llama::pop_front(llama::Tuple{1.0f, 1, nullptr}) == llama::Tuple{1, nullptr});
+    STATIC_REQUIRE(llama::popFront(llama::Tuple{1}) == llama::Tuple{});
+    STATIC_REQUIRE(llama::popFront(llama::Tuple{1, 1.0f}) == llama::Tuple{1.0f});
+    STATIC_REQUIRE(llama::popFront(llama::Tuple{1.0f, 1, nullptr}) == llama::Tuple{1, nullptr});
 }


### PR DESCRIPTION
The names used in LLAMA have grown too inconsistent over time. Mostly a mix of `camelBack`, `CamelCase` and `snake_case` is used. This PR enables several more identifier naming checks in clang-tidy and enforces them in the CI.