### PR TITLE
Add Projection and Byteswap mappings

### DIFF
--- a/include/llama/llama.hpp
+++ b/include/llama/llama.hpp
@@ -60,6 +60,7 @@
 #include "mapping/BitPackedFloatSoA.hpp"
 #include "mapping/BitPackedIntSoA.hpp"
 #include "mapping/Bytesplit.hpp"
+#include "mapping/Byteswap.hpp"
 #include "mapping/ChangeType.hpp"
 #include "mapping/Heatmap.hpp"
 #include "mapping/Null.hpp"

--- a/include/llama/llama.hpp
+++ b/include/llama/llama.hpp
@@ -64,6 +64,7 @@
 #include "mapping/Heatmap.hpp"
 #include "mapping/Null.hpp"
 #include "mapping/One.hpp"
+#include "mapping/Projection.hpp"
 #include "mapping/SoA.hpp"
 #include "mapping/Split.hpp"
 #include "mapping/Trace.hpp"

--- a/include/llama/mapping/Byteswap.hpp
+++ b/include/llama/mapping/Byteswap.hpp
@@ -1,0 +1,80 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#pragma once
+
+#include "../Core.hpp"
+#include "../ProxyRefOpMixin.hpp"
+#include "Common.hpp"
+#include "Projection.hpp"
+
+namespace llama::mapping
+{
+    namespace internal
+    {
+        // TODO(bgruber): replace by std::byteswap in C++23
+        template<typename T>
+        LLAMA_FN_HOST_ACC_INLINE auto byteswap(T t) -> T
+        {
+            llama::Array<std::byte, sizeof(T)> arr;
+            std::memcpy(&arr, &t, sizeof(T));
+
+            for(std::size_t i = 0; i < sizeof(T) / 2; i++)
+            {
+                const auto a = arr[i];
+                const auto b = arr[sizeof(T) - 1 - i];
+                arr[i] = b;
+                arr[sizeof(T) - 1 - i] = a;
+            }
+
+            std::memcpy(&t, &arr, sizeof(T));
+            return t;
+        }
+
+        template<typename T>
+        struct ByteswapProjection
+        {
+            LLAMA_FN_HOST_ACC_INLINE static auto load(T v) -> T
+            {
+                return byteswap(v);
+            }
+
+            LLAMA_FN_HOST_ACC_INLINE static auto store(T v) -> T
+            {
+                return byteswap(v);
+            }
+        };
+
+        template<typename T>
+        using MakeByteswapProjectionPair = boost::mp11::mp_list<T, ByteswapProjection<T>>;
+
+        template<typename RecordDim>
+        using MakeByteswapProjectionMap
+            = boost::mp11::mp_transform<MakeByteswapProjectionPair, boost::mp11::mp_unique<FlatRecordDim<RecordDim>>>;
+    } // namespace internal
+
+    /// Mapping that swaps the byte order of all values when loading/storing.
+    template<typename ArrayExtents, typename RecordDim, template<typename, typename> typename InnerMapping>
+    struct Byteswap : Projection<ArrayExtents, RecordDim, InnerMapping, internal::MakeByteswapProjectionMap<RecordDim>>
+    {
+    private:
+        using Base = Projection<ArrayExtents, RecordDim, InnerMapping, internal::MakeByteswapProjectionMap<RecordDim>>;
+
+    public:
+        using Base::Base;
+    };
+
+    /// Binds parameters to a \ref ChangeType mapping except for array and record dimension, producing a quoted
+    /// meta function accepting the latter two. Useful to to prepare this mapping for a meta mapping.
+    template<template<typename, typename> typename InnerMapping>
+    struct BindByteswap
+    {
+        template<typename ArrayExtents, typename RecordDim>
+        using fn = Byteswap<ArrayExtents, RecordDim, InnerMapping>;
+    };
+
+    template<typename Mapping>
+    inline constexpr bool isByteswap = false;
+
+    template<typename TArrayExtents, typename TRecordDim, template<typename, typename> typename InnerMapping>
+    inline constexpr bool isByteswap<Byteswap<TArrayExtents, TRecordDim, InnerMapping>> = true;
+} // namespace llama::mapping

--- a/include/llama/mapping/Projection.hpp
+++ b/include/llama/mapping/Projection.hpp
@@ -1,0 +1,183 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#pragma once
+
+#include "../ProxyRefOpMixin.hpp"
+#include "../View.hpp"
+#include "Common.hpp"
+
+namespace llama::mapping
+{
+    namespace internal
+    {
+        template<typename F>
+        struct UnaryFunctionTraits
+        {
+            static_assert(sizeof(F) == 0, "F is not an unary function");
+        };
+
+        template<typename Arg, typename Ret>
+        struct UnaryFunctionTraits<Ret (*)(Arg)>
+        {
+            using ArgumentType = Arg;
+            using ReturnType = Ret;
+        };
+
+        template<typename ProjectionMap, typename Coord, typename RecordDimType>
+        auto projectionOrVoidImpl()
+        {
+            using namespace boost::mp11;
+            if constexpr(mp_map_contains<ProjectionMap, Coord>::value)
+                return mp_identity<mp_second<mp_map_find<ProjectionMap, Coord>>>{};
+            else if constexpr(mp_map_contains<ProjectionMap, RecordDimType>::value)
+                return mp_identity<mp_second<mp_map_find<ProjectionMap, RecordDimType>>>{};
+            else
+                return mp_identity<void>{};
+        }
+
+        template<typename ProjectionMap, typename Coord, typename RecordDimType>
+        using ProjectionOrVoid = typename decltype(projectionOrVoidImpl<ProjectionMap, Coord, RecordDimType>())::type;
+
+        template<typename ProjectionMap>
+        struct MakeReplacerProj
+        {
+            template<typename Coord, typename RecordDimType>
+            static auto replacedTypeProj()
+            {
+                using Projection = ProjectionOrVoid<ProjectionMap, Coord, RecordDimType>;
+                if constexpr(std::is_void_v<Projection>)
+                    return boost::mp11::mp_identity<RecordDimType>{};
+                else
+                {
+                    using LoadFunc = UnaryFunctionTraits<decltype(&Projection::load)>;
+                    using StoreFunc = UnaryFunctionTraits<decltype(&Projection::store)>;
+
+                    static_assert(std::is_same_v<typename LoadFunc::ReturnType, RecordDimType>);
+                    static_assert(std::is_same_v<typename StoreFunc::ArgumentType, RecordDimType>);
+                    static_assert(std::is_same_v<typename LoadFunc::ArgumentType, typename StoreFunc::ReturnType>);
+
+                    return boost::mp11::mp_identity<typename StoreFunc::ReturnType>{};
+                }
+            }
+
+            template<typename Coord, typename RecordDimType>
+            using fn = typename decltype(replacedTypeProj<Coord, RecordDimType>())::type;
+        };
+
+        template<typename RecordDim, typename ProjectionMap>
+        using ReplaceTypesByProjectionResults
+            = TransformLeavesWithCoord<RecordDim, MakeReplacerProj<ProjectionMap>::template fn>;
+
+        template<typename Reference, typename Projection>
+        struct ProjectionReference
+            : ProxyRefOpMixin<
+                  ProjectionReference<Reference, Projection>,
+                  decltype(Projection::load(std::declval<Reference>()))>
+        {
+        private:
+            Reference storageRef;
+
+        public:
+            using value_type = decltype(Projection::load(std::declval<Reference>()));
+
+            LLAMA_FN_HOST_ACC_INLINE constexpr explicit ProjectionReference(Reference storageRef)
+                : storageRef{storageRef}
+            {
+            }
+
+            // NOLINTNEXTLINE(google-explicit-constructor,hicpp-explicit-conversions)
+            LLAMA_FN_HOST_ACC_INLINE constexpr operator value_type() const
+            {
+                return Projection::load(storageRef);
+            }
+
+            LLAMA_FN_HOST_ACC_INLINE constexpr auto operator=(value_type v) -> ProjectionReference&
+            {
+                storageRef = Projection::store(v);
+                return *this;
+            }
+        };
+    } // namespace internal
+
+    /// Mapping that projects types in the record domain to different types. Projections are executed during load and
+    /// store.
+    /// @tparam TProjectionMap A type list of binary type lists (a map) specifing a projection (map value) for a type
+    /// or the type at a \ref RecordCoord (map key). A projection is a type with two functions:
+    /// struct Proj {
+    ///   static auto load(auto&& fromMem);
+    ///   static auto store(auto&& toMem);
+    /// };
+    template<
+        typename TArrayExtents,
+        typename TRecordDim,
+        template<typename, typename>
+        typename InnerMapping,
+        typename TProjectionMap>
+    struct Projection
+        : private InnerMapping<TArrayExtents, internal::ReplaceTypesByProjectionResults<TRecordDim, TProjectionMap>>
+    {
+        using Inner
+            = InnerMapping<TArrayExtents, internal::ReplaceTypesByProjectionResults<TRecordDim, TProjectionMap>>;
+        using ProjectionMap = TProjectionMap;
+        using ArrayExtents = typename Inner::ArrayExtents;
+        using ArrayIndex = typename Inner::ArrayIndex;
+        using RecordDim = TRecordDim; // hide Inner::RecordDim
+        using Inner::blobCount;
+        using Inner::blobSize;
+        using Inner::extents;
+        using Inner::Inner;
+
+        template<typename RecordCoord>
+        LLAMA_FN_HOST_ACC_INLINE static constexpr auto isComputed(RecordCoord) -> bool
+        {
+            return !std::is_void_v<
+                internal::ProjectionOrVoid<ProjectionMap, RecordCoord, GetType<RecordDim, RecordCoord>>>;
+        }
+
+        template<std::size_t... RecordCoords, typename BlobArray>
+        LLAMA_FN_HOST_ACC_INLINE constexpr auto compute(
+            typename Inner::ArrayIndex ai,
+            RecordCoord<RecordCoords...> rc,
+            BlobArray& blobs) const
+        {
+            static_assert(isComputed(rc));
+            using RecordDimType = GetType<RecordDim, RecordCoord<RecordCoords...>>;
+            using Reference = decltype(mapToMemory(static_cast<const Inner&>(*this), ai, rc, blobs));
+            using Projection = internal::ProjectionOrVoid<ProjectionMap, RecordCoord<RecordCoords...>, RecordDimType>;
+            static_assert(!std::is_void_v<Projection>);
+            Reference r = mapToMemory(static_cast<const Inner&>(*this), ai, rc, blobs);
+
+            LLAMA_BEGIN_SUPPRESS_HOST_DEVICE_WARNING
+            return internal::ProjectionReference<Reference, Projection>{r};
+            LLAMA_END_SUPPRESS_HOST_DEVICE_WARNING
+        }
+
+        template<std::size_t... RecordCoords>
+        LLAMA_FN_HOST_ACC_INLINE constexpr auto blobNrAndOffset(ArrayIndex ai, RecordCoord<RecordCoords...> rc = {})
+            const -> NrAndOffset<typename ArrayExtents::value_type>
+        {
+            static_assert(!isComputed(rc));
+            return Inner::blobNrAndOffset(ai, rc);
+        }
+    };
+
+    /// Binds parameters to a \ref Projection mapping except for array and record dimension, producing a quoted
+    /// meta function accepting the latter two. Useful to to prepare this mapping for a meta mapping.
+    template<template<typename, typename> typename InnerMapping, typename ProjectionMap>
+    struct BindProjection
+    {
+        template<typename ArrayExtents, typename RecordDim>
+        using fn = Projection<ArrayExtents, RecordDim, InnerMapping, ProjectionMap>;
+    };
+
+    template<typename Mapping>
+    inline constexpr bool isProjection = false;
+
+    template<
+        typename TArrayExtents,
+        typename TRecordDim,
+        template<typename, typename>
+        typename InnerMapping,
+        typename ReplacementMap>
+    inline constexpr bool isProjection<Projection<TArrayExtents, TRecordDim, InnerMapping, ReplacementMap>> = true;
+} // namespace llama::mapping

--- a/tests/mapping.Projection.cpp
+++ b/tests/mapping.Projection.cpp
@@ -1,0 +1,102 @@
+#include "common.hpp"
+
+#include <cstdint>
+
+TEST_CASE("mapping.Projection.AoS")
+{
+    auto mapping = llama::mapping::Projection<
+        llama::ArrayExtents<std::size_t, 128>,
+        Vec3D,
+        llama::mapping::BindAoS<false>::fn,
+        boost::mp11::mp_list<>>{{}};
+    CHECK(mapping.blobSize(0) == 3072);
+    auto view = llama::allocView(mapping);
+    iotaFillView(view);
+    iotaCheckView(view);
+}
+
+namespace
+{
+    struct DoubleToFloat
+    {
+        static auto load(float f) -> double
+        {
+            return f;
+        }
+
+        static auto store(double d) -> float
+        {
+            return static_cast<float>(d);
+        }
+    };
+} // namespace
+
+TEST_CASE("mapping.Projection.AoS.DoubleToFloat")
+{
+    auto mapping = llama::mapping::Projection<
+        llama::ArrayExtents<std::size_t, 128>,
+        Vec3D,
+        llama::mapping::BindAoS<false>::fn,
+        boost::mp11::mp_list<boost::mp11::mp_list<double, DoubleToFloat>>>{{}};
+    CHECK(mapping.blobSize(0) == 1536);
+    auto view = llama::allocView(mapping);
+    iotaFillView(view);
+    iotaCheckView(view);
+}
+
+namespace
+{
+    struct Sqrt
+    {
+        static auto load(float v) -> double
+        {
+            return std::sqrt(v);
+        }
+
+        static auto store(double d) -> float
+        {
+            return static_cast<float>(d * d);
+        }
+    };
+} // namespace
+
+TEST_CASE("mapping.Projection.AoS.Sqrt")
+{
+    auto mapping = llama::mapping::Projection<
+        llama::ArrayExtents<std::size_t, 128>,
+        Vec3D,
+        llama::mapping::BindAoS<false>::fn,
+        boost::mp11::mp_list<boost::mp11::mp_list<double, Sqrt>>>{{}};
+    CHECK(mapping.blobSize(0) == 1536);
+    auto view = llama::allocView(mapping);
+    iotaFillView(view);
+    iotaCheckView(view);
+}
+
+TEST_CASE("mapping.Projection.AoS.Coord1.Sqrt")
+{
+    auto mapping = llama::mapping::Projection<
+        llama::ArrayExtents<std::size_t, 128>,
+        Vec3D,
+        llama::mapping::BindAoS<false>::fn,
+        boost::mp11::mp_list<boost::mp11::mp_list<llama::RecordCoord<1>, Sqrt>>>{{}};
+    CHECK(mapping.blobSize(0) == 2560);
+    auto view = llama::allocView(mapping);
+    iotaFillView(view);
+    iotaCheckView(view);
+}
+
+TEST_CASE("mapping.Projection.AoS.CoordsAndTypes")
+{
+    auto mapping = llama::mapping::Projection<
+        llama::ArrayExtents<std::size_t, 128>,
+        Vec3D,
+        llama::mapping::BindAoS<false>::fn,
+        boost::mp11::
+            mp_list<boost::mp11::mp_list<double, DoubleToFloat>, boost::mp11::mp_list<llama::RecordCoord<1>, Sqrt>>>{
+        {}};
+    CHECK(mapping.blobSize(0) == 1536);
+    auto view = llama::allocView(mapping);
+    iotaFillView(view);
+    iotaCheckView(view);
+}


### PR DESCRIPTION
This PR adds the new mappings `Projection` and `Byteswap`. The `ChangeType` mapping is reimplemented based on `Projection`.