### PR TITLE
Refactor constructField

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -35,6 +35,7 @@ endif()
 if (MSVC)
 	# FIXME(bgruber): alpaka uses M_PI, so we need to make it available on MSVC. This may be fixed in alpaka 1.0.0.
 	target_compile_definitions(llama INTERFACE _USE_MATH_DEFINES)
+	target_compile_options(${PROJECT_NAME} INTERFACE /Zc:lambda) # needed in C++17 mode, remove when upgrading to C++20
 endif()
 
 # CUDA

--- a/include/llama/View.hpp
+++ b/include/llama/View.hpp
@@ -98,34 +98,29 @@ namespace llama
         typename Mapping::ArrayExtents::Index ai,
         RecordCoord<RCs...> rc)
     {
-        using FieldType = GetType<typename Mapping::RecordDim, decltype(rc)>;
+        auto init = [](auto&& ref) LLAMA_LAMBDA_INLINE
+        {
+            using FieldType = GetType<typename Mapping::RecordDim, RecordCoord<RCs...>>;
+            using RefType = decltype(ref);
+            if constexpr(isProxyReference<std::remove_reference_t<RefType>>)
+            {
+                ref = FieldType{};
+            }
+            else if constexpr(
+                std::is_lvalue_reference_v<RefType> && !std::is_const_v<std::remove_reference_t<RefType>>)
+            {
+                new(&ref) FieldType{};
+            }
+        };
 
         // this handles physical and computed mappings
         if constexpr(sizeof...(RCs) == 0)
         {
-            using RefType = decltype(view(ai));
-            if constexpr(isProxyReference<RefType>)
-            {
-                view(ai) = FieldType{};
-            }
-            else if constexpr(
-                std::is_lvalue_reference_v<RefType> && !std::is_const_v<std::remove_reference_t<RefType>>)
-            {
-                new(&view(ai)) FieldType{};
-            }
+            init(view(ai));
         }
         else
         {
-            using RefType = decltype(view(ai)(rc));
-            if constexpr(isProxyReference<RefType>)
-            {
-                view(ai)(rc) = FieldType{};
-            }
-            else if constexpr(
-                std::is_lvalue_reference_v<RefType> && !std::is_const_v<std::remove_reference_t<RefType>>)
-            {
-                new(&view(ai)(rc)) FieldType{};
-            }
+            init(view(ai)(rc));
         }
     }
 


### PR DESCRIPTION
This PR refactors the implementation of `constructField`. An issue with MSVC was uncovered during this refactoring, and solved by enabling the newer lambda processor in MSVC, which is used by default in C++20.