### PR TITLE
Extend SIMD API

### DIFF
--- a/examples/alpaka/nbody/nbody.cpp
+++ b/examples/alpaka/nbody/nbody.cpp
@@ -134,7 +134,7 @@ template<int ProblemSize, int Elems, int BlockSize, Mapping MappingSM>
 struct UpdateKernel
 {
     template<typename Acc, typename View>
-    LLAMA_FN_HOST_ACC_INLINE void operator()(const Acc& acc, View particles) const
+    ALPAKA_FN_HOST_ACC void operator()(const Acc& acc, View particles) const
     {
         auto sharedView = [&]
         {
@@ -188,7 +188,7 @@ template<int ProblemSize, int Elems>
 struct MoveKernel
 {
     template<typename Acc, typename View>
-    LLAMA_FN_HOST_ACC_INLINE void operator()(const Acc& acc, View particles) const
+    ALPAKA_FN_HOST_ACC void operator()(const Acc& acc, View particles) const
     {
         const auto ti = alpaka::getIdx<alpaka::Grid, alpaka::Threads>(acc)[0];
         const auto i = ti * Elems;

--- a/examples/nbody/nbody.cpp
+++ b/examples/nbody/nbody.cpp
@@ -208,7 +208,7 @@ namespace usellama
     template<typename View>
     void updateSimd(View& particles)
     {
-        constexpr auto width = llama::simdLanesFor<typename View::RecordDim, MakeBatch>;
+        constexpr auto width = llama::simdLanesWithFullVectorsFor<typename View::RecordDim, MakeBatch>;
         for(std::size_t i = 0; i < problemSize; i += width)
         {
             llama::SimdN<typename View::RecordDim, width, xsimd::make_sized_batch_t> pis;
@@ -222,12 +222,13 @@ namespace usellama
     template<typename View>
     void moveSimd(View& particles)
     {
-        constexpr auto width = llama::simdLanesFor<typename View::RecordDim, MakeBatch>;
+        using RecordDim = typename View::RecordDim;
+        constexpr auto width = llama::simdLanesWithFullVectorsFor<RecordDim, MakeBatch>;
         LLAMA_INDEPENDENT_DATA // TODO(bgruber): why is this needed
             for(std::size_t i = 0; i < problemSize; i += width)
         {
-            llama::SimdN<llama::GetType<typename View::RecordDim, tag::Pos>, width, xsimd::make_sized_batch_t> pos;
-            llama::SimdN<llama::GetType<typename View::RecordDim, tag::Vel>, width, xsimd::make_sized_batch_t> vel;
+            llama::SimdN<llama::GetType<RecordDim, tag::Pos>, width, xsimd::make_sized_batch_t> pos;
+            llama::SimdN<llama::GetType<RecordDim, tag::Vel>, width, xsimd::make_sized_batch_t> vel;
             llama::loadSimd(pos, particles(i)(tag::Pos{}));
             llama::loadSimd(vel, particles(i)(tag::Vel{}));
             llama::storeSimd(particles(i)(tag::Pos{}), pos + vel * timestep);

--- a/include/llama/RecordRef.hpp
+++ b/include/llama/RecordRef.hpp
@@ -746,9 +746,9 @@ namespace llama
         // to find subsequent elements. This is not a great design for now and the SIMD load/store functions should
         // probably take iterators to records.
         template<typename Simd, typename RecordRef>
-        friend void loadSimd(Simd& simd, const RecordRef& rr);
+        friend void loadSimd(Simd& simd, const RecordRef& ref);
         template<typename RecordRef, typename Simd>
-        friend void storeSimd(RecordRef&& rr, Simd simd);
+        friend void storeSimd(RecordRef&& ref, Simd simd);
     };
 
     // swap for heterogeneous RecordRef

--- a/tests/simd.cpp
+++ b/tests/simd.cpp
@@ -76,12 +76,27 @@ TEST_CASE("simd.Simdize.stdsimd")
                        llama::Field<tag::Y, stdx::native_simd<float>>>>);
 }
 
-TEST_CASE("simd.simdLanesFor.stdsimd")
+TEST_CASE("simd.simdLanesWithFullVectorsFor.stdsimd")
 {
-    STATIC_REQUIRE(llama::simdLanesFor<float, stdx::native_simd> == stdx::native_simd<float>::size());
-    STATIC_REQUIRE(llama::simdLanesFor<Vec2F, stdx::native_simd> == stdx::native_simd<float>::size());
-    STATIC_REQUIRE(llama::simdLanesFor<Vec3D, stdx::native_simd> == stdx::native_simd<double>::size());
-    STATIC_REQUIRE(llama::simdLanesFor<ParticleSimd, stdx::native_simd> == stdx::native_simd<uint8_t>::size());
+    STATIC_REQUIRE(llama::simdLanesWithFullVectorsFor<float, stdx::native_simd> == stdx::native_simd<float>::size());
+    STATIC_REQUIRE(llama::simdLanesWithFullVectorsFor<Vec2F, stdx::native_simd> == stdx::native_simd<float>::size());
+    STATIC_REQUIRE(llama::simdLanesWithFullVectorsFor<Vec3D, stdx::native_simd> == stdx::native_simd<double>::size());
+    STATIC_REQUIRE(
+        llama::simdLanesWithFullVectorsFor<ParticleSimd, stdx::native_simd> == stdx::native_simd<uint8_t>::size());
+}
+
+TEST_CASE("simd.simdLanesWithLeastRegistersFor.stdsimd")
+{
+    STATIC_REQUIRE(
+        llama::simdLanesWithLeastRegistersFor<float, stdx::native_simd> == stdx::native_simd<float>::size());
+    STATIC_REQUIRE(
+        llama::simdLanesWithLeastRegistersFor<Vec2F, stdx::native_simd> == stdx::native_simd<float>::size());
+    STATIC_REQUIRE(
+        llama::simdLanesWithLeastRegistersFor<Vec3D, stdx::native_simd> == stdx::native_simd<double>::size());
+    STATIC_REQUIRE(
+        llama::simdLanesWithLeastRegistersFor<
+            ParticleSimd,
+            stdx::native_simd> == stdx::native_simd<double>::size()); // 11 registers with 4 lanes used each
 }
 
 TEST_CASE("simd.SimdN.stdsimd")
@@ -141,18 +156,29 @@ TEST_CASE("simd.Simd.stdsimd")
 
 TEST_CASE("simd.simdLanes.stdsimd")
 {
+    STATIC_REQUIRE(llama::simdLanes<float> == 1);
+
+    STATIC_REQUIRE(llama::simdLanes<llama::One<ParticleSimd>> == 1);
+
     STATIC_REQUIRE(llama::simdLanes<stdx::native_simd<float>> == stdx::native_simd<float>::size());
     STATIC_REQUIRE(llama::simdLanes<stdx::fixed_size_simd<float, 4>> == 4);
-}
 
-TEST_CASE("simd.simdLanes.Simd")
-{
     STATIC_REQUIRE(llama::simdLanes<llama::Simd<float, stdx::native_simd>> == stdx::native_simd<float>::size());
     STATIC_REQUIRE(llama::simdLanes<llama::Simd<Vec2F, stdx::native_simd>> == stdx::native_simd<float>::size());
+
     STATIC_REQUIRE(llama::simdLanes<llama::SimdN<ParticleSimd, 8, stdx::fixed_size_simd>> == 8);
+    STATIC_REQUIRE(llama::simdLanes<llama::SimdN<ParticleSimd, 1, stdx::fixed_size_simd>> == 1);
 }
 
-TEST_CASE("simd.loadSimd.scalar.stdsimd")
+TEST_CASE("simd.loadSimd.scalar")
+{
+    float mem = 3.14f;
+    float s = 0;
+    llama::loadSimd(s, mem);
+    CHECK(s == mem);
+}
+
+TEST_CASE("simd.loadSimd.simd.stdsimd")
 {
     std::array<float, 4> a{};
     std::iota(begin(a), end(a), 1.0f);
@@ -213,7 +239,15 @@ TEST_CASE("simd.loadSimd.record.stdsimd")
         == SimdRange{stdx::fixed_size_simd<std::uint8_t, 4>{[](auto ic) -> std::uint8_t { return 10 + ic * 11; }}});
 }
 
-TEST_CASE("simd.storeSimd.scalar.stdsimd")
+TEST_CASE("simd.storeSimd.scalar")
+{
+    float mem = 0;
+    float s = 3.14f;
+    llama::storeSimd(mem, s);
+    CHECK(s == mem);
+}
+
+TEST_CASE("simd.storeSimd.simd.stdsimd")
 {
     stdx::fixed_size_simd<float, 4> s([](auto ic) -> float { return ic() + 1; });
 


### PR DESCRIPTION
* Replace simdLanesFor by simdLanesWithFullVectorsFor and simdLanesWithLeastRegistersFor, as well as a generic chooseSimdLanes.
* Add tests for loadSimd/storeSimd with scalars.
* Small refactoring of n-body examples.