### PR TITLE
Study layout effects on LHCB B2HHH analysis

### DIFF
--- a/examples/root/lhcb_analysis/CMakeLists.txt
+++ b/examples/root/lhcb_analysis/CMakeLists.txt
@@ -2,9 +2,11 @@ cmake_minimum_required (VERSION 3.18)
 project(llama-root-lhcb_analysis)
 
 find_package(ROOT REQUIRED)
+find_package(OpenMP REQUIRED)
 if (NOT TARGET llama::llama)
 	find_package(llama REQUIRED)
 endif()
 add_executable(${PROJECT_NAME} lhcb.cpp)
 #target_compile_features(${PROJECT_NAME} PUBLIC cxx_std_20)
-target_link_libraries(${PROJECT_NAME} PRIVATE ROOT::Hist ROOT::Graf ROOT::Gpad ROOT::ROOTNTuple llama::llama)
+target_link_libraries(${PROJECT_NAME} PRIVATE
+		ROOT::Hist ROOT::Graf ROOT::Gpad ROOT::ROOTNTuple llama::llama OpenMP::OpenMP_CXX)


### PR DESCRIPTION
This changeset extends the ROOT LHCB B2HHH analysis example:

* Parallelize histogram generation
* Test multiple memory layouts
* Save histograms to disk
* Extend benchmark result by mean, stddev, error
