### PR TITLE
Add codecov token

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -101,6 +101,7 @@ jobs:
     - name: upload coverage report
       uses: codecov/codecov-action@v3
       with:
+        token: ${{ secrets.CODECOV_TOKEN }}
         fail_ci_if_error: true
         verbose: true
 


### PR DESCRIPTION
This should help use avoid rate limits with the GitHub CI which lead to CI failures.