### PR TITLE
Allow string literals and reflection in/of record dimension

### DIFF
--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -1,0 +1,14 @@
+{
+  "version": 6,
+  "configurePresets": [
+    {
+      "name": "default",
+      "toolchainFile": "~/dev/vcpkg/scripts/buildsystems/vcpkg.cmake",
+      "cacheVariables": {
+        "BUILD_TESTING": "ON",
+        "LLAMA_BUILD_EXAMPLES": "ON",
+        "alpaka_ACC_CPU_B_SEQ_T_SEQ_ENABLE": "ON"
+      }
+    }
+  ]
+}


### PR DESCRIPTION
Allows the following:

```c++
    using RecordDim = llama::Record<
        llama::NamedField<"x", int>, // NEW: NamedField with string literal
        llama::NamedField<"y", int>,
        llama::NamedField<"pos", Vec2F>,
        llama::Field<tag::Vel, llama::Record<llama::Field<tag::X, float>, llama::NamedField<"y", float>>>>;

    using namespace llama::literals;

    auto view = llama::allocView(llama::mapping::AoS{llama::ArrayExtents{1}, RecordDim{}});
    view(0)("x"_Name) = 1; // NEW: access with string literal (using literal operator _Name)
    view(0)("y"_Name) = 2;
    view(0)("pos"_Name, tag::X{}) = 3;
    view(0)("pos"_Name, tag::Y{}) = 4;
    view(0)(tag::Vel{}, tag::X{}) = 5;
```

Any better suggestions over `NamedField` and `_Name`?

And:

```c++
    struct MyVel
    {
        int x;
        int y;
    };
    BOOST_DESCRIBE_STRUCT(MyVel, (), (x, y));

    struct MyStruct
    {
        int a;
        int b;
        MyVel pos;
    };
    BOOST_DESCRIBE_STRUCT(MyStruct, (), (a, b, pos));

    using RecordDim = llama::ReflectToRecordDim<MyStruct>; // NEW
    auto view = llama::allocView(llama::mapping::AoS{llama::ArrayExtents{1}, RecordDim{}});

    using namespace llama::literals;

    view(0)("a"_Name) = 1;
    view(0)("b"_Name) = 2;
    view(0)("pos"_Name, "x"_Name) = 3;
    view(0)("pos"_Name, "y"_Name) = 4;
```