### PR TITLE
Add missing license identifier

### DIFF
--- a/examples/alpaka/asyncblur/CMakeLists.txt
+++ b/examples/alpaka/asyncblur/CMakeLists.txt
@@ -1,3 +1,6 @@
+# Copyright 2022 Alexander Matthes, Bernhard Manfred Gruber
+# SPDX-License-Identifier: CC0-1.0
+
 cmake_minimum_required (VERSION 3.18.3)
 project(llama-alpaka-asyncblur CXX)
 

--- a/examples/alpaka/asyncblur/asyncblur.cpp
+++ b/examples/alpaka/asyncblur/asyncblur.cpp
@@ -1,14 +1,5 @@
-/* To the extent possible under law, Alexander Matthes has waived all
- * copyright and related or neighboring rights to this example of LLAMA using
- * the CC0 license, see https://creativecommons.org/publicdomain/zero/1.0 .
- *
- * This example is meant to be "stolen" from to learn how to use LLAMA, which
- * itself is not under the public domain but LGPL3+.
- */
-
-/** \file asynccopy.cpp
- *  \brief Asynchronous bluring example for LLAMA using ALPAKA.
- */
+// Copyright 2022 Alexander Matthes, Bernhard Manfred Gruber
+// SPDX-License-Identifier: CC0-1.0
 
 #define STB_IMAGE_IMPLEMENTATION
 #define STB_IMAGE_WRITE_IMPLEMENTATION

--- a/examples/alpaka/babelstream/CMakeLists.txt
+++ b/examples/alpaka/babelstream/CMakeLists.txt
@@ -1,3 +1,6 @@
+# Copyright 2022 Bernhard Manfred Gruber
+# SPDX-License-Identifier: CC0-1.0
+
 cmake_minimum_required (VERSION 3.18.3)
 project(llama-alpaka-babelstream CXX)
 

--- a/examples/alpaka/daxpy/CMakeLists.txt
+++ b/examples/alpaka/daxpy/CMakeLists.txt
@@ -1,3 +1,6 @@
+# Copyright 2022 Bernhard Manfred Gruber
+# SPDX-License-Identifier: LGPL-3.0-or-later
+
 cmake_minimum_required (VERSION 3.18.3)
 project(llama-alpaka-daxpy CXX)
 

--- a/examples/alpaka/daxpy/daxpy.cpp
+++ b/examples/alpaka/daxpy/daxpy.cpp
@@ -1,3 +1,6 @@
+// Copyright 2022 Bernhard Manfred Gruber
+// SPDX-License-Identifier: LGPL-3.0-or-later
+
 #include "../../common/Stopwatch.hpp"
 #include "../../common/hostname.hpp"
 

--- a/examples/alpaka/nbody/CMakeLists.txt
+++ b/examples/alpaka/nbody/CMakeLists.txt
@@ -1,3 +1,6 @@
+# Copyright 2022 Bernhard Manfred Gruber
+# SPDX-License-Identifier: LGPL-3.0-or-later
+
 cmake_minimum_required (VERSION 3.18.3)
 project(llama-alpaka-nbody CXX)
 

--- a/examples/alpaka/nbody/nbody.cpp
+++ b/examples/alpaka/nbody/nbody.cpp
@@ -1,3 +1,6 @@
+// Copyright 2022 Bernhard Manfred Gruber
+// SPDX-License-Identifier: LGPL-3.0-or-later
+
 #include "../../common/Stopwatch.hpp"
 #include "../../common/hostname.hpp"
 

--- a/examples/alpaka/pic/CMakeLists.txt
+++ b/examples/alpaka/pic/CMakeLists.txt
@@ -1,3 +1,6 @@
+# Copyright 2022 Bernhard Manfred Gruber
+# SPDX-License-Identifier: LGPL-3.0-or-later
+
 cmake_minimum_required (VERSION 3.18.3)
 project(llama-alpaka-pic)
 

--- a/examples/alpaka/pic/pic.cpp
+++ b/examples/alpaka/pic/pic.cpp
@@ -1,9 +1,6 @@
-/*
- * main.cpp
- *
- *  Created on: Aug 20, 2020
- *      Author: Jiri Vyskocil
- */
+// Copyright 2020 Jiri Vyskocil, Bernhard Manfred Gruber
+// SPDX-License-Identifier: LGPL-3.0-or-later
+
 #define _USE_MATH_DEFINES // NOLINT
 #if defined(ALPAKA_ACC_GPU_CUDA_ENABLED) && !defined(ALPAKA_ACC_GPU_CUDA_ONLY_MODE)
 #    define ALPAKA_ACC_GPU_CUDA_ONLY_MODE

--- a/examples/alpaka/vectoradd/CMakeLists.txt
+++ b/examples/alpaka/vectoradd/CMakeLists.txt
@@ -1,3 +1,6 @@
+# Copyright 2022 Bernhard Manfred Gruber
+# SPDX-License-Identifier: CC0-1.0
+
 cmake_minimum_required (VERSION 3.18.3)
 project(llama-alpaka-vectoradd CXX)
 

--- a/examples/alpaka/vectoradd/vectoradd.cpp
+++ b/examples/alpaka/vectoradd/vectoradd.cpp
@@ -1,10 +1,5 @@
-/* To the extent possible under law, Alexander Matthes has waived all
- * copyright and related or neighboring rights to this example of LLAMA using
- * the CC0 license, see https://creativecommons.org/publicdomain/zero/1.0 .
- *
- * This example is meant to be "stolen" from to learn how to use LLAMA, which
- * itself is not under the public domain but LGPL3+.
- */
+// Copyright 2022 Alexander Matthes, Bernhard Manfred Gruber
+// SPDX-License-Identifier: CC0-1.0
 
 #include "../../common/Stopwatch.hpp"
 #include "../../common/hostname.hpp"

--- a/examples/bitpackfloat/CMakeLists.txt
+++ b/examples/bitpackfloat/CMakeLists.txt
@@ -1,3 +1,6 @@
+# Copyright 2022 Bernhard Manfred Gruber
+# SPDX-License-Identifier: LGPL-3.0-or-later
+
 cmake_minimum_required (VERSION 3.18.3)
 project(llama-bitpackfloat CXX)
 

--- a/examples/bitpackfloat/bitpackfloat.cpp
+++ b/examples/bitpackfloat/bitpackfloat.cpp
@@ -1,3 +1,6 @@
+// Copyright 2022 Bernhard Manfred Gruber
+// SPDX-License-Identifier: LGPL-3.0-or-later
+
 #include <fmt/core.h>
 #include <llama/llama.hpp>
 #include <random>

--- a/examples/bitpackint/CMakeLists.txt
+++ b/examples/bitpackint/CMakeLists.txt
@@ -1,3 +1,6 @@
+# Copyright 2022 Bernhard Manfred Gruber
+# SPDX-License-Identifier: LGPL-3.0-or-later
+
 cmake_minimum_required (VERSION 3.18.3)
 project(llama-bitpackint CXX)
 

--- a/examples/bitpackint/bitpackint.cpp
+++ b/examples/bitpackint/bitpackint.cpp
@@ -1,3 +1,6 @@
+// Copyright 2022 Bernhard Manfred Gruber
+// SPDX-License-Identifier: LGPL-3.0-or-later
+
 #include <cstdint>
 #include <fmt/core.h>
 #include <llama/llama.hpp>

--- a/examples/bufferguard/CMakeLists.txt
+++ b/examples/bufferguard/CMakeLists.txt
@@ -1,3 +1,6 @@
+# Copyright 2022 Bernhard Manfred Gruber
+# SPDX-License-Identifier: LGPL-3.0-or-later
+
 cmake_minimum_required (VERSION 3.18.3)
 project(llama-bufferguard CXX)
 

--- a/examples/bufferguard/bufferguard.cpp
+++ b/examples/bufferguard/bufferguard.cpp
@@ -1,3 +1,6 @@
+// Copyright 2021 Bernhard Manfred Gruber
+// SPDX-License-Identifier: LGPL-3.0-or-later
+
 #include <algorithm>
 #include <array>
 #include <cstring>

--- a/examples/bytesplit/CMakeLists.txt
+++ b/examples/bytesplit/CMakeLists.txt
@@ -1,3 +1,6 @@
+# Copyright 2022 Bernhard Manfred Gruber
+# SPDX-License-Identifier: LGPL-3.0-or-later
+
 cmake_minimum_required (VERSION 3.18.3)
 project(llama-bytesplit CXX)
 

--- a/examples/bytesplit/bytesplit.cpp
+++ b/examples/bytesplit/bytesplit.cpp
@@ -1,3 +1,6 @@
+// Copyright 2022 Bernhard Manfred Gruber
+// SPDX-License-Identifier: LGPL-3.0-or-later
+
 #include <cstdint>
 #include <fmt/core.h>
 #include <llama/llama.hpp>

--- a/examples/common/Stopwatch.hpp
+++ b/examples/common/Stopwatch.hpp
@@ -1,3 +1,6 @@
+// Copyright 2020 Bernhard Manfred Gruber
+// SPDX-License-Identifier: LGPL-3.0-or-later
+
 #pragma once
 
 #include <chrono>

--- a/examples/common/alpakaHelpers.hpp
+++ b/examples/common/alpakaHelpers.hpp
@@ -1,10 +1,5 @@
-/* To the extent possible under law, Alexander Matthes has waived all
- * copyright and related or neighboring rights to this example of LLAMA using
- * the CC0 license, see https://creativecommons.org/publicdomain/zero/1.0 .
- *
- * This example is meant to be "stolen" from to learn how to use LLAMA, which
- * itself is not under the public domain but LGPL3+.
- */
+// Copyright 2020 Alexander Matthes, Bernhard Manfred Gruber
+// SPDX-License-Identifier: CC0-1.0
 
 #pragma once
 

--- a/examples/common/hostname.hpp
+++ b/examples/common/hostname.hpp
@@ -1,4 +1,5 @@
-// SPDX-License-Identifier: GPL-3.0-or-later
+// Copyright 2021 Bernhard Manfred Gruber
+// SPDX-License-Identifier: LGPL-3.0-or-later
 
 #pragma once
 

--- a/examples/common/ttjet_13tev_june2019.hpp
+++ b/examples/common/ttjet_13tev_june2019.hpp
@@ -1,3 +1,6 @@
+// Copyright 2021 Bernhard Manfred Gruber
+// SPDX-License-Identifier: LGPL-3.0-or-later
+
 #pragma once
 
 // This record dimension example is inspired by a non-public CMS NanoAOD file called: ttjet_13tev_june2019_lzma.

--- a/examples/cuda/nbody/CMakeLists.txt
+++ b/examples/cuda/nbody/CMakeLists.txt
@@ -1,3 +1,6 @@
+# Copyright 2022 Bernhard Manfred Gruber
+# SPDX-License-Identifier: LGPL-3.0-or-later
+
 cmake_minimum_required(VERSION 3.18.3)
 project(llama-cuda-nbody CUDA)
 

--- a/examples/cuda/nbody/nbody.cu
+++ b/examples/cuda/nbody/nbody.cu
@@ -1,3 +1,6 @@
+// Copyright 2022 Bernhard Manfred Gruber
+// SPDX-License-Identifier: LGPL-3.0-or-later
+
 #include "../../common/Stopwatch.hpp"
 #include "../../common/hostname.hpp"
 

--- a/examples/cuda/pitch/CMakeLists.txt
+++ b/examples/cuda/pitch/CMakeLists.txt
@@ -1,3 +1,6 @@
+# Copyright 2022 Bernhard Manfred Gruber
+# SPDX-License-Identifier: LGPL-3.0-or-later
+
 cmake_minimum_required(VERSION 3.18.3)
 project(llama-cuda-pitch CUDA)
 

--- a/examples/cuda/pitch/pitch.cu
+++ b/examples/cuda/pitch/pitch.cu
@@ -1,3 +1,6 @@
+// Copyright 2022 Bernhard Manfred Gruber
+// SPDX-License-Identifier: LGPL-3.0-or-later
+
 #define STB_IMAGE_WRITE_IMPLEMENTATION
 
 #include <cstddef>

--- a/examples/heatequation/CMakeLists.txt
+++ b/examples/heatequation/CMakeLists.txt
@@ -1,3 +1,6 @@
+# Copyright 2020 Bernhard Manfred Gruber
+# SPDX-License-Identifier: ISC
+
 cmake_minimum_required (VERSION 3.18.3)
 project(llama-heatequation CXX)
 

--- a/examples/heatequation/heatequation.cpp
+++ b/examples/heatequation/heatequation.cpp
@@ -1,18 +1,5 @@
-/* Copyright 2020 Benjamin Worpitz, Matthias Werner, Jakob Krude,
- *                Sergei Bastrakov, Bernhard Manfred Gruber
- *
- * Permission to use, copy, modify, and/or distribute this software for any
- * purpose with or without fee is hereby granted, provided that the above
- * copyright notice and this permission notice appear in all copies.
- *
- * THE SOFTWARE IS PROVIDED “AS IS” AND ISC DISCLAIMS ALL WARRANTIES WITH
- * REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
- * MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL ISC BE LIABLE FOR ANY
- * SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
- * WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
- * ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF OR
- * IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
- */
+// Copyright 2020 Benjamin Worpitz, Matthias Werner, Jakob Krude, Sergei Bastrakov, Bernhard Manfred Gruber
+// SPDX-License-Identifier: ISC
 
 #include <algorithm>
 #include <chrono>

--- a/examples/memmap/CMakeLists.txt
+++ b/examples/memmap/CMakeLists.txt
@@ -1,3 +1,6 @@
+# Copyright 2022 Bernhard Manfred Gruber
+# SPDX-License-Identifier: LGPL-3.0-or-later
+
 cmake_minimum_required (VERSION 3.18.3)
 project(llama-memmap CXX)
 

--- a/examples/memmap/memmap.cpp
+++ b/examples/memmap/memmap.cpp
@@ -1,3 +1,6 @@
+// Copyright 2022 Bernhard Manfred Gruber
+// SPDX-License-Identifier: LGPL-3.0-or-later
+
 #include <boost/iostreams/device/mapped_file.hpp>
 #include <iostream>
 #include <llama/llama.hpp>

--- a/examples/nbody/CMakeLists.txt
+++ b/examples/nbody/CMakeLists.txt
@@ -1,3 +1,6 @@
+# Copyright 2022 Bernhard Manfred Gruber
+# SPDX-License-Identifier: LGPL-3.0-or-later
+
 cmake_minimum_required (VERSION 3.18.3)
 project(llama-nbody CXX)
 

--- a/examples/nbody/nbody.cpp
+++ b/examples/nbody/nbody.cpp
@@ -1,3 +1,6 @@
+// Copyright 2022 Bernhard Manfred Gruber
+// SPDX-License-Identifier: LGPL-3.0-or-later
+
 #include "../common/Stopwatch.hpp"
 #include "../common/hostname.hpp"
 

--- a/examples/raycast/CMakeLists.txt
+++ b/examples/raycast/CMakeLists.txt
@@ -1,3 +1,6 @@
+# Copyright 2020 Bernhard Manfred Gruber
+# SPDX-License-Identifier: LGPL-3.0-or-later
+
 cmake_minimum_required (VERSION 3.18.3)
 project (llama-raycast CXX)
 

--- a/examples/raycast/raycast.cpp
+++ b/examples/raycast/raycast.cpp
@@ -1,3 +1,6 @@
+// Copyright 2020 Bernhard Manfred Gruber
+// SPDX-License-Identifier: LGPL-3.0-or-later
+
 #include "../common/Stopwatch.hpp"
 
 #define STB_IMAGE_WRITE_IMPLEMENTATION

--- a/examples/root/lhcb_analysis/CMakeLists.txt
+++ b/examples/root/lhcb_analysis/CMakeLists.txt
@@ -1,3 +1,6 @@
+# Copyright 2022 Bernhard Manfred Gruber
+# SPDX-License-Identifier: LGPL-3.0-or-later
+
 cmake_minimum_required (VERSION 3.18)
 project(llama-root-lhcb_analysis)
 

--- a/examples/stream/CMakeLists.txt
+++ b/examples/stream/CMakeLists.txt
@@ -1,3 +1,6 @@
+# Copyright 2022 Bernhard Manfred Gruber
+# SPDX-License-Identifier: LGPL-3.0-or-later
+
 cmake_minimum_required (VERSION 3.18.3)
 
 find_package(OpenMP REQUIRED)

--- a/examples/vectoradd/CMakeLists.txt
+++ b/examples/vectoradd/CMakeLists.txt
@@ -1,3 +1,6 @@
+# Copyright 2021 Bernhard Manfred Gruber
+# SPDX-License-Identifier: LGPL-3.0-or-later
+
 cmake_minimum_required (VERSION 3.18.3)
 project(llama-vectoradd CXX)
 

--- a/examples/vectoradd/vectoradd.cpp
+++ b/examples/vectoradd/vectoradd.cpp
@@ -1,3 +1,6 @@
+// Copyright 2021 Bernhard Manfred Gruber
+// SPDX-License-Identifier: LGPL-3.0-or-later
+
 #include "../common/Stopwatch.hpp"
 #include "../common/hostname.hpp"
 

--- a/examples/viewcopy/CMakeLists.txt
+++ b/examples/viewcopy/CMakeLists.txt
@@ -1,3 +1,6 @@
+# Copyright 2020 Bernhard Manfred Gruber
+# SPDX-License-Identifier: LGPL-3.0-or-later
+
 cmake_minimum_required (VERSION 3.18.3)
 project(llama-viewcopy CXX)
 

--- a/examples/viewcopy/viewcopy.cpp
+++ b/examples/viewcopy/viewcopy.cpp
@@ -1,3 +1,6 @@
+// Copyright 2020 Bernhard Manfred Gruber
+// SPDX-License-Identifier: LGPL-3.0-or-later
+
 #include "../common/Stopwatch.hpp"
 #include "../common/hostname.hpp"
 #include "../common/ttjet_13tev_june2019.hpp"

--- a/include/llama/Accessors.hpp
+++ b/include/llama/Accessors.hpp
@@ -1,3 +1,6 @@
+// Copyright 2023 Bernhard Manfred Gruber
+// SPDX-License-Identifier: LGPL-3.0-or-later
+
 #pragma once
 
 #include "Concepts.hpp"

--- a/include/llama/Array.hpp
+++ b/include/llama/Array.hpp
@@ -1,5 +1,5 @@
-// Copyright 2018 Alexander Matthes
-// SPDX-License-Identifier: GPL-3.0-or-later
+// Copyright 2022 Alexander Matthes, Bernhard Manfred Gruber
+// SPDX-License-Identifier: LGPL-3.0-or-later
 
 #pragma once
 

--- a/include/llama/ArrayExtents.hpp
+++ b/include/llama/ArrayExtents.hpp
@@ -1,4 +1,5 @@
-// SPDX-License-Identifier: GPL-3.0-or-later
+// Copyright 2022 Bernhard Manfred Gruber
+// SPDX-License-Identifier: LGPL-3.0-or-later
 
 #pragma once
 

--- a/include/llama/ArrayIndexRange.hpp
+++ b/include/llama/ArrayIndexRange.hpp
@@ -1,3 +1,6 @@
+// Copyright 2022 Bernhard Manfred Gruber
+// SPDX-License-Identifier: LGPL-3.0-or-later
+
 #pragma once
 
 #include "ArrayExtents.hpp"

--- a/include/llama/BlobAllocators.hpp
+++ b/include/llama/BlobAllocators.hpp
@@ -1,5 +1,5 @@
-// Copyright 2018 Alexander Matthes
-// SPDX-License-Identifier: GPL-3.0-or-later
+// Copyright 2022 Alexander Matthes, Bernhard Manfred Gruber
+// SPDX-License-Identifier: LGPL-3.0-or-later
 
 #pragma once
 

--- a/include/llama/Concepts.hpp
+++ b/include/llama/Concepts.hpp
@@ -1,3 +1,6 @@
+// Copyright 2022 Bernhard Manfred Gruber
+// SPDX-License-Identifier: LGPL-3.0-or-later
+
 #pragma once
 
 #include "Array.hpp"

--- a/include/llama/Copy.hpp
+++ b/include/llama/Copy.hpp
@@ -1,4 +1,5 @@
-// SPDX-License-Identifier: GPL-3.0-or-later
+// Copyright 2021 Bernhard Manfred Gruber
+// SPDX-License-Identifier: LGPL-3.0-or-later
 
 #pragma once
 

--- a/include/llama/Core.hpp
+++ b/include/llama/Core.hpp
@@ -1,5 +1,5 @@
-// Copyright 2018 Alexander Matthes
-// SPDX-License-Identifier: GPL-3.0-or-later
+// Copyright 2023 Alexander Matthes, Bernhard Manfred Gruber
+// SPDX-License-Identifier: LGPL-3.0-or-later
 
 #pragma once
 

--- a/include/llama/DumpMapping.hpp
+++ b/include/llama/DumpMapping.hpp
@@ -1,4 +1,5 @@
-// SPDX-License-Identifier: GPL-3.0-or-later
+// Copyright 2022 Bernhard Manfred Gruber
+// SPDX-License-Identifier: LGPL-3.0-or-later
 
 #pragma once
 

--- a/include/llama/HasRanges.hpp
+++ b/include/llama/HasRanges.hpp
@@ -1,4 +1,5 @@
-// SPDX-License-Identifier: GPL-3.0-or-later
+// Copyright 2022 Bernhard Manfred Gruber
+// SPDX-License-Identifier: LGPL-3.0-or-later
 
 #pragma once
 

--- a/include/llama/Meta.hpp
+++ b/include/llama/Meta.hpp
@@ -1,4 +1,5 @@
-// SPDX-License-Identifier: GPL-3.0-or-later
+// Copyright 2022 Bernhard Manfred Gruber
+// SPDX-License-Identifier: LGPL-3.0-or-later
 
 #pragma once
 

--- a/include/llama/Proofs.hpp
+++ b/include/llama/Proofs.hpp
@@ -1,4 +1,5 @@
-// SPDX-License-Identifier: GPL-3.0-or-later
+// Copyright 2022 Bernhard Manfred Gruber
+// SPDX-License-Identifier: LGPL-3.0-or-later
 
 #pragma once
 

--- a/include/llama/ProxyRefOpMixin.hpp
+++ b/include/llama/ProxyRefOpMixin.hpp
@@ -1,4 +1,5 @@
-// SPDX-License-Identifier: GPL-3.0-or-later
+// Copyright 2022 Bernhard Manfred Gruber
+// SPDX-License-Identifier: LGPL-3.0-or-later
 
 #pragma once
 

--- a/include/llama/RecordCoord.hpp
+++ b/include/llama/RecordCoord.hpp
@@ -1,5 +1,5 @@
-// Copyright 2018 Alexander Matthes
-// SPDX-License-Identifier: GPL-3.0-or-later
+// Copyright 2022 Alexander Matthes, Bernhard Manfred Gruber
+// SPDX-License-Identifier: LGPL-3.0-or-later
 
 #pragma once
 

--- a/include/llama/RecordRef.hpp
+++ b/include/llama/RecordRef.hpp
@@ -1,5 +1,5 @@
-// Copyright 2018 Alexander Matthes
-// SPDX-License-Identifier: GPL-3.0-or-later
+// Copyright 2022 Alexander Matthes, Bernhard Manfred Gruber
+// SPDX-License-Identifier: LGPL-3.0-or-later
 
 #pragma once
 

--- a/include/llama/Simd.hpp
+++ b/include/llama/Simd.hpp
@@ -1,3 +1,6 @@
+// Copyright 2022 Bernhard Manfred Gruber
+// SPDX-License-Identifier: LGPL-3.0-or-later
+
 #pragma once
 
 #include "Core.hpp"

--- a/include/llama/StructName.hpp
+++ b/include/llama/StructName.hpp
@@ -1,4 +1,5 @@
-// SPDX-License-Identifier: GPL-3.0-or-later
+// Copyright 2022 Bernhard Manfred Gruber
+// SPDX-License-Identifier: LGPL-3.0-or-later
 
 #pragma once
 

--- a/include/llama/Tuple.hpp
+++ b/include/llama/Tuple.hpp
@@ -1,5 +1,5 @@
-// Copyright 2018 Alexander Matthes
-// SPDX-License-Identifier: GPL-3.0-or-later
+// Copyright 2023 Alexander Matthes, Bernhard Manfred Gruber
+// SPDX-License-Identifier: LGPL-3.0-or-later
 
 #pragma once
 

--- a/include/llama/Vector.hpp
+++ b/include/llama/Vector.hpp
@@ -1,4 +1,5 @@
-// SPDX-License-Identifier: GPL-3.0-or-later
+// Copyright 2021 Bernhard Manfred Gruber
+// SPDX-License-Identifier: LGPL-3.0-or-later
 
 #pragma once
 

--- a/include/llama/View.hpp
+++ b/include/llama/View.hpp
@@ -1,5 +1,5 @@
-// Copyright 2018 Alexander Matthes
-// SPDX-License-Identifier: GPL-3.0-or-later
+// Copyright 2022 Alexander Matthes, Bernhard Manfred Gruber
+// SPDX-License-Identifier: LGPL-3.0-or-later
 
 #pragma once
 

--- a/include/llama/llama.hpp
+++ b/include/llama/llama.hpp
@@ -1,5 +1,5 @@
-// Copyright 2018 Alexander Matthes
-// SPDX-License-Identifier: GPL-3.0-or-later
+// Copyright 2018 Alexander Matthes, Bernhard Manfred Gruber
+// SPDX-License-Identifier: LGPL-3.0-or-later
 
 #pragma once
 

--- a/include/llama/macros.hpp
+++ b/include/llama/macros.hpp
@@ -1,5 +1,5 @@
-// Copyright 2018 Alexander Matthes
-// SPDX-License-Identifier: GPL-3.0-or-later
+// Copyright 2022 Alexander Matthes, Bernhard Manfred Gruber
+// SPDX-License-Identifier: LGPL-3.0-or-later
 
 #pragma once
 

--- a/include/llama/mapping/AoS.hpp
+++ b/include/llama/mapping/AoS.hpp
@@ -1,5 +1,5 @@
-// Copyright 2018 Alexander Matthes
-// SPDX-License-Identifier: GPL-3.0-or-later
+// Copyright 2022 Alexander Matthes, Bernhard Manfred Gruber
+// SPDX-License-Identifier: LGPL-3.0-or-later
 
 #pragma once
 

--- a/include/llama/mapping/AoSoA.hpp
+++ b/include/llama/mapping/AoSoA.hpp
@@ -1,4 +1,5 @@
-// SPDX-License-Identifier: GPL-3.0-or-later
+// Copyright 2022 Bernhard Manfred Gruber
+// SPDX-License-Identifier: LGPL-3.0-or-later
 
 #pragma once
 

--- a/include/llama/mapping/BitPackedFloat.hpp
+++ b/include/llama/mapping/BitPackedFloat.hpp
@@ -1,4 +1,5 @@
-// SPDX-License-Identifier: GPL-3.0-or-later
+// Copyright 2023 Bernhard Manfred Gruber
+// SPDX-License-Identifier: LGPL-3.0-or-later
 
 #pragma once
 

--- a/include/llama/mapping/BitPackedInt.hpp
+++ b/include/llama/mapping/BitPackedInt.hpp
@@ -1,4 +1,5 @@
-// SPDX-License-Identifier: GPL-3.0-or-later
+// Copyright 2023 Bernhard Manfred Gruber
+// SPDX-License-Identifier: LGPL-3.0-or-later
 
 #pragma once
 

--- a/include/llama/mapping/Bytesplit.hpp
+++ b/include/llama/mapping/Bytesplit.hpp
@@ -1,4 +1,5 @@
-// SPDX-License-Identifier: GPL-3.0-or-later
+// Copyright 2022 Bernhard Manfred Gruber
+// SPDX-License-Identifier: LGPL-3.0-or-later
 
 #pragma once
 

--- a/include/llama/mapping/Byteswap.hpp
+++ b/include/llama/mapping/Byteswap.hpp
@@ -1,4 +1,5 @@
-// SPDX-License-Identifier: GPL-3.0-or-later
+// Copyright 2022 Bernhard Manfred Gruber
+// SPDX-License-Identifier: LGPL-3.0-or-later
 
 #pragma once
 

--- a/include/llama/mapping/ChangeType.hpp
+++ b/include/llama/mapping/ChangeType.hpp
@@ -1,4 +1,5 @@
-// SPDX-License-Identifier: GPL-3.0-or-later
+// Copyright 2022 Bernhard Manfred Gruber
+// SPDX-License-Identifier: LGPL-3.0-or-later
 
 #pragma once
 

--- a/include/llama/mapping/Common.hpp
+++ b/include/llama/mapping/Common.hpp
@@ -1,5 +1,5 @@
-// Copyright 2018 Alexander Matthes
-// SPDX-License-Identifier: GPL-3.0-or-later
+// Copyright 2022 Alexander Matthes, Bernhard Manfred Gruber
+// SPDX-License-Identifier: LGPL-3.0-or-later
 
 #pragma once
 

--- a/include/llama/mapping/FieldAccessCount.hpp
+++ b/include/llama/mapping/FieldAccessCount.hpp
@@ -1,3 +1,6 @@
+// Copyright 2022 Bernhard Manfred Gruber
+// SPDX-License-Identifier: LGPL-3.0-or-later
+
 #pragma once
 
 #include "../StructName.hpp"

--- a/include/llama/mapping/Heatmap.hpp
+++ b/include/llama/mapping/Heatmap.hpp
@@ -1,3 +1,6 @@
+// Copyright 2022 Bernhard Manfred Gruber
+// SPDX-License-Identifier: LGPL-3.0-or-later
+
 #pragma once
 
 #include "Common.hpp"

--- a/include/llama/mapping/Null.hpp
+++ b/include/llama/mapping/Null.hpp
@@ -1,4 +1,5 @@
-// SPDX-License-Identifier: GPL-3.0-or-later
+// Copyright 2022 Bernhard Manfred Gruber
+// SPDX-License-Identifier: LGPL-3.0-or-later
 
 #pragma once
 

--- a/include/llama/mapping/One.hpp
+++ b/include/llama/mapping/One.hpp
@@ -1,5 +1,5 @@
-// Copyright 2018 Alexander Matthes
-// SPDX-License-Identifier: GPL-3.0-or-later
+// Copyright 2022 Alexander Matthes, Bernhard Manfred Gruber
+// SPDX-License-Identifier: LGPL-3.0-or-later
 
 #pragma once
 

--- a/include/llama/mapping/PermuteArrayIndex.hpp
+++ b/include/llama/mapping/PermuteArrayIndex.hpp
@@ -1,4 +1,5 @@
-// SPDX-License-Identifier: GPL-3.0-or-later
+// Copyright 2022 Bernhard Manfred Gruber
+// SPDX-License-Identifier: LGPL-3.0-or-later
 
 #pragma once
 

--- a/include/llama/mapping/Projection.hpp
+++ b/include/llama/mapping/Projection.hpp
@@ -1,4 +1,5 @@
-// SPDX-License-Identifier: GPL-3.0-or-later
+// Copyright 2022 Bernhard Manfred Gruber
+// SPDX-License-Identifier: LGPL-3.0-or-later
 
 #pragma once
 

--- a/include/llama/mapping/SoA.hpp
+++ b/include/llama/mapping/SoA.hpp
@@ -1,5 +1,5 @@
-// Copyright 2018 Alexander Matthes
-// SPDX-License-Identifier: GPL-3.0-or-later
+// Copyright 2022 Alexander Matthes, Bernhard Manfred Gruber
+// SPDX-License-Identifier: LGPL-3.0-or-later
 
 #pragma once
 

--- a/include/llama/mapping/Split.hpp
+++ b/include/llama/mapping/Split.hpp
@@ -1,3 +1,6 @@
+// Copyright 2022 Bernhard Manfred Gruber
+// SPDX-License-Identifier: LGPL-3.0-or-later
+
 #pragma once
 
 #include "../View.hpp"

--- a/include/llama/mapping/tree/Functors.hpp
+++ b/include/llama/mapping/tree/Functors.hpp
@@ -1,5 +1,5 @@
-// Copyright 2018 Alexander Matthes
-// SPDX-License-Identifier: GPL-3.0-or-later
+// Copyright 2020 Alexander Matthes, Bernhard Manfred Gruber
+// SPDX-License-Identifier: LGPL-3.0-or-later
 
 #pragma once
 

--- a/include/llama/mapping/tree/Mapping.hpp
+++ b/include/llama/mapping/tree/Mapping.hpp
@@ -1,5 +1,5 @@
-// Copyright 2018 Alexander Matthes
-// SPDX-License-Identifier: GPL-3.0-or-later
+// Copyright 2020 Alexander Matthes, Bernhard Manfred Gruber
+// SPDX-License-Identifier: LGPL-3.0-or-later
 
 #pragma once
 

--- a/include/llama/mapping/tree/TreeFromDimensions.hpp
+++ b/include/llama/mapping/tree/TreeFromDimensions.hpp
@@ -1,5 +1,5 @@
-// Copyright 2018 Alexander Matthes
-// SPDX-License-Identifier: GPL-3.0-or-later
+// Copyright 2020 Alexander Matthes, Bernhard Manfred Gruber
+// SPDX-License-Identifier: LGPL-3.0-or-later
 #pragma once
 
 #include "../../Core.hpp"

--- a/include/llama/mapping/tree/toString.hpp
+++ b/include/llama/mapping/tree/toString.hpp
@@ -1,5 +1,5 @@
-// Copyright 2018 Alexander Matthes
-// SPDX-License-Identifier: GPL-3.0-or-later
+// Copyright 2020 Alexander Matthes, Bernhard Manfred Gruber
+// SPDX-License-Identifier: LGPL-3.0-or-later
 
 #pragma once
 

--- a/tests/accessor.cpp
+++ b/tests/accessor.cpp
@@ -1,3 +1,6 @@
+// Copyright 2022 Bernhard Manfred Gruber
+// SPDX-License-Identifier: LGPL-3.0-or-later
+
 #include "common.hpp"
 
 TEST_CASE("view.allocView.Default")

--- a/tests/array.cpp
+++ b/tests/array.cpp
@@ -1,3 +1,6 @@
+// Copyright 2022 Bernhard Manfred Gruber
+// SPDX-License-Identifier: LGPL-3.0-or-later
+
 #include "common.hpp"
 
 TEST_CASE("Array.empty")

--- a/tests/arrayextents.cpp
+++ b/tests/arrayextents.cpp
@@ -1,3 +1,6 @@
+// Copyright 2022 Bernhard Manfred Gruber
+// SPDX-License-Identifier: LGPL-3.0-or-later
+
 #include "common.hpp"
 
 TEMPLATE_LIST_TEST_CASE("dyn", "", SizeTypes)

--- a/tests/arrayindexrange.cpp
+++ b/tests/arrayindexrange.cpp
@@ -1,3 +1,6 @@
+// Copyright 2022 Bernhard Manfred Gruber
+// SPDX-License-Identifier: LGPL-3.0-or-later
+
 #include "common.hpp"
 
 TEST_CASE("ArrayIndexIterator.concepts")

--- a/tests/bloballocators.cpp
+++ b/tests/bloballocators.cpp
@@ -1,3 +1,6 @@
+// Copyright 2022 Bernhard Manfred Gruber
+// SPDX-License-Identifier: LGPL-3.0-or-later
+
 #include "common.hpp"
 
 #include <memory>

--- a/tests/common.hpp
+++ b/tests/common.hpp
@@ -1,3 +1,6 @@
+// Copyright 2022 Bernhard Manfred Gruber
+// SPDX-License-Identifier: LGPL-3.0-or-later
+
 #pragma once
 
 #include <boost/core/demangle.hpp>

--- a/tests/computedprop.cpp
+++ b/tests/computedprop.cpp
@@ -1,3 +1,6 @@
+// Copyright 2022 Bernhard Manfred Gruber
+// SPDX-License-Identifier: LGPL-3.0-or-later
+
 #include "common.hpp"
 
 #include <catch2/catch_approx.hpp>

--- a/tests/copy.cpp
+++ b/tests/copy.cpp
@@ -1,3 +1,6 @@
+// Copyright 2022 Bernhard Manfred Gruber
+// SPDX-License-Identifier: LGPL-3.0-or-later
+
 #include "common.hpp"
 
 namespace

--- a/tests/core.cpp
+++ b/tests/core.cpp
@@ -1,3 +1,6 @@
+// Copyright 2022 Bernhard Manfred Gruber
+// SPDX-License-Identifier: LGPL-3.0-or-later
+
 #include "common.hpp"
 
 TEST_CASE("prettyPrintType")

--- a/tests/dump.cpp
+++ b/tests/dump.cpp
@@ -1,3 +1,6 @@
+// Copyright 2022 Bernhard Manfred Gruber
+// SPDX-License-Identifier: LGPL-3.0-or-later
+
 #include "common.hpp"
 
 #include <filesystem>

--- a/tests/iterator.cpp
+++ b/tests/iterator.cpp
@@ -1,3 +1,6 @@
+// Copyright 2022 Bernhard Manfred Gruber
+// SPDX-License-Identifier: LGPL-3.0-or-later
+
 #include "common.hpp"
 
 #include <algorithm>

--- a/tests/mapping.AoS.cpp
+++ b/tests/mapping.AoS.cpp
@@ -1,3 +1,6 @@
+// Copyright 2022 Bernhard Manfred Gruber
+// SPDX-License-Identifier: LGPL-3.0-or-later
+
 #include "common.hpp"
 
 TEST_CASE("mapping.AoS.Packed.address")

--- a/tests/mapping.AoSoA.cpp
+++ b/tests/mapping.AoSoA.cpp
@@ -1,3 +1,6 @@
+// Copyright 2022 Bernhard Manfred Gruber
+// SPDX-License-Identifier: LGPL-3.0-or-later
+
 #include "common.hpp"
 
 TEST_CASE("mapping.maxLanes")

--- a/tests/mapping.BitPackedFloat.cpp
+++ b/tests/mapping.BitPackedFloat.cpp
@@ -1,3 +1,6 @@
+// Copyright 2022 Bernhard Manfred Gruber
+// SPDX-License-Identifier: LGPL-3.0-or-later
+
 #include "common.hpp"
 
 #include <catch2/catch_approx.hpp>

--- a/tests/mapping.BitPackedInt.cpp
+++ b/tests/mapping.BitPackedInt.cpp
@@ -1,3 +1,6 @@
+// Copyright 2022 Bernhard Manfred Gruber
+// SPDX-License-Identifier: LGPL-3.0-or-later
+
 #include "common.hpp"
 
 #include <random>

--- a/tests/mapping.Bytesplit.cpp
+++ b/tests/mapping.Bytesplit.cpp
@@ -1,3 +1,6 @@
+// Copyright 2022 Bernhard Manfred Gruber
+// SPDX-License-Identifier: LGPL-3.0-or-later
+
 #include "common.hpp"
 
 // #include <bit>

--- a/tests/mapping.Byteswap.cpp
+++ b/tests/mapping.Byteswap.cpp
@@ -1,3 +1,6 @@
+// Copyright 2022 Bernhard Manfred Gruber
+// SPDX-License-Identifier: LGPL-3.0-or-later
+
 #include "common.hpp"
 
 TEST_CASE("mapping.Byteswap.AoS")

--- a/tests/mapping.ChangeType.cpp
+++ b/tests/mapping.ChangeType.cpp
@@ -1,3 +1,6 @@
+// Copyright 2022 Bernhard Manfred Gruber
+// SPDX-License-Identifier: LGPL-3.0-or-later
+
 #include "common.hpp"
 
 #include <cstdint>

--- a/tests/mapping.HeatmapTrace.cpp
+++ b/tests/mapping.HeatmapTrace.cpp
@@ -1,3 +1,6 @@
+// Copyright 2022 Bernhard Manfred Gruber
+// SPDX-License-Identifier: LGPL-3.0-or-later
+
 #include "common.hpp"
 
 #include <boost/iostreams/device/back_inserter.hpp>

--- a/tests/mapping.Null.cpp
+++ b/tests/mapping.Null.cpp
@@ -1,3 +1,6 @@
+// Copyright 2022 Bernhard Manfred Gruber
+// SPDX-License-Identifier: LGPL-3.0-or-later
+
 #include "common.hpp"
 
 #include <cstdint>

--- a/tests/mapping.One.cpp
+++ b/tests/mapping.One.cpp
@@ -1,3 +1,6 @@
+// Copyright 2022 Bernhard Manfred Gruber
+// SPDX-License-Identifier: LGPL-3.0-or-later
+
 #include "common.hpp"
 
 TEST_CASE("mapping.One.Packed.address")

--- a/tests/mapping.PermuteArrayIndex.cpp
+++ b/tests/mapping.PermuteArrayIndex.cpp
@@ -1,3 +1,6 @@
+// Copyright 2022 Bernhard Manfred Gruber
+// SPDX-License-Identifier: LGPL-3.0-or-later
+
 #include "common.hpp"
 
 TEST_CASE("mapping.PermuteArrayIndex.ctors")

--- a/tests/mapping.Projection.cpp
+++ b/tests/mapping.Projection.cpp
@@ -1,3 +1,6 @@
+// Copyright 2022 Bernhard Manfred Gruber
+// SPDX-License-Identifier: LGPL-3.0-or-later
+
 #include "common.hpp"
 
 #include <cstdint>

--- a/tests/mapping.SoA.cpp
+++ b/tests/mapping.SoA.cpp
@@ -1,3 +1,6 @@
+// Copyright 2022 Bernhard Manfred Gruber
+// SPDX-License-Identifier: LGPL-3.0-or-later
+
 #include "common.hpp"
 
 TEST_CASE("mapping.SoA.SingleBlob.Packed.address")

--- a/tests/mapping.Split.cpp
+++ b/tests/mapping.Split.cpp
@@ -1,3 +1,6 @@
+// Copyright 2022 Bernhard Manfred Gruber
+// SPDX-License-Identifier: LGPL-3.0-or-later
+
 #include "common.hpp"
 
 #include <fstream>

--- a/tests/mapping.Tree.cpp
+++ b/tests/mapping.Tree.cpp
@@ -1,3 +1,6 @@
+// Copyright 2022 Bernhard Manfred Gruber
+// SPDX-License-Identifier: LGPL-3.0-or-later
+
 #include "common.hpp"
 
 #ifdef __NVCC__

--- a/tests/mapping.cpp
+++ b/tests/mapping.cpp
@@ -1,3 +1,6 @@
+// Copyright 2022 Bernhard Manfred Gruber
+// SPDX-License-Identifier: LGPL-3.0-or-later
+
 #include "common.hpp"
 
 #ifdef __cpp_lib_concepts

--- a/tests/meta.cpp
+++ b/tests/meta.cpp
@@ -1,3 +1,6 @@
+// Copyright 2022 Bernhard Manfred Gruber
+// SPDX-License-Identifier: LGPL-3.0-or-later
+
 #include "common.hpp"
 
 TEST_CASE("ReplacePlaceholders")

--- a/tests/proofs.cpp
+++ b/tests/proofs.cpp
@@ -1,3 +1,6 @@
+// Copyright 2022 Bernhard Manfred Gruber
+// SPDX-License-Identifier: LGPL-3.0-or-later
+
 #include "common.hpp"
 
 #include <llama/Proofs.hpp>

--- a/tests/proxyrefopmixin.cpp
+++ b/tests/proxyrefopmixin.cpp
@@ -1,3 +1,6 @@
+// Copyright 2022 Bernhard Manfred Gruber
+// SPDX-License-Identifier: LGPL-3.0-or-later
+
 #include "common.hpp"
 
 namespace

--- a/tests/recordcoord.cpp
+++ b/tests/recordcoord.cpp
@@ -1,3 +1,6 @@
+// Copyright 2022 Bernhard Manfred Gruber
+// SPDX-License-Identifier: LGPL-3.0-or-later
+
 #include "common.hpp"
 
 #include <sstream>

--- a/tests/recorddimension.cpp
+++ b/tests/recorddimension.cpp
@@ -1,3 +1,6 @@
+// Copyright 2022 Bernhard Manfred Gruber
+// SPDX-License-Identifier: LGPL-3.0-or-later
+
 #include "common.hpp"
 
 #include <array>

--- a/tests/recordref.cpp
+++ b/tests/recordref.cpp
@@ -1,3 +1,6 @@
+// Copyright 2022 Bernhard Manfred Gruber
+// SPDX-License-Identifier: LGPL-3.0-or-later
+
 #include "common.hpp"
 
 #include <algorithm>

--- a/tests/simd.cpp
+++ b/tests/simd.cpp
@@ -1,3 +1,6 @@
+// Copyright 2022 Bernhard Manfred Gruber
+// SPDX-License-Identifier: LGPL-3.0-or-later
+
 #include "common.hpp"
 
 #include <ciso646>

--- a/tests/subview.cpp
+++ b/tests/subview.cpp
@@ -1,3 +1,6 @@
+// Copyright 2022 Bernhard Manfred Gruber
+// SPDX-License-Identifier: LGPL-3.0-or-later
+
 #include "common.hpp"
 
 TEST_CASE("SubView.CTAD")

--- a/tests/tuple.cpp
+++ b/tests/tuple.cpp
@@ -1,3 +1,6 @@
+// Copyright 2022 Bernhard Manfred Gruber
+// SPDX-License-Identifier: LGPL-3.0-or-later
+
 #include "common.hpp"
 
 TEST_CASE("Tuple.CTAD")

--- a/tests/vector.cpp
+++ b/tests/vector.cpp
@@ -1,3 +1,6 @@
+// Copyright 2022 Bernhard Manfred Gruber
+// SPDX-License-Identifier: LGPL-3.0-or-later
+
 #include "common.hpp"
 
 using RecordDim = Vec3D;

--- a/tests/view.cpp
+++ b/tests/view.cpp
@@ -1,3 +1,6 @@
+// Copyright 2022 Bernhard Manfred Gruber
+// SPDX-License-Identifier: LGPL-3.0-or-later
+
 #include "common.hpp"
 
 #include <atomic>


### PR DESCRIPTION
This PR ensures that every C++ and CMake source file of LLAMA has a copyright/license header of the form:
```
// Copyright <year> <autor>
// SPDX-License-Identifier: <license>
```
This also fixes using the wrong SPDX identifier `GPL-3.0-or-later` in some places, where  `LGPL-3.0-or-later` was intended, since LLAMA as a whole is licensed under LGPL as pointed out in the `LICENSE` file.
No relicensing of any kind is performed. Just adding and correcting information where missing or wrong.