### PR TITLE
Extend PermuteArrayIndex constructor overload set

### DIFF
--- a/include/llama/mapping/PermuteArrayIndex.hpp
+++ b/include/llama/mapping/PermuteArrayIndex.hpp
@@ -18,9 +18,20 @@ namespace llama::mapping
 
     public:
         using Inner = Mapping;
-
-        using Inner::Inner;
         using ArrayIndex = typename Inner::ArrayIndex;
+
+        constexpr PermuteArrayIndex() = default;
+
+        LLAMA_FN_HOST_ACC_INLINE
+        explicit PermuteArrayIndex(Mapping mapping) : Mapping(std::move(mapping))
+        {
+        }
+
+        template<typename... Args>
+        LLAMA_FN_HOST_ACC_INLINE explicit PermuteArrayIndex(Args&&... innerArgs)
+            : Mapping(std::forward<Args>(innerArgs)...)
+        {
+        }
 
         static_assert(
             sizeof...(Permutation) == ArrayIndex::rank,

--- a/tests/mapping.PermuteArrayIndex.cpp
+++ b/tests/mapping.PermuteArrayIndex.cpp
@@ -1,9 +1,21 @@
 #include "common.hpp"
 
+TEST_CASE("mapping.PermuteArrayIndex.ctors")
+{
+    using AE = llama::ArrayExtentsDynamic<int, 3>;
+    using InnerMapping = llama::mapping::AoS<AE, Vec3I>;
+
+    auto inner = InnerMapping{AE{3, 4, 5}};
+    [[maybe_unused]] auto perm1 = llama::mapping::PermuteArrayIndex<InnerMapping, 2, 0, 1>{};
+    [[maybe_unused]] auto perm2 = llama::mapping::PermuteArrayIndex<InnerMapping, 2, 0, 1>{AE{3, 4, 5}};
+    [[maybe_unused]] auto perm3 = llama::mapping::PermuteArrayIndex<InnerMapping, 2, 0, 1>{inner};
+}
+
 TEST_CASE("mapping.PermuteArrayIndex")
 {
     using InnerMapping = llama::mapping::AoS<llama::ArrayExtents<int, 4, 5, 6>, Vec3I>;
-    auto view = llama::allocView(InnerMapping{{}});
+    auto inner = InnerMapping{{}};
+    auto view = llama::allocView(inner);
 
     for(int x = 0; x < 4; x++)
         for(int y = 0; y < 5; y++)


### PR DESCRIPTION
Additionally allows construction from inner mapping.