### PR TITLE
Update alpaka and CUDA n-body example

### DIFF
--- a/examples/alpaka/nbody/CMakeLists.txt
+++ b/examples/alpaka/nbody/CMakeLists.txt
@@ -16,7 +16,7 @@ target_compile_features(${PROJECT_NAME} PRIVATE cxx_std_17)
 target_link_libraries(${PROJECT_NAME} PRIVATE llama::llama fmt::fmt alpaka::alpaka xsimd)
 
 if (MSVC)
-	target_compile_options(${PROJECT_NAME} PRIVATE /arch:AVX2 /fp:fast)
+	target_compile_options(${PROJECT_NAME} PRIVATE $<$<COMPILE_LANGUAGE:CXX>:/arch:AVX2 /fp:fast>)
 else()
 	target_compile_options(${PROJECT_NAME} PRIVATE -march=native $<IF:$<CXX_COMPILER_ID:NVHPC>,-fast,-ffast-math>)
 endif()

--- a/examples/nbody/nbody.cpp
+++ b/examples/nbody/nbody.cpp
@@ -34,7 +34,7 @@ constexpr auto newtonRaphsonAfterRsqrt = true; // generate a newton raphson refi
 constexpr auto runUpate = true; // run update step. Useful to disable for benchmarking the move step.
 
 constexpr auto timestep = FP{0.0001};
-constexpr auto epS2 = FP{0.01};
+constexpr auto eps2 = FP{0.01};
 
 constexpr auto rngSeed = 42;
 constexpr auto referenceParticleIndex = 1338;
@@ -169,7 +169,7 @@ namespace usellama
     {
         auto dist = pi(tag::Pos{}) - pj(tag::Pos{});
         dist *= dist;
-        const auto distSqr = epS2 + dist(tag::X{}) + dist(tag::Y{}) + dist(tag::Z{});
+        const auto distSqr = eps2 + dist(tag::X{}) + dist(tag::Y{}) + dist(tag::Z{});
         const auto distSixth = distSqr * distSqr * distSqr;
         const auto invDistCube = [&]
         {
@@ -399,7 +399,7 @@ namespace manualAoS
     {
         auto distance = pi.pos - pj.pos;
         distance *= distance;
-        const FP distSqr = epS2 + distance.x + distance.y + distance.z;
+        const FP distSqr = eps2 + distance.x + distance.y + distance.z;
         const FP distSixth = distSqr * distSqr * distSqr;
         const FP invDistCube = 1.0f / std::sqrt(distSixth);
         const FP sts = pj.mass * invDistCube * timestep;
@@ -487,7 +487,7 @@ namespace manualSoA
         xdistance *= xdistance;
         ydistance *= ydistance;
         zdistance *= zdistance;
-        const FP distSqr = epS2 + xdistance + ydistance + zdistance;
+        const FP distSqr = eps2 + xdistance + ydistance + zdistance;
         const FP distSixth = distSqr * distSqr * distSqr;
         const FP invDistCube = 1.0f / std::sqrt(distSixth);
         const FP sts = pjmass * invDistCube * timestep;
@@ -613,7 +613,7 @@ namespace manualAoSoA
         xdistance *= xdistance;
         ydistance *= ydistance;
         zdistance *= zdistance;
-        const FP distSqr = epS2 + xdistance + ydistance + zdistance;
+        const FP distSqr = eps2 + xdistance + ydistance + zdistance;
         const FP distSixth = distSqr * distSqr * distSqr;
         const FP invDistCube = 1.0f / std::sqrt(distSixth);
         const FP sts = pjmass * invDistCube * timestep;
@@ -787,7 +787,7 @@ namespace manualAoSoAManualAVX
     };
 
     constexpr auto blocks = problemSize / lanes;
-    const __m256 vEPS2 = _mm256_set1_ps(epS2); // NOLINT(cert-err58-cpp)
+    const __m256 vEPS2 = _mm256_set1_ps(eps2); // NOLINT(cert-err58-cpp)
     const __m256 vTIMESTEP = _mm256_set1_ps(timestep); // NOLINT(cert-err58-cpp)
 
     inline void pPInteraction(
@@ -1014,7 +1014,7 @@ namespace manualAoSoASIMD
         const Simd xdistanceSqr = xdistance * xdistance;
         const Simd ydistanceSqr = ydistance * ydistance;
         const Simd zdistanceSqr = zdistance * zdistance;
-        const Simd distSqr = epS2 + xdistanceSqr + ydistanceSqr + zdistanceSqr;
+        const Simd distSqr = eps2 + xdistanceSqr + ydistanceSqr + zdistanceSqr;
         const Simd distSixth = distSqr * distSqr * distSqr;
         const Simd invDistCube = [&]
         {

--- a/include/llama/Simd.hpp
+++ b/include/llama/Simd.hpp
@@ -31,12 +31,12 @@ namespace llama
 
         inline static constexpr std::size_t lanes = 1;
 
-        static LLAMA_FORCE_INLINE auto loadUnaligned(const T* mem) -> T
+        static LLAMA_FN_HOST_ACC_INLINE auto loadUnaligned(const T* mem) -> T
         {
             return *mem;
         }
 
-        static LLAMA_FORCE_INLINE void storeUnaligned(T t, T* mem)
+        static LLAMA_FN_HOST_ACC_INLINE void storeUnaligned(T t, T* mem)
         {
             *mem = t;
         }
@@ -230,7 +230,7 @@ namespace llama
     /// vector will be stored for each of the fields. The number of elements stored per SIMD vector depends on the
     /// SIMD width of the vector. Simd is allowed to have different vector lengths per element.
     template<typename T, typename Simd>
-    LLAMA_FN_HOST_ACC_INLINE void storeSimd(T&& ref, Simd simd)
+    LLAMA_FN_HOST_ACC_INLINE void storeSimd(T&& ref, const Simd simd)
     {
         // structured Simd type and record reference
         if constexpr(isRecordRef<Simd> && isRecordRef<T>)
@@ -257,7 +257,7 @@ namespace llama
                         auto b = ArrayIndexIterator{ref.view.mapping().extents(), ref.arrayIndex()};
                         for(auto i = 0; i < Traits::lanes; i++)
                             ref.view (*b++)(cat(typename T::BoundRecordCoord{}, rc))
-                                = reinterpret_cast<FieldType*>(&simd(rc))[i]; // scalar store
+                                = reinterpret_cast<const FieldType*>(&simd(rc))[i]; // scalar store
                     }
                 });
         }

--- a/tests/simd.cpp
+++ b/tests/simd.cpp
@@ -189,6 +189,29 @@ TEST_CASE("simd.loadSimd.simd.stdsimd")
     CHECK(s[3] == 4.0f);
 }
 
+TEST_CASE("simd.loadSimd.record.scalar")
+{
+    using ArrayExtents = llama::ArrayExtentsDynamic<int, 1>;
+    const auto mapping = llama::mapping::SoA<ArrayExtents, ParticleSimd>(ArrayExtents{1});
+    auto view = llama::allocViewUninitialized(mapping);
+    iotaFillView(view);
+
+    llama::SimdN<ParticleSimd, 1, stdx::fixed_size_simd> p;
+    llama::loadSimd(p, view(0));
+
+    CHECK(p(tag::Pos{}, tag::X{}) == 0);
+    CHECK(p(tag::Pos{}, tag::Y{}) == 1);
+    CHECK(p(tag::Pos{}, tag::Z{}) == 2);
+    CHECK(p(tag::Mass{}) == 3);
+    CHECK(p(tag::Vel{}, tag::X{}) == 4);
+    CHECK(p(tag::Vel{}, tag::Y{}) == 5);
+    CHECK(p(tag::Vel{}, tag::Z{}) == 6);
+    CHECK(p(tag::Flags{}, llama::RecordCoord<0>{}) == 7);
+    CHECK(p(tag::Flags{}, llama::RecordCoord<1>{}) == 8);
+    CHECK(p(tag::Flags{}, llama::RecordCoord<2>{}) == 9);
+    CHECK(p(tag::Flags{}, llama::RecordCoord<3>{}) == 10);
+}
+
 TEST_CASE("simd.loadSimd.record.stdsimd")
 {
     using ArrayExtents = llama::ArrayExtentsDynamic<int, 1>;
@@ -255,6 +278,39 @@ TEST_CASE("simd.storeSimd.simd.stdsimd")
     CHECK(a[1] == 2.0f);
     CHECK(a[2] == 3.0f);
     CHECK(a[3] == 4.0f);
+}
+
+TEST_CASE("simd.storeSimd.record.scalar")
+{
+    using ArrayExtents = llama::ArrayExtentsDynamic<int, 1>;
+    const auto mapping = llama::mapping::SoA<ArrayExtents, ParticleSimd>(ArrayExtents{1});
+    auto view = llama::allocViewUninitialized(mapping);
+
+    llama::SimdN<ParticleSimd, 1, stdx::fixed_size_simd> p;
+    p(tag::Pos{}, tag::X{}) = 0;
+    p(tag::Pos{}, tag::Y{}) = 1;
+    p(tag::Pos{}, tag::Z{}) = 2;
+    p(tag::Mass{}) = 3;
+    p(tag::Vel{}, tag::X{}) = 4;
+    p(tag::Vel{}, tag::Y{}) = 5;
+    p(tag::Vel{}, tag::Z{}) = 6;
+    p(tag::Flags{}, llama::RecordCoord<0>{}) = 7;
+    p(tag::Flags{}, llama::RecordCoord<1>{}) = 8;
+    p(tag::Flags{}, llama::RecordCoord<2>{}) = 9;
+    p(tag::Flags{}, llama::RecordCoord<3>{}) = 10;
+    llama::storeSimd(view(0), p);
+
+    CHECK(view(0)(tag::Pos{}, tag::X{}) == 0);
+    CHECK(view(0)(tag::Pos{}, tag::Y{}) == 1);
+    CHECK(view(0)(tag::Pos{}, tag::Z{}) == 2);
+    CHECK(view(0)(tag::Mass{}) == 3);
+    CHECK(view(0)(tag::Vel{}, tag::X{}) == 4);
+    CHECK(view(0)(tag::Vel{}, tag::Y{}) == 5);
+    CHECK(view(0)(tag::Vel{}, tag::Z{}) == 6);
+    CHECK(view(0)(tag::Flags{}, llama::RecordCoord<0>{}) == 7);
+    CHECK(view(0)(tag::Flags{}, llama::RecordCoord<1>{}) == 8);
+    CHECK(view(0)(tag::Flags{}, llama::RecordCoord<2>{}) == 9);
+    CHECK(view(0)(tag::Flags{}, llama::RecordCoord<3>{}) == 10);
 }
 
 TEST_CASE("simd.storeSimd.record.stdsimd")


### PR DESCRIPTION
* Make both examples more similar
* Fix missing host/device attribute on SIMD traits, which causes the alpaka n-body to malfunction with SoA layouts on the CUDA backend
* Add tests for scalar record SIMD loads/stores