### PR TITLE
Fix TArrayExtents::rankStatic being inaccessible in SOA

### DIFF
--- a/include/llama/mapping/Common.hpp
+++ b/include/llama/mapping/Common.hpp
@@ -14,7 +14,7 @@
 namespace llama::mapping
 {
     template<typename TArrayExtents, typename TRecordDim>
-    struct MappingBase : private TArrayExtents
+    struct MappingBase : protected TArrayExtents
     {
         using ArrayExtents = TArrayExtents;
         using ArrayIndex = typename ArrayExtents::Index;


### PR DESCRIPTION
MSVC claims that it cannot access `TArrayExtents::rankStatic` inside the implementation of SoA because `MappingBase` privately inherits from `TArrayExtents`. This actually seems right, but gcc compiles fine. This change fixes the issue for MSVC.