### PR TITLE
Support RecordRef::at<"str">()

### DIFF
--- a/include/llama/RecordRef.hpp
+++ b/include/llama/RecordRef.hpp
@@ -461,6 +461,25 @@ namespace llama
             return operator()(RecordCoord{});
         }
 
+#ifdef LLAMA_HAS_STRING_FIELDS
+        /// Experimental
+        template<internal::FixedString Name>
+        LLAMA_FN_HOST_ACC_INLINE auto at() const -> decltype(auto)
+        {
+            using RecordCoord = GetCoordFromTags<AccessibleRecordDim, internal::StringTag<Name>>;
+            return operator()(RecordCoord{});
+        }
+
+        // FIXME(bgruber): remove redundancy
+        /// Experimental
+        template<internal::FixedString Name>
+        LLAMA_FN_HOST_ACC_INLINE auto at() -> decltype(auto)
+        {
+            using RecordCoord = GetCoordFromTags<AccessibleRecordDim, internal::StringTag<Name>>;
+            return operator()(RecordCoord{});
+        }
+#endif
+
         template<typename T>
         LLAMA_FN_HOST_ACC_INLINE auto operator=(const T& other) -> RecordRef&
         {

--- a/tests/recorddimension.cpp
+++ b/tests/recorddimension.cpp
@@ -386,6 +386,16 @@ TEST_CASE("recorddim.Boost.Describe")
     CHECK(view(0)(llama::RecordCoord<1>{}) == 2);
     CHECK(view(0)(llama::RecordCoord<2, 0>{}) == 3);
     CHECK(view(0)(llama::RecordCoord<2, 1>{}) == 4);
+
+    view(0).at<"a">() = 5;
+    view(0).at<"b">() = 6;
+    view(0).at<"pos">().at<"x">() = 7;
+    view(0).at<"pos">().at<"y">() = 8;
+
+    CHECK(view(0)(llama::RecordCoord<0>{}) == 5);
+    CHECK(view(0)(llama::RecordCoord<1>{}) == 6);
+    CHECK(view(0)(llama::RecordCoord<2, 0>{}) == 7);
+    CHECK(view(0)(llama::RecordCoord<2, 1>{}) == 8);
 }
 #endif
 


### PR DESCRIPTION
This adds an alternative access syntax when record dimension reflection is available.