### PR TITLE
Reduce CI build jobs to 2

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -10,7 +10,7 @@ concurrency:
   cancel-in-progress: true
 
 env:
-  THREADS: 4
+  THREADS: 2
   CONFIG: RelWithDebInfo
   VCPKG_INSTALL: "vcpkg install alpaka fmt tinyobjloader boost-mp11 boost-atomic boost-smart-ptr boost-functional boost-container boost-iostreams[core] catch2; until vcpkg install --head xsimd; do echo 'Retrying'; done"
 


### PR DESCRIPTION
This is a bit faster than running with 4 build jobs.