### PR TITLE
Improve CUDA examples

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -8,6 +8,7 @@
 # fuchsia-statically-constructed-objects # too much noise with Catch2
 # bugprone-easily-swappable-parameters # too noisy
 # altera-struct-pack-align # too noisy, flags e.g. all traits
+# google-runtime-int # too noisy
 Checks: >
     *,
     -bugprone-exception-escape,
@@ -29,6 +30,7 @@ Checks: >
     -fuchsia-trailing-return,
     -google-build-using-namespace,
     -google-readability-braces-around-statements,
+    -google-runtime-int,
     -google-runtime-references,
     -hicpp-avoid-c-arrays,
     -hicpp-braces-around-statements,

--- a/examples/cuda/nbody/CMakeLists.txt
+++ b/examples/cuda/nbody/CMakeLists.txt
@@ -1,12 +1,14 @@
-cmake_minimum_required (VERSION 3.18.3)
-project(llama-cuda-nbody CXX CUDA)
+cmake_minimum_required(VERSION 3.18.3)
+project(llama-cuda-nbody CUDA)
 
 find_package(CUDAToolkit) # for include directories
 find_package(fmt CONFIG REQUIRED)
 if (NOT TARGET llama::llama)
-	find_package(llama REQUIRED)
-endif()
+    find_package(llama REQUIRED)
+endif ()
 add_executable(${PROJECT_NAME} nbody.cu ../../common/Stopwatch.hpp)
 target_compile_features(${PROJECT_NAME} PRIVATE cuda_std_17)
-target_compile_options(${PROJECT_NAME} PUBLIC $<$<COMPILE_LANGUAGE:CUDA>:--expt-extended-lambda --expt-relaxed-constexpr --use_fast_math>)
+target_compile_options(${PROJECT_NAME} PUBLIC
+        --expt-extended-lambda --expt-relaxed-constexpr --use_fast_math
+        --compiler-options -Wall,-Wextra)
 target_link_libraries(${PROJECT_NAME} PRIVATE llama::llama CUDA::cudart fmt::fmt)

--- a/examples/cuda/nbody/nbody.cu
+++ b/examples/cuda/nbody/nbody.cu
@@ -29,11 +29,10 @@ static_assert(sharedElementsPerBlock % threadsPerBlock == 0);
 
 constexpr FP epS2 = 0.01;
 
-#if __CUDA_ARCH__ >= 600
-using CountType = unsigned long long int;
-#else
-using CountType = unsigned;
+#if defined(__CUDA_ARCH__) && __CUDA_ARCH__ <= 600
+static_assert(!trace, "Since tracing is enabled, this example needs compute capability >= 60 for 64bit atomics");
 #endif
+using CountType = unsigned long long int;
 
 using namespace std::literals;
 
@@ -210,6 +209,7 @@ try
                 llama::RecordCoord<1>,
                 llama::mapping::BindSoA<>::fn,
                 llama::mapping::BindSoA<>::fn,
+
                 true>{extents};
     }();
     auto tmapping = [&]

--- a/examples/cuda/nbody/nbody.cu
+++ b/examples/cuda/nbody/nbody.cu
@@ -17,7 +17,7 @@ constexpr auto sharedElementsPerBlock = 512;
 constexpr auto steps = 5; ///< number of steps to calculate
 constexpr auto allowRsqrt = true; // rsqrt can be way faster, but less accurate
 constexpr auto runUpate = true; // run update step. Useful to disable for benchmarking the move step.
-constexpr auto trace = true;
+constexpr auto trace = false;
 constexpr FP timestep = 0.0001f;
 
 constexpr auto threadsPerBlock = 256;

--- a/examples/cuda/pitch/CMakeLists.txt
+++ b/examples/cuda/pitch/CMakeLists.txt
@@ -1,13 +1,15 @@
-cmake_minimum_required (VERSION 3.18.3)
-project(llama-cuda-pitch CXX CUDA)
+cmake_minimum_required(VERSION 3.18.3)
+project(llama-cuda-pitch CUDA)
 
 find_package(CUDAToolkit) # for include directories
 find_package(fmt CONFIG REQUIRED)
 if (NOT TARGET llama::llama)
-	find_package(llama REQUIRED)
-endif()
+    find_package(llama REQUIRED)
+endif ()
 add_executable(${PROJECT_NAME} pitch.cu)
 target_compile_features(${PROJECT_NAME} PRIVATE cuda_std_17)
-target_compile_options(${PROJECT_NAME} PUBLIC $<$<COMPILE_LANGUAGE:CUDA>:--expt-extended-lambda --expt-relaxed-constexpr>)
+target_compile_options(${PROJECT_NAME} PUBLIC
+        --expt-extended-lambda --expt-relaxed-constexpr --use_fast_math
+        --compiler-options -Wall,-Wextra)
 target_include_directories(${PROJECT_NAME} SYSTEM PRIVATE ../../../thirdparty/stb/include)
 target_link_libraries(${PROJECT_NAME} PRIVATE llama::llama CUDA::cudart fmt::fmt)

--- a/include/llama/Simd.hpp
+++ b/include/llama/Simd.hpp
@@ -186,7 +186,11 @@ namespace llama
 
                     // TODO(bgruber): can we generalize the logic whether we can load a simd from that mapping?
                     if constexpr(mapping::isSoA<typename T::View::Mapping>)
+                    {
+                        LLAMA_BEGIN_SUPPRESS_HOST_DEVICE_WARNING
                         simd(rc) = Traits::loadUnaligned(&ref(rc)); // SIMD load
+                        LLAMA_END_SUPPRESS_HOST_DEVICE_WARNING
+                    }
                     // else if constexpr(mapping::isAoSoA<typename T::View::Mapping>)
                     //{
                     //    // it turns out we do not need the specialization, because clang already fuses the scalar
@@ -210,7 +214,9 @@ namespace llama
         // unstructured simd and reference type
         else if constexpr(!isRecordRef<Simd> && !isRecordRef<T>)
         {
+            LLAMA_BEGIN_SUPPRESS_HOST_DEVICE_WARNING
             simd = SimdTraits<Simd>::loadUnaligned(&ref);
+            LLAMA_END_SUPPRESS_HOST_DEVICE_WARNING
         }
         else
         {
@@ -239,7 +245,11 @@ namespace llama
 
                     // TODO(bgruber): can we generalize the logic whether we can store a simd to that mapping?
                     if constexpr(mapping::isSoA<typename T::View::Mapping>)
+                    {
+                        LLAMA_BEGIN_SUPPRESS_HOST_DEVICE_WARNING
                         Traits::storeUnaligned(simd(rc), &ref(rc)); // SIMD store
+                        LLAMA_END_SUPPRESS_HOST_DEVICE_WARNING
+                    }
                     else
                     {
                         // TODO(bgruber): how does this generalize conceptually to 2D and higher dimensions? in which
@@ -254,7 +264,9 @@ namespace llama
         // unstructured simd and reference type
         else if constexpr(!isRecordRef<Simd> && !isRecordRef<T>)
         {
+            LLAMA_BEGIN_SUPPRESS_HOST_DEVICE_WARNING
             SimdTraits<Simd>::storeUnaligned(simd, &ref);
+            LLAMA_END_SUPPRESS_HOST_DEVICE_WARNING
         }
         else
         {

--- a/include/llama/llama.hpp
+++ b/include/llama/llama.hpp
@@ -28,8 +28,7 @@
 
 // suppress warnings on missing return statements. we get a lot of these because nvcc/nvc++ have some troubles with if
 // constexpr.
-#ifdef __NVCC__
-#    pragma push
+#ifdef __CUDACC__
 #    ifdef __NVCC_DIAG_PRAGMA_SUPPORT__
 #        pragma nv_diag_suppress 940
 #    else
@@ -70,6 +69,10 @@
 #include "mapping/Trace.hpp"
 #include "mapping/tree/Mapping.hpp"
 
-#if defined(__NVCC__) || defined(__NVCOMPILER)
-#    pragma pop
+#if defined(__CUDACC__) || defined(__NVCOMPILER)
+#    ifdef __NVCC_DIAG_PRAGMA_SUPPORT__
+#        pragma nv_diag_default 940
+#    else
+#        pragma diag_default 940
+#    endif
 #endif

--- a/include/llama/mapping/BitPackedFloatSoA.hpp
+++ b/include/llama/mapping/BitPackedFloatSoA.hpp
@@ -252,6 +252,7 @@ namespace llama::mapping
 
             using QualifiedStoredIntegral = CopyConst<Blobs, StoredIntegral>;
             using DstType = GetType<TRecordDim, RecordCoord<RecordCoords...>>;
+            LLAMA_BEGIN_SUPPRESS_HOST_DEVICE_WARNING
             return internal::BitPackedFloatRef<DstType, QualifiedStoredIntegral*, VHExp, VHMan, size_type>{
                 reinterpret_cast<QualifiedStoredIntegral*>(&blobs[blob][0]),
                 bitOffset,
@@ -262,6 +263,7 @@ namespace llama::mapping
                 reinterpret_cast<QualifiedStoredIntegral*>(&blobs[blob][0] + blobSize(blob))
 #endif
             };
+            LLAMA_END_SUPPRESS_HOST_DEVICE_WARNING
         }
     };
 

--- a/include/llama/mapping/ChangeType.hpp
+++ b/include/llama/mapping/ChangeType.hpp
@@ -108,8 +108,10 @@ namespace llama::mapping
             using StoredT = internal::ReplacedType<ReplacementMap, RecordCoord<RecordCoords...>, UserT>;
             using QualifiedStoredT = CopyConst<BlobArray, StoredT>;
             const auto [nr, offset] = Inner::template blobNrAndOffset<RecordCoords...>(ai);
+            LLAMA_BEGIN_SUPPRESS_HOST_DEVICE_WARNING
             return internal::ChangeTypeReference<UserT, QualifiedStoredT>{
                 reinterpret_cast<QualifiedStoredT&>(blobs[nr][offset])};
+            LLAMA_END_SUPPRESS_HOST_DEVICE_WARNING
         }
 
         template<std::size_t... RecordCoords>


### PR DESCRIPTION
This PR mostly fixes some warnings around calling between host/device function. In once instance, a host/device annotation was missing and this was actually a bug that broke the tracing in the n-body CUDA example.