### PR TITLE
Tighten requirements for computed mappings

### DIFF
--- a/docs/pages/mappings.rst
+++ b/docs/pages/mappings.rst
@@ -94,7 +94,7 @@ The integral type used for computing blob number and offset should be the value 
         template <typename M>
         concept ComputedMapping = Mapping<M> && requires(M m, typename M::ArrayIndex ai, RecordCoord<> rc) {
             { m.isComputed(rc) } -> std::same_as<bool>;
-            { m.compute(ai, rc, Array<Array<std::byte, 0>, 0>{}) } -> AnyReference;
+            { m.compute(ai, rc, Array<Array<std::byte, 0>, 0>{}) } -> AnyReferenceTo<GetType<typename M::RecordDim, RC>>;
             { m.blobNrAndOffset(ai, rc) } -> std::same_as<NrAndOffset<typename M::ArrayExtents::value_type>>;
         };
 

--- a/include/llama/Concepts.hpp
+++ b/include/llama/Concepts.hpp
@@ -56,9 +56,12 @@ namespace llama
     template <typename R>
     concept AnyReference = LValueReference<R> || ProxyReference<R>;
 
+    template <typename R, typename T>
+    concept AnyReferenceTo = (LValueReference<R> && std::is_same_v<std::remove_cvref_t<R>, T>) || (ProxyReference<R> && std::is_same_v<typename R::value_type, T>);
+
     template <typename M, typename RC>
     concept ComputedField = M::isComputed(RC{}) && requires(M m, typename M::ArrayIndex ai, Array<Array<std::byte, 1>, 1> blobs) {
-        { m.compute(ai, RC{}, blobs) } -> AnyReference;
+        { m.compute(ai, RC{}, blobs) } -> AnyReferenceTo<GetType<typename M::RecordDim, RC>>;
     };
 
     template<typename M>

--- a/tests/mapping.cpp
+++ b/tests/mapping.cpp
@@ -27,6 +27,7 @@ TEMPLATE_LIST_TEST_CASE("mapping.concepts", "", SizeTypes)
 
     using Inner = llama::mapping::AlignedAoS<llama::ArrayExtentsDynamic<TestType, 2>, Particle>;
     STATIC_REQUIRE(llama::FullyComputedMapping<llama::mapping::Trace<Inner>>);
+    STATIC_REQUIRE(llama::FullyComputedMapping<llama::mapping::Trace<Inner, std::size_t, false>>);
 #    ifndef _MSC_VER
     STATIC_REQUIRE(llama::FullyComputedMapping<llama::mapping::Heatmap<Inner>>);
 #    endif


### PR DESCRIPTION
The value type of references returned from computed mappings must match the corresponding type in the record dimension.