### PR TITLE
Split clang-tidy tests CI run

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -44,7 +44,8 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - files: '../tests'
+          - files: '../tests/m.*'
+          - files: '../tests/[^m].*'
           - files: '../examples'
     steps:
     - uses: actions/checkout@v3


### PR DESCRIPTION
To further balance the load on the CI.