### PR TITLE
Support proxy references in RecordRef tuple interface

### DIFF
--- a/include/llama/Core.hpp
+++ b/include/llama/Core.hpp
@@ -698,6 +698,22 @@ namespace llama
 
     namespace internal
     {
+        template<typename T>
+        struct IsConstant : std::false_type
+        {
+        };
+
+        template<typename T, T V>
+        struct IsConstant<std::integral_constant<T, V>> : std::true_type
+        {
+        };
+    } // namespace internal
+
+    template<typename T>
+    inline constexpr bool isConstant = internal::IsConstant<T>::value;
+
+    namespace internal
+    {
         /// Holds a value of type T. Is useful as a base class. Is specialized for llama::Constant to not store the
         /// value at runtime. \tparam T Type of value to store. \tparam I Is used to disambiguate multiple BoxedValue
         /// base classes.

--- a/include/llama/RecordRef.hpp
+++ b/include/llama/RecordRef.hpp
@@ -195,6 +195,13 @@ namespace llama
             }
         };
 
+        template<typename ProxyReference, typename T>
+        LLAMA_FN_HOST_ACC_INLINE auto asTupleImpl(ProxyReference&& leaf, T)
+            -> std::enable_if_t<!isRecordRef<std::decay_t<ProxyReference>>, ProxyReference>
+        {
+            return leaf;
+        }
+
         template<typename TWithOptionalConst, typename T>
         LLAMA_FN_HOST_ACC_INLINE auto asTupleImpl(TWithOptionalConst& leaf, T) -> std::
             enable_if_t<!isRecordRef<std::decay_t<TWithOptionalConst>>, std::reference_wrapper<TWithOptionalConst>>
@@ -218,6 +225,13 @@ namespace llama
         LLAMA_FN_HOST_ACC_INLINE auto asTupleImpl(RecordRef&& vd, Record<Fields...>)
         {
             return std::make_tuple(asTupleImpl(vd(GetFieldTag<Fields>{}), GetFieldType<Fields>{})...);
+        }
+
+        template<typename ProxyReference, typename T>
+        LLAMA_FN_HOST_ACC_INLINE auto asFlatTupleImpl(ProxyReference&& leaf, T)
+            -> std::enable_if_t<!isRecordRef<std::decay_t<ProxyReference>>, std::tuple<ProxyReference>>
+        {
+            return {std::move(leaf)};
         }
 
         template<typename TWithOptionalConst, typename T>

--- a/include/llama/mapping/BitPackedIntSoA.hpp
+++ b/include/llama/mapping/BitPackedIntSoA.hpp
@@ -191,12 +191,19 @@ namespace llama::mapping
     public:
         static constexpr std::size_t blobCount = boost::mp11::mp_size<FlatRecordDim<TRecordDim>>::value;
 
-        using Base::Base;
-
+        template<typename B = Bits, std::enable_if_t<isConstant<B>, int> = 0>
         LLAMA_FN_HOST_ACC_INLINE constexpr explicit BitPackedIntSoA(
-            TArrayExtents extents,
+            TArrayExtents extents = {},
             Bits bits = {},
             TRecordDim = {})
+            : Base(extents)
+            , VHBits{bits}
+        {
+            static_assert(VHBits::value() > 0);
+        }
+
+        template<typename B = Bits, std::enable_if_t<!isConstant<B>, int> = 0>
+        LLAMA_FN_HOST_ACC_INLINE constexpr explicit BitPackedIntSoA(TArrayExtents extents, Bits bits, TRecordDim = {})
             : Base(extents)
             , VHBits{bits}
         {

--- a/tests/core.cpp
+++ b/tests/core.cpp
@@ -532,3 +532,11 @@ TEST_CASE("isProxyReference")
     STATIC_REQUIRE(llama::internal::IsProxyReferenceImpl<decltype(ref)>::value);
     STATIC_REQUIRE(llama::isProxyReference<decltype(ref)>);
 }
+
+TEST_CASE("isConstant")
+{
+    STATIC_REQUIRE(!llama::isConstant<int>);
+    STATIC_REQUIRE(llama::isConstant<std::true_type>);
+    STATIC_REQUIRE(llama::isConstant<std::integral_constant<int, 34>>);
+    STATIC_REQUIRE(llama::isConstant<llama::Constant<3u>>);
+}

--- a/tests/recordref.cpp
+++ b/tests/recordref.cpp
@@ -802,7 +802,8 @@ TEST_CASE("RecordRef.load.constref")
 
 TEST_CASE("RecordRef.load.value.fromproxyref")
 {
-    auto view = llama::allocView(llama::mapping::BitPackedIntSoA<llama::ArrayExtents<int, 1>, ParticleInt>{});
+    auto view = llama::allocView(
+        llama::mapping::BitPackedIntSoA<llama::ArrayExtents<int, 1>, ParticleInt, llama::Constant<14>>{});
     auto&& record = view(0);
     record = 1;
 
@@ -868,7 +869,8 @@ TEST_CASE("RecordRef.store")
 
 TEST_CASE("RecordRef.store.toproxyref")
 {
-    auto view = llama::allocView(llama::mapping::BitPackedIntSoA<llama::ArrayExtents<int, 1>, ParticleInt>{});
+    auto view = llama::allocView(
+        llama::mapping::BitPackedIntSoA<llama::ArrayExtents<int, 1>, ParticleInt, llama::Constant<14>>{});
     auto&& record = view(0);
 
     record = 1;
@@ -951,7 +953,8 @@ TEST_CASE("RecordRef.loadAs.constref")
 
 TEST_CASE("RecordRef.loadAs.value.fromproxyref")
 {
-    auto view = llama::allocView(llama::mapping::BitPackedIntSoA<llama::ArrayExtents<int, 1>, ParticleInt>{});
+    auto view = llama::allocView(
+        llama::mapping::BitPackedIntSoA<llama::ArrayExtents<int, 1>, ParticleInt, llama::Constant<14>>{});
     auto&& record = view(0);
     record = 1;
 


### PR DESCRIPTION
The tuple interface of `RecordRef` allows to convert between a `RecordRef` and a user-defined struct implementing the tuple interface. This did not work though if the `RecordRef` used a mapping using proxy references. This PR fixes this shortcoming.

On the side, the constructor of `BitPackedIntSoA` has been improved to detect uninitialized bit sizes. This uncovered some errors in the unit tests, which were fixed as well.