### PR TITLE
Improve BitPackedIntSoA

### DIFF
--- a/include/llama/Array.hpp
+++ b/include/llama/Array.hpp
@@ -42,12 +42,12 @@ namespace llama
 
         LLAMA_FN_HOST_ACC_INLINE constexpr auto end() -> T*
         {
-            return &element[N];
+            return &element[0] + N;
         }
 
         LLAMA_FN_HOST_ACC_INLINE constexpr auto end() const -> const T*
         {
-            return &element[N];
+            return &element[0] + N;
         }
 
         LLAMA_FN_HOST_ACC_INLINE constexpr auto front() -> T&

--- a/tests/mapping.BitPackedIntSoA.cpp
+++ b/tests/mapping.BitPackedIntSoA.cpp
@@ -198,6 +198,17 @@ TEST_CASE("mapping.BitPackedIntSoA.Size")
         sizeof(llama::mapping::BitPackedIntSoA<llama::ArrayExtents<unsigned, 16>, SInts>{{}, 7}) == sizeof(unsigned));
 }
 
+TEST_CASE("mapping.BitPackedIntSoA.FullBitWidth.16")
+{
+    // this could detect bugs when shifting integers by their bit-width
+    auto view = llama::allocView(
+        llama::mapping::BitPackedIntSoA<llama::ArrayExtents<>, std::uint16_t, llama::Constant<16>>{});
+
+    constexpr std::uint16_t value = 0xAABB;
+    view() = value;
+    CHECK(view() == value);
+}
+
 TEST_CASE("mapping.BitPackedIntSoA.FullBitWidth.32")
 {
     // this could detect bugs when shifting integers by their bit-width
@@ -218,4 +229,10 @@ TEST_CASE("mapping.BitPackedIntSoA.FullBitWidth.64")
     constexpr std::uint64_t value = 0xAABBCCDDEEFF8899;
     view() = value;
     CHECK(view() == value);
+}
+
+TEST_CASE("mapping.BitPackedIntSoA.ValidateBitsSmallerThanFieldType")
+{
+    // 11 bits are larger than the uint8_t field type
+    CHECK_THROWS(llama::mapping::BitPackedIntSoA<llama::ArrayExtents<std::size_t, 16>, UInts, unsigned>{{}, 11});
 }

--- a/tests/mapping.BitPackedIntSoA.cpp
+++ b/tests/mapping.BitPackedIntSoA.cpp
@@ -173,10 +173,6 @@ TEMPLATE_TEST_CASE("mapping.BitPackedIntSoA.Enum", "", Grades, GradesClass)
 {
     using Enum = TestType;
 
-    using StoredIntegral =
-        typename llama::mapping::internal::MakeUnsigned<llama::mapping::internal::LargestIntegral<Enum>>::type;
-    STATIC_REQUIRE(std::is_same_v<StoredIntegral, unsigned>);
-
     auto view = llama::allocView(
         llama::mapping::BitPackedIntSoA<llama::ArrayExtentsDynamic<std::size_t, 1>, Enum, llama::Constant<3>>{{6}});
     view(0) = Enum::A;
@@ -202,8 +198,18 @@ TEST_CASE("mapping.BitPackedIntSoA.Size")
         sizeof(llama::mapping::BitPackedIntSoA<llama::ArrayExtents<unsigned, 16>, SInts>{{}, 7}) == sizeof(unsigned));
 }
 
+TEST_CASE("mapping.BitPackedIntSoA.FullBitWidth.32")
+{
+    // this could detect bugs when shifting integers by their bit-width
+    auto view = llama::allocView(
+        llama::mapping::BitPackedIntSoA<llama::ArrayExtents<>, std::uint32_t, llama::Constant<32>>{});
 
-TEST_CASE("mapping.BitPackedIntSoA.FullBitWidth")
+    constexpr std::uint32_t value = 0xAABBCCDD;
+    view() = value;
+    CHECK(view() == value);
+}
+
+TEST_CASE("mapping.BitPackedIntSoA.FullBitWidth.64")
 {
     // this could detect bugs when shifting integers by their bit-width
     auto view = llama::allocView(

--- a/tests/mapping.BitPackedIntSoA.cpp
+++ b/tests/mapping.BitPackedIntSoA.cpp
@@ -237,6 +237,21 @@ TEST_CASE("mapping.BitPackedIntSoA.ValidateBitsSmallerThanFieldType")
     CHECK_THROWS(llama::mapping::BitPackedIntSoA<llama::ArrayExtents<std::size_t, 16>, UInts, unsigned>{{}, 11});
 }
 
+TEST_CASE("mapping.BitPackedIntSoA.ValidateBitsSmallerThanStorageIntegral")
+{
+    CHECK_THROWS(llama::mapping::BitPackedIntSoA<
+                 llama::ArrayExtents<std::size_t, 16>,
+                 std::uint32_t,
+                 unsigned,
+                 llama::mapping::LinearizeArrayDimsCpp,
+                 std::uint32_t>{{}, 40});
+}
+
+TEST_CASE("mapping.BitPackedIntSoA.ValidateBitsNotZero")
+{
+    CHECK_THROWS(llama::mapping::BitPackedIntSoA<llama::ArrayExtents<std::size_t, 16>, UInts, unsigned>{{}, 0});
+}
+
 TEMPLATE_TEST_CASE(
     "mapping.BitPackedIntSoA.bitpack",
     "",
@@ -254,25 +269,28 @@ TEMPLATE_TEST_CASE(
         [](auto si)
         {
             using StoredIntegral = decltype(si);
-            std::vector<StoredIntegral> blob(sizeof(Integral) * 32);
-
-            // 5 bits are required to store values from 0..31, +1 for sign bit
-            for(StoredIntegral bitCount = 5 + 1; bitCount <= sizeof(Integral) * CHAR_BIT; bitCount++)
+            if constexpr(sizeof(StoredIntegral) >= sizeof(TestType))
             {
-                for(Integral i = 0; i < 32; i++)
-                    llama::mapping::internal::bitpack<Integral>(
-                        blob.data(),
-                        static_cast<StoredIntegral>(i * bitCount),
-                        bitCount,
-                        i);
+                std::vector<StoredIntegral> blob(sizeof(Integral) * 32);
 
-                for(Integral i = 0; i < 32; i++)
-                    CHECK(
-                        llama::mapping::internal::bitunpack<Integral>(
+                // 5 bits are required to store values from 0..31, +1 for sign bit
+                for(StoredIntegral bitCount = 5 + 1; bitCount <= sizeof(Integral) * CHAR_BIT; bitCount++)
+                {
+                    for(Integral i = 0; i < 32; i++)
+                        llama::mapping::internal::bitpack<Integral>(
                             blob.data(),
                             static_cast<StoredIntegral>(i * bitCount),
-                            bitCount)
-                        == i);
+                            bitCount,
+                            i);
+
+                    for(Integral i = 0; i < 32; i++)
+                        CHECK(
+                            llama::mapping::internal::bitunpack<Integral>(
+                                blob.data(),
+                                static_cast<StoredIntegral>(i * bitCount),
+                                bitCount)
+                            == i);
+                }
             }
         });
 }

--- a/tests/mapping.BitPackedIntSoA.cpp
+++ b/tests/mapping.BitPackedIntSoA.cpp
@@ -201,3 +201,15 @@ TEST_CASE("mapping.BitPackedIntSoA.Size")
     STATIC_REQUIRE(
         sizeof(llama::mapping::BitPackedIntSoA<llama::ArrayExtents<unsigned, 16>, SInts>{{}, 7}) == sizeof(unsigned));
 }
+
+
+TEST_CASE("mapping.BitPackedIntSoA.FullBitWidth")
+{
+    // this could detect bugs when shifting integers by their bit-width
+    auto view = llama::allocView(
+        llama::mapping::BitPackedIntSoA<llama::ArrayExtents<>, std::uint64_t, llama::Constant<64>>{});
+
+    constexpr std::uint64_t value = 0xAABBCCDDEEFF8899;
+    view() = value;
+    CHECK(view() == value);
+}

--- a/tests/mapping.Bytesplit.cpp
+++ b/tests/mapping.Bytesplit.cpp
@@ -59,15 +59,15 @@ TEST_CASE("mapping.ByteSplit.ChangeType.SoA")
 
 TEST_CASE("mapping.ByteSplit.Split.BitPackedIntSoA")
 {
-    auto view = llama::allocView(llama::mapping::Bytesplit<
-                                 llama::ArrayExtentsDynamic<int, 1>,
-                                 Vec3I,
-                                 llama::mapping::BindSplit<
-                                     llama::RecordCoord<1>,
-                                     llama::mapping::BitPackedIntSoA,
-                                     llama::mapping::BindAoS<>::fn,
-                                     true>::fn>{
-        std::tuple{std::tuple{llama::ArrayExtents{128}, 23}, std::tuple{llama::ArrayExtents{128}}}});
+    auto view = llama::allocView(
+        llama::mapping::Bytesplit<
+            llama::ArrayExtentsDynamic<int, 1>,
+            Vec3I,
+            llama::mapping::BindSplit<
+                llama::RecordCoord<1>,
+                llama::mapping::BitPackedIntSoA,
+                llama::mapping::BindAoS<>::fn,
+                true>::fn>{std::tuple{std::tuple{llama::ArrayExtents{128}, 8}, std::tuple{llama::ArrayExtents{128}}}});
     iotaFillView(view);
     iotaCheckView(view);
 }


### PR DESCRIPTION
* Fix a mask generation: If the packed bit count is the same as the bit count of the storage integral, the code invoked UB during shifts.
* Further hardening of the packing/unpacking code.
* Fix UB in `llama::Array` reported by UBSan.