### PR TITLE
Upgrade to clang-format-16

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -19,11 +19,11 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
     - uses: actions/checkout@v3
-    - uses: DoozyX/clang-format-lint-action@v0.15
+    - uses: DoozyX/clang-format-lint-action@v0.16.2
       with:
         exclude: './thirdparty'
         extensions: 'cpp,hpp,h,cu'
-        clangFormatVersion: 15
+        clangFormatVersion: 16
         inplace: True
     - name: git diff
       run: git diff

--- a/include/llama/Tuple.hpp
+++ b/include/llama/Tuple.hpp
@@ -111,7 +111,7 @@ namespace llama
     };
 
     template<typename... Elements>
-    LLAMA_HOST_ACC Tuple(Elements...)->Tuple<std::remove_cv_t<std::remove_reference_t<Elements>>...>;
+    LLAMA_HOST_ACC Tuple(Elements...) -> Tuple<std::remove_cv_t<std::remove_reference_t<Elements>>...>;
 
     template<std::size_t I, typename... Elements>
     LLAMA_FN_HOST_ACC_INLINE constexpr auto get(Tuple<Elements...>& tuple) -> auto&

--- a/tests/simd.cpp
+++ b/tests/simd.cpp
@@ -8,10 +8,10 @@
 // MSVC does not support std::experimental::simd and #warning
 #elif defined(__NVCOMPILER)
 #    pragma message(                                                                                                  \
-        "LLAMA SIMD tests disabled for nvc++. It fails to compile std::experimental::simd due to unrecognized intrinsics")
+            "LLAMA SIMD tests disabled for nvc++. It fails to compile std::experimental::simd due to unrecognized intrinsics")
 #elif defined(__NVCC__)
 #    pragma message(                                                                                                  \
-        "LLAMA SIMD tests disabled for nvcc. It fails to compile std::experimental::simd due to invalid type conversions")
+            "LLAMA SIMD tests disabled for nvcc. It fails to compile std::experimental::simd due to invalid type conversions")
 #elif defined(_LIBCPP_VERSION)
 #    warning "LLAMA SIMD tests disabled for libc++. Their std::experimental::simd implementation is incomplete"
 #elif !__has_include(<experimental/simd>)


### PR DESCRIPTION
clang-format-16 is much better in formatting C++20 concept definitions.