### PR TITLE
[on hold] Support pointers

### DIFF
--- a/include/llama/RecordRef.hpp
+++ b/include/llama/RecordRef.hpp
@@ -371,11 +371,13 @@ namespace llama
             return *this;
         }
 
-        LLAMA_FN_HOST_ACC_INLINE constexpr auto isNull() const {
+        LLAMA_FN_HOST_ACC_INLINE constexpr auto isNull() const
+        {
             return ai[0] == maxAiVal;
         }
 
-        LLAMA_FN_HOST_ACC_INLINE constexpr void setNull() {
+        LLAMA_FN_HOST_ACC_INLINE constexpr void setNull()
+        {
             ai[0] = maxAiVal;
         }
 
@@ -434,9 +436,7 @@ namespace llama
     private:
         LLAMA_FN_HOST_ACC_INLINE static void checkViews([[maybe_unused]] const View* a, [[maybe_unused]] const View* b)
         {
-            assert(
-                (a == nullptr || b == nullptr || a == b)
-                && "Mixing pointers into different views is not allowed");
+            assert((a == nullptr || b == nullptr || a == b) && "Mixing pointers into different views is not allowed");
         }
     };
 

--- a/include/llama/RecordRef.hpp
+++ b/include/llama/RecordRef.hpp
@@ -330,6 +330,125 @@ namespace llama
         LLAMA_FN_HOST_ACC_INLINE void storeSimdRecord(const Simd& srcSimd, T&& dstRef, RecordCoord rc);
     } // namespace internal
 
+    template<typename View, typename BoundRecordCoord, bool OwnIndex = false>
+    struct PointerRef
+    {
+        using ArrayIndex = typename View::ArrayIndex;
+
+    private:
+        using ArrayIndexQual = std::conditional_t<OwnIndex, ArrayIndex, ArrayIndex&>;
+        inline static constexpr auto maxAiVal = std::numeric_limits<typename ArrayIndex::value_type>::max();
+
+    public:
+        LLAMA_FN_HOST_ACC_INLINE constexpr PointerRef(std::nullptr_t) : ai{}, view(nullptr)
+        {
+            setNull();
+            static_assert(OwnIndex);
+        }
+
+        constexpr PointerRef(const PointerRef& other) = default;
+
+        LLAMA_FN_HOST_ACC_INLINE constexpr PointerRef(ArrayIndexQual ai, View& view) : ai(ai), view(&view)
+        {
+        }
+
+        LLAMA_FN_HOST_ACC_INLINE constexpr auto operator=(const PointerRef& other) -> PointerRef&
+        {
+            checkViews(view, other.view);
+            ai = other.ai;
+            view = other.view; // adopt other view (in case this was a nullptr)
+            return *this;
+        }
+
+        // retarget pointer
+        template<bool OtherOwnIndex>
+        LLAMA_FN_HOST_ACC_INLINE constexpr auto operator=(
+            const PointerRef<View, BoundRecordCoord, OtherOwnIndex>& other) -> PointerRef&
+        {
+            checkViews(view, other.view);
+            ai = other.ai;
+            view = other.view; // adopt other view (in case this was a nullptr)
+            return *this;
+        }
+
+        LLAMA_FN_HOST_ACC_INLINE constexpr auto isNull() const {
+            return ai[0] == maxAiVal;
+        }
+
+        LLAMA_FN_HOST_ACC_INLINE constexpr void setNull() {
+            ai[0] = maxAiVal;
+        }
+
+        LLAMA_FN_HOST_ACC_INLINE constexpr auto operator*()
+        {
+            assert(!isNull() && "nullptr dereferences");
+            return RecordRef<View, BoundRecordCoord>{ai, *view};
+        }
+
+        LLAMA_FN_HOST_ACC_INLINE constexpr auto operator*() const
+        {
+            assert(!isNull() && "nullptr dereferences");
+            return RecordRef<const View, BoundRecordCoord>{ai, *view};
+        }
+
+        LLAMA_FN_HOST_ACC_INLINE constexpr auto operator=(std::nullptr_t) -> PointerRef&
+        {
+            static_assert(ArrayIndex::rank > 0, "nullptr is not supported for zero-dim views");
+            setNull();
+            return *this;
+        }
+        LLAMA_FN_HOST_ACC_INLINE friend constexpr auto operator==(PointerRef a, PointerRef b) -> bool
+        {
+            checkViews(a.view, b.view);
+            return a.ai == b.ai;
+        }
+
+        LLAMA_FN_HOST_ACC_INLINE friend constexpr auto operator==(PointerRef a, std::nullptr_t) -> bool
+        {
+            return a.isNull();
+        }
+
+        LLAMA_FN_HOST_ACC_INLINE friend constexpr auto operator==(std::nullptr_t, PointerRef b) -> bool
+        {
+            return b.isNull();
+        }
+
+        LLAMA_FN_HOST_ACC_INLINE friend constexpr auto operator!=(PointerRef a, PointerRef b) -> bool
+        {
+            return !(a == b);
+        }
+
+        LLAMA_FN_HOST_ACC_INLINE friend constexpr auto operator!=(std::nullptr_t a, PointerRef b) -> bool
+        {
+            return !(a == b);
+        }
+
+        LLAMA_FN_HOST_ACC_INLINE friend constexpr auto operator!=(PointerRef a, std::nullptr_t b) -> bool
+        {
+            return !(a == b);
+        }
+
+        ArrayIndexQual ai;
+        View* view;
+
+    private:
+        LLAMA_FN_HOST_ACC_INLINE static void checkViews([[maybe_unused]] const View* a, [[maybe_unused]] const View* b)
+        {
+            assert(
+                (a == nullptr || b == nullptr || a == b)
+                && "Mixing pointers into different views is not allowed");
+        }
+    };
+
+    template<typename View, typename BoundRecordCoord>
+    using Pointer = PointerRef<View, BoundRecordCoord, true>;
+
+    template<typename T>
+    inline constexpr bool isPointerRef = false;
+
+    template<typename View, typename BoundRecordCoord, bool OwnIndex>
+    inline constexpr bool isPointerRef<PointerRef<View, BoundRecordCoord, OwnIndex>> = true;
+
     /// Record reference type returned by \ref View after resolving an array dimensions coordinate or partially
     /// resolving a \ref RecordCoord. A record reference does not hold data itself, it just binds enough information
     /// (array dimensions coord and partial record coord) to retrieve it later from a \ref View. Records references
@@ -338,6 +457,9 @@ namespace llama
     template<typename TView, typename TBoundRecordCoord, bool OwnView>
     struct RecordRef : private TView::Mapping::ArrayIndex
     {
+        template<typename View, typename BoundRecordCoord, bool OwnIndex>
+        friend struct PointerRef;
+
         using View = TView; ///< View this record reference points into.
         using BoundRecordCoord
             = TBoundRecordCoord; ///< Record coords into View::RecordDim which are already bound by this RecordRef.
@@ -382,6 +504,11 @@ namespace llama
         auto operator=(RecordRef&&) noexcept -> RecordRef& = default;
 
         ~RecordRef() = default;
+
+        LLAMA_FN_HOST_ACC_INLINE constexpr auto arrayIndex() -> ArrayIndex&
+        {
+            return static_cast<ArrayIndex&>(*this);
+        }
 
         LLAMA_FN_HOST_ACC_INLINE constexpr auto arrayIndex() const -> ArrayIndex
         {
@@ -430,6 +557,14 @@ namespace llama
                 LLAMA_FORCE_INLINE_RECURSIVE
                 return RecordRef<const View, AbsolutCoord>{arrayIndex(), this->view};
             }
+            //            else if constexpr(/*isPointer<AccessedType>*/ std::is_same_v<AccessedType, ArrayIndex>)
+            //            {
+            //                const ArrayIndex dstAi = this->view.access(arrayIndex(), AbsolutCoord{});
+            //                // using DstRecordDim = typename AccessedType::type;
+            //                // static_assert(std::is_same_v<DstRecordDim, RecordDim>, "Implementation limit");
+            //                using Pointee = RecordRef<View, RecordCoord<>, false>;
+            //                return Pointer<Pointee>{Pointee{dstAi, view}};
+            //            }
             else
             {
                 LLAMA_FORCE_INLINE_RECURSIVE
@@ -448,6 +583,14 @@ namespace llama
                 LLAMA_FORCE_INLINE_RECURSIVE
                 return RecordRef<View, AbsolutCoord>{arrayIndex(), this->view};
             }
+            //            else if constexpr(/*isPointer<AccessedType>*/ std::is_same_v<AccessedType, ArrayIndex>)
+            //            {
+            //                const ArrayIndex dstAi = this->view.access(arrayIndex(), AbsolutCoord{});
+            //                // using DstRecordDim = typename AccessedType::type;
+            //                // static_assert(std::is_same_v<DstRecordDim, RecordDim>, "Implementation limit");
+            //                using Pointee = RecordRef<View, RecordCoord<>, false>;
+            //                return Pointer<Pointee>{Pointee{dstAi, view}};
+            //            }
             else
             {
                 LLAMA_FORCE_INLINE_RECURSIVE
@@ -724,6 +867,16 @@ namespace llama
         LLAMA_FN_HOST_ACC_INLINE void store(const TupleLike& t)
         {
             internal::assignTuples(asTuple(), t, std::make_index_sequence<std::tuple_size_v<TupleLike>>{});
+        }
+
+        LLAMA_FN_HOST_ACC_INLINE constexpr auto operator&()
+        {
+            return Pointer<View, BoundRecordCoord>{arrayIndex(), view};
+        }
+
+        LLAMA_FN_HOST_ACC_INLINE constexpr auto operator&() const
+        {
+            return Pointer<View, BoundRecordCoord>{arrayIndex(), view};
         }
 
         // swap for equal RecordRef

--- a/include/llama/llama.hpp
+++ b/include/llama/llama.hpp
@@ -71,6 +71,7 @@
 #include "mapping/Null.hpp"
 #include "mapping/One.hpp"
 #include "mapping/PermuteArrayIndex.hpp"
+#include "mapping/PointerToIndex.hpp"
 #include "mapping/Projection.hpp"
 #include "mapping/SoA.hpp"
 #include "mapping/Split.hpp"

--- a/include/llama/mapping/PointerToIndex.hpp
+++ b/include/llama/mapping/PointerToIndex.hpp
@@ -1,0 +1,89 @@
+// Copyright 2022 Bernhard Manfred Gruber
+// SPDX-License-Identifier: LGPL-3.0-or-later
+
+#pragma once
+
+#include "../ProxyRefOpMixin.hpp"
+#include "Common.hpp"
+
+namespace llama::mapping
+{
+    struct PointerToRecordDim
+    {
+    };
+
+    namespace internal
+    {
+        template<typename Replacement, typename T>
+        struct ReplacePointerImpl
+        {
+            using type = std::conditional_t<std::is_same_v<T, PointerToRecordDim>, Replacement, T>;
+        };
+
+        template<typename Replacement, typename... Fields>
+        struct ReplacePointerImpl<Replacement, Record<Fields...>>
+        {
+            using type = Record<
+                Field<GetFieldTag<Fields>, typename ReplacePointerImpl<Replacement, GetFieldType<Fields>>::type>...>;
+        };
+
+        template<typename Replacement, typename T>
+        using ReplacePointer = typename ReplacePointerImpl<Replacement, T>::type;
+    } // namespace internal
+
+    template<typename TArrayExtents, typename TRecordDim, template<typename, typename> typename InnerMapping>
+    struct PointerToIndex
+        : private InnerMapping<TArrayExtents, internal::ReplacePointer<typename TArrayExtents::Index, TRecordDim>>
+    {
+        using Inner = InnerMapping<TArrayExtents, internal::ReplacePointer<typename TArrayExtents::Index, TRecordDim>>;
+        using ArrayExtents = typename Inner::ArrayExtents;
+        using ArrayIndex = typename Inner::ArrayIndex;
+        using RecordDim = TRecordDim; // hide Inner::RecordDim
+        using Inner::blobCount;
+        using Inner::blobSize;
+        using Inner::extents;
+        using Inner::Inner;
+
+        template<typename RecordCoord>
+        LLAMA_FN_HOST_ACC_INLINE static constexpr auto isComputed(RecordCoord) -> bool
+        {
+            return std::is_same_v<GetType<RecordDim, RecordCoord>, PointerToRecordDim>;
+        }
+
+        template<std::size_t... RecordCoords, typename BlobArray>
+        LLAMA_FN_HOST_ACC_INLINE constexpr auto compute(
+            ArrayIndex ai,
+            RecordCoord<RecordCoords...> rc,
+            BlobArray& blobs) const
+        {
+            static_assert(isComputed(rc));
+            using View = llama::View<PointerToIndex, std::decay_t<decltype(blobs[0])>, accessor::Default>;
+            ArrayIndex& dstAi = mapToMemory(static_cast<const Inner&>(*this), ai, rc, blobs);
+            auto& view = const_cast<View&>(reinterpret_cast<const View&>(*this));
+            return PointerRef<View, RecordCoord<>>{dstAi, view};
+        }
+
+        template<std::size_t... RecordCoords>
+        LLAMA_FN_HOST_ACC_INLINE constexpr auto blobNrAndOffset(ArrayIndex ai, RecordCoord<RecordCoords...> rc = {})
+            const -> NrAndOffset<typename ArrayExtents::value_type>
+        {
+            static_assert(!isComputed(rc));
+            return Inner::blobNrAndOffset(ai, rc);
+        }
+    };
+
+    /// Binds parameters to a \ref ChangeType mapping except for array and record dimension, producing a quoted
+    /// meta function accepting the latter two. Useful to to prepare this mapping for a meta mapping.
+    template<template<typename, typename> typename InnerMapping>
+    struct BindPointerToIndex
+    {
+        template<typename ArrayExtents, typename RecordDim>
+        using fn = PointerToIndex<ArrayExtents, RecordDim, InnerMapping>;
+    };
+
+    template<typename Mapping>
+    inline constexpr bool isPointerToIndex = false;
+
+    template<typename TArrayExtents, typename TRecordDim, template<typename, typename> typename InnerMapping>
+    inline constexpr bool isPointerToIndex<PointerToIndex<TArrayExtents, TRecordDim, InnerMapping>> = true;
+} // namespace llama::mapping


### PR DESCRIPTION
This PR adds support for pointers to other records (with some limitations). This enables self-referrential data structures. The unit tests contain an example of a linked list and a binary search tree.