### PR TITLE
Fix g++-13 warnings and fmt 10.0 errors

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -12,7 +12,7 @@ concurrency:
 env:
   THREADS: 2
   CONFIG: RelWithDebInfo
-  VCPKG_INSTALL: "vcpkg install alpaka fmt tinyobjloader boost-mp11 boost-atomic boost-smart-ptr boost-functional boost-container boost-iostreams[core] catch2 xsimd"
+  VCPKG_INSTALL: "vcpkg --version; vcpkg install alpaka fmt tinyobjloader boost-mp11 boost-atomic boost-smart-ptr boost-functional boost-container boost-iostreams[core] catch2 xsimd"
 
 jobs:
   clang-format:

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -118,6 +118,14 @@ if (BUILD_TESTING)
 		target_compile_options(tests PRIVATE --display_error_number -Wc,--pending_instantiations=0)
 		target_compile_options(tests PRIVATE --diag_suppress=177) # disable: #177-D: variable "<unnamed>::autoRegistrar72" was declared but never referenced
 	endif()
+	if (CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
+		if (LLAMA_ENABLE_ASAN_FOR_TESTS AND CMAKE_CXX_COMPILER_VERSION VERSION_GREATER_EQUAL 12.0 AND CMAKE_CXX_COMPILER_VERSION VERSION_LESS 14.0)
+			target_compile_options(tests PRIVATE -Wno-maybe-uninitialized) # triggered inside std::function by std::regex
+		endif()
+		if (CMAKE_CXX_COMPILER_VERSION VERSION_GREATER_EQUAL 13.0 AND CMAKE_CXX_COMPILER_VERSION VERSION_LESS 14.0)
+			target_compile_options(tests PRIVATE -Wno-dangling-reference) # triggered by an access involving RecordRef, so basically everywhere
+		endif()
+	endif()
 	target_link_libraries(tests PRIVATE Catch2::Catch2WithMain llama::llama)
 
 	option(LLAMA_ENABLE_ASAN_FOR_TESTS "Enables address sanitizer for tests" OFF)

--- a/docs/pages/api.rst
+++ b/docs/pages/api.rst
@@ -17,6 +17,8 @@ Useful helpers
 .. doxygentypedef:: CopyConst
 .. doxygenstruct:: llama::ProxyRefOpMixin
    :members:
+.. doxygenfunction:: llama::decayCopy
+.. doxygenstruct:: llama::ScopedUpdate
 
 Array
 ^^^^^

--- a/examples/bitpackfloat/bitpackfloat.cpp
+++ b/examples/bitpackfloat/bitpackfloat.cpp
@@ -33,7 +33,7 @@ auto main() -> int
         {
             fmt::print(
                 "Blob {}: {} bytes (uncompressed {} bytes)\n",
-                ic,
+                ic(),
                 mapping.blobSize(ic),
                 n * sizeof(llama::GetType<Vector, llama::RecordCoord<decltype(ic)::value>>));
         });

--- a/examples/bitpackint/bitpackint.cpp
+++ b/examples/bitpackint/bitpackint.cpp
@@ -35,7 +35,7 @@ auto main() -> int
         {
             fmt::print(
                 "Blob {}: {} bytes (uncompressed {} bytes)\n",
-                ic,
+                ic(),
                 mapping.blobSize(ic),
                 n * sizeof(llama::GetType<Vector, llama::RecordCoord<decltype(ic)::value>>));
         });
@@ -49,7 +49,11 @@ auto main() -> int
 
     fmt::print("Bitpacked initial:\n");
     for(std::size_t i = 0; i < n; i++)
-        fmt::print("[{}, {}, {}]\n", view(i)(tag::X{}), view(i)(tag::Y{}), view(i)(tag::Z{}));
+        fmt::print(
+            "[{}, {}, {}]\n",
+            llama::decayCopy(view(i)(tag::X{})),
+            llama::decayCopy(view(i)(tag::Y{})),
+            llama::decayCopy(view(i)(tag::Z{})));
 
     // extract into a view of full size integers
     auto viewExtracted
@@ -67,5 +71,9 @@ auto main() -> int
 
     fmt::print("Bitpacked after % 10:\n");
     for(std::size_t i = 0; i < n; i++)
-        fmt::print("[{}, {}, {}]\n", view(i)(tag::X{}), view(i)(tag::Y{}), view(i)(tag::Z{}));
+        fmt::print(
+            "[{}, {}, {}]\n",
+            llama::decayCopy(view(i)(tag::X{})),
+            llama::decayCopy(view(i)(tag::Y{})),
+            llama::decayCopy(view(i)(tag::Z{})));
 }

--- a/examples/bytesplit/bytesplit.cpp
+++ b/examples/bytesplit/bytesplit.cpp
@@ -48,7 +48,10 @@ auto main() -> int
                 using T = llama::GetType<Data, decltype(rc)>;
                 ++value;
                 if(view(i)(rc) != static_cast<T>(value))
-                    fmt::print("Error: value after store is corrupt. {} != {}\n", view(i)(rc), value);
+                    fmt::print(
+                        "Error: value after store is corrupt. {} != {}\n",
+                        llama::decayCopy(view(i)(rc)),
+                        value);
             });
 
     // extract into a view of unsplit fields
@@ -72,7 +75,10 @@ auto main() -> int
                 using T = llama::GetType<Data, decltype(rc)>;
                 ++value;
                 if(view(i)(rc) != static_cast<T>(static_cast<T>(value) * 2))
-                    fmt::print("Error: value after resplit is corrupt. {} != {}\n", view(i)(rc), value);
+                    fmt::print(
+                        "Error: value after resplit is corrupt. {} != {}\n",
+                        llama::decayCopy(view(i)(rc)),
+                        value);
             });
 
     // compute something on the split view
@@ -89,7 +95,7 @@ auto main() -> int
                 if(view(i)(rc) != static_cast<T>(static_cast<T>(value) * 4))
                     fmt::print(
                         "Error: value after computation on split data is corrupt. {} != {}\n",
-                        view(i)(rc),
+                        llama::decayCopy(view(i)(rc)),
                         value);
             });
 

--- a/include/llama/RecordRef.hpp
+++ b/include/llama/RecordRef.hpp
@@ -807,12 +807,12 @@ namespace llama
 
     namespace internal
     {
-        // gets the value type for a given T, where T models a reference type. T is either an l-value reference, a
-        // proxy reference or a RecordRef
+        // gets the value type for a given T, where T models either a value, an l-value reference, a proxy reference or
+        // a RecordRef.
         template<typename T, typename = void>
         struct ValueOf
         {
-            static_assert(sizeof(T) == 0, "T does not model a reference");
+            using type = T;
         };
 
         template<typename T>
@@ -837,6 +837,13 @@ namespace llama
             using type = T;
         };
     } // namespace internal
+
+    /// Pulls a copy of the given value or reference. Proxy references are resolved to their value types.
+    template<typename T>
+    auto decayCopy(T&& valueOrRef) -> typename internal::ValueOf<T>::type
+    {
+        return std::forward<T>(valueOrRef);
+    }
 
     /// Scope guard type. ScopedUpdate takes a copy of a value through a reference and stores it internally during
     /// construction. The stored value is written back when ScopedUpdate is destroyed. ScopedUpdate tries to act like

--- a/tests/recordref.cpp
+++ b/tests/recordref.cpp
@@ -1214,7 +1214,15 @@ TEST_CASE("ScopedUpdate.Object")
 {
     std::vector v = {1};
     {
+#if defined(__GNUC__) && __GNUC__ == 13
+#    pragma GCC diagnostic push
+#    pragma GCC diagnostic ignored "-Warray-bounds"
+#    pragma GCC diagnostic ignored "-Wstringop-overflow"
+#endif
         llama::ScopedUpdate u(v);
+#if defined(__GNUC__) && __GNUC__ == 13
+#    pragma GCC diagnostic pop
+#endif
         STATIC_REQUIRE(std::is_same_v<decltype(u), llama::ScopedUpdate<std::vector<int>&>>);
         u.push_back(2);
         CHECK(u == std::vector{1, 2});

--- a/tests/recordref.cpp
+++ b/tests/recordref.cpp
@@ -1192,6 +1192,21 @@ TEST_CASE("ValueOf")
 #endif
     STATIC_REQUIRE(std::is_same_v<llama::internal::ValueOf<decltype(ref)>::type, int>);
 }
+
+TEST_CASE("decayCopy")
+{
+    STATIC_REQUIRE(std::is_same_v<decltype(llama::decayCopy(42)), int>);
+    const int i = 42;
+    STATIC_REQUIRE(std::is_same_v<decltype(llama::decayCopy(i)), int>);
+    const int& ir = i;
+    STATIC_REQUIRE(std::is_same_v<decltype(llama::decayCopy(ir)), int>);
+
+    auto mapping = llama::mapping::BitPackedIntSoA<llama::ArrayExtents<int, 4>, Vec3I>{{}, 17};
+    auto v = llama::allocView(mapping);
+    STATIC_REQUIRE(std::is_same_v<decltype(llama::decayCopy(v(1))), llama::One<Vec3I>>);
+    STATIC_REQUIRE(std::is_same_v<decltype(llama::decayCopy(v(1)(tag::X{}))), int>);
+}
+
 TEST_CASE("ScopedUpdate.Fundamental")
 {
     int i = 1;


### PR DESCRIPTION
This PR fixes a couple of warnings with g++-13 (and g++-12 with ASAN) as well as a couple of compilation errors with libfmt 10.0.