### PR TITLE
Allow BitPackedIntSoA to omit sign bit

### DIFF
--- a/include/llama/mapping/BitPackedFloatSoA.hpp
+++ b/include/llama/mapping/BitPackedFloatSoA.hpp
@@ -120,7 +120,8 @@ namespace llama::mapping
                 FloatBits,
                 StoredIntegralCV,
                 decltype(integBits(std::declval<VHExp>(), std::declval<VHMan>())),
-                SizeType>
+                SizeType,
+                SignBit::Discard>
                 intref;
 
         public:

--- a/tests/mapping.Bytesplit.cpp
+++ b/tests/mapping.Bytesplit.cpp
@@ -1,6 +1,6 @@
 #include "common.hpp"
 
-//#include <bit>
+// #include <bit>
 
 TEST_CASE("mapping.ByteSplit.AoS")
 {
@@ -65,7 +65,7 @@ TEST_CASE("mapping.ByteSplit.Split.BitPackedIntSoA")
             Vec3I,
             llama::mapping::BindSplit<
                 llama::RecordCoord<1>,
-                llama::mapping::BitPackedIntSoA,
+                llama::mapping::BindBitPackedIntSoA<>::fn,
                 llama::mapping::BindAoS<>::fn,
                 true>::fn>{std::tuple{std::tuple{llama::ArrayExtents{128}, 8}, std::tuple{llama::ArrayExtents{128}}}});
     iotaFillView(view);

--- a/tests/mapping.Split.cpp
+++ b/tests/mapping.Split.cpp
@@ -218,8 +218,11 @@ TEST_CASE("mapping.Split.BitPacked")
         Vec3I,
         llama::RecordCoord<0>,
         llama::mapping::BindBitPackedIntSoA<llama::Constant<3>>::fn,
-        llama::mapping::
-            BindSplit<llama::RecordCoord<0>, llama::mapping::BitPackedIntSoA, llama::mapping::PackedAoS, true>::fn,
+        llama::mapping::BindSplit<
+            llama::RecordCoord<0>,
+            llama::mapping::BindBitPackedIntSoA<>::fn,
+            llama::mapping::PackedAoS,
+            true>::fn,
         true>{std::tuple{extents}, std::tuple{std::tuple{extents, 5}, std::tuple{extents}}};
 
     STATIC_REQUIRE(mapping.blobCount == 3);


### PR DESCRIPTION
This saves one bit when storing signed integers.