### PR TITLE
Improve dumping

### DIFF
--- a/include/llama/Core.hpp
+++ b/include/llama/Core.hpp
@@ -18,12 +18,6 @@ namespace llama
     {
     };
 
-    /// A type list of \ref Field%s which may be used to define a record dimension.
-    template<typename... Fields>
-    struct Record
-    {
-    };
-
     /// @brief Tells whether the given type is allowed as a field type in LLAMA. Such types need to be trivially
     /// constructible and trivially destructible.
     template<typename T>
@@ -40,6 +34,23 @@ namespace llama
     struct Field
     {
         static_assert(isAllowedFieldType<Type>, "This field's type is not allowed");
+    };
+
+    template<typename T>
+    inline constexpr bool isField = false;
+
+    template<typename Tag, typename Type>
+    inline constexpr bool isField<Field<Tag, Type>> = true;
+
+    /// A type list of \ref Field%s which may be used to define a record dimension.
+    template<typename... Fields>
+#if __cpp_concepts
+        // Cannot use a fold expression here, because clang/nvcc/icx cannot handle more than 256 arguments.
+        // If you get an error here, then you passed a type which is not llama::Field as argument to Record
+        requires(boost::mp11::mp_all<boost::mp11::mp_bool<isField<Fields>>...>::value)
+#endif
+    struct Record
+    {
     };
 
     template<typename T>

--- a/include/llama/DumpMapping.hpp
+++ b/include/llama/DumpMapping.hpp
@@ -40,6 +40,38 @@ namespace llama
             return c;
         }
 
+        // from: https://stackoverflow.com/questions/5665231/most-efficient-way-to-escape-xml-html-in-c-string
+        inline auto xmlEscape(const std::string& str) -> std::string
+        {
+            std::string result;
+            result.reserve(str.size());
+            for(const char c : str)
+            {
+                switch(c)
+                {
+                case '&':
+                    result.append("&amp;");
+                    break;
+                case '\"':
+                    result.append("&quot;");
+                    break;
+                case '\'':
+                    result.append("&apos;");
+                    break;
+                case '<':
+                    result.append("&lt;");
+                    break;
+                case '>':
+                    result.append("&gt;");
+                    break;
+                default:
+                    result += c;
+                    break;
+                }
+            }
+            return result;
+        }
+
         template<typename T, std::size_t Dim>
         auto formatArrayIndex(const ArrayIndex<T, Dim>& ai)
         {
@@ -347,7 +379,7 @@ namespace llama
                 x + width / 2,
                 y + byteSizeInPixel * 3 / 4,
                 internal::formatArrayIndex(info.arrayIndex),
-                info.recordTags);
+                internal::xmlEscape(std::string{info.recordTags}));
             if(cropBoxes)
                 svg += R"(</svg>
 )";
@@ -463,7 +495,7 @@ namespace llama
                 R"(<div class="box {0}" title="{1} {2}">{1} {2}</div>)",
                 internal::cssClass(std::string{info.recordTags}),
                 internal::formatArrayIndex(info.arrayIndex),
-                info.recordTags);
+                internal::xmlEscape(std::string{info.recordTags}));
         }
         html += R"(</body>
 </html>)";

--- a/include/llama/StructName.hpp
+++ b/include/llama/StructName.hpp
@@ -261,9 +261,12 @@ namespace llama
     {
         constexpr auto intToStrSize(std::size_t s)
         {
-            std::size_t len = 1;
-            for(auto n = s; n != 0; n /= 10)
+            std::size_t len = 0;
+            do
+            {
                 len++;
+                s /= 10;
+            } while(s != 0);
             return len;
         }
 
@@ -291,8 +294,6 @@ namespace llama
             }
             ();
             llama::Array<char, size> a{};
-            for(auto& c : a)
-                c = '?';
             auto w = a.begin();
 
             boost::mp11::mp_for_each<Tags>([&](auto tag) constexpr {

--- a/tests/dump.cpp
+++ b/tests/dump.cpp
@@ -43,6 +43,13 @@ TEST_CASE("dump.different_extents")
     CHECK(refHtml == llama::toHtml(mapping4));
 }
 
+TEST_CASE("dump.xmlEscape")
+{
+    CHECK(llama::internal::xmlEscape("position") == "position");
+    CHECK(llama::internal::xmlEscape("position<position_pic>") == "position&lt;position_pic&gt;");
+    CHECK(llama::internal::xmlEscape("a<b>c&d\"e'f") == "a&lt;b&gt;c&amp;d&quot;e&apos;f");
+}
+
 TEST_CASE("dump.int")
 {
     dump(llama::mapping::AlignedAoS<llama::ArrayExtentsDynamic<std::size_t, 1>, int>{{32}});


### PR DESCRIPTION
This PR contains several small fixes for the dumping and textual representations of record dimension tags.

- Escape recordTags before dumping into HTML/SVG
- Add more tests for recordCoordTags
- Fix names when dumping record dims with arrays
- Check that Record is only instantiated with fields
- Add picongpu related tests for structName and qualifiedTypeName