### PR TITLE
Workaround nvcc failing to call base class ctors

### DIFF
--- a/include/llama/mapping/One.hpp
+++ b/include/llama/mapping/One.hpp
@@ -31,7 +31,15 @@ namespace llama::mapping
         using Flattener = FlattenRecordDim<TRecordDim>;
         static constexpr std::size_t blobCount = 1;
 
+#ifndef __NVCC__
         using Base::Base;
+#else
+        constexpr One() = default;
+
+        LLAMA_FN_HOST_ACC_INLINE constexpr explicit One(TArrayExtents extents, TRecordDim = {}) : Base(extents)
+        {
+        }
+#endif
 
         LLAMA_FN_HOST_ACC_INLINE constexpr auto blobSize(size_type) const -> size_type
         {

--- a/include/llama/mapping/SoA.hpp
+++ b/include/llama/mapping/SoA.hpp
@@ -39,7 +39,15 @@ namespace llama::mapping
         inline static constexpr std::size_t blobCount
             = SeparateBuffers ? boost::mp11::mp_size<FlatRecordDim<TRecordDim>>::value : 1;
 
+#ifndef __NVCC__
         using Base::Base;
+#else
+        constexpr SoA() = default;
+
+        LLAMA_FN_HOST_ACC_INLINE constexpr explicit SoA(TArrayExtents extents, TRecordDim = {}) : Base(extents)
+        {
+        }
+#endif
 
         LLAMA_FN_HOST_ACC_INLINE
         constexpr auto blobSize([[maybe_unused]] size_type blobIndex) const -> size_type


### PR DESCRIPTION
And that occurs in picongpu.