### PR TITLE
Disable SIMD tests for g++-12 and higher when ASan is enabled

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -170,8 +170,9 @@ jobs:
           - name: build-ubuntu-gcc10-nvcc11.6
             cxx: g++-10
             cuda_url: https://developer.download.nvidia.com/compute/cuda/11.6.2/local_installers/cuda_11.6.2_510.47.03_linux.run
-          - name: build-ubuntu-gcc11
+          - name: build-ubuntu-gcc11-asan
             cxx: g++-11
+            asan: ON
           - name: build-ubuntu-gcc11-nvcc11.7
             cxx: g++-11
             cuda_url: https://developer.download.nvidia.com/compute/cuda/11.7.1/local_installers/cuda_11.7.1_515.65.01_linux.run

--- a/tests/simd.cpp
+++ b/tests/simd.cpp
@@ -16,6 +16,8 @@
 #    warning "LLAMA SIMD tests disabled for libc++. Their std::experimental::simd implementation is incomplete"
 #elif !__has_include(<experimental/simd>)
 #    warning "LLAMA SIMD tests disabled. Need std::experimental::simd, which is available in libstdc++ since GCC 11"
+#elif defined(__GNUG__) && __GNUC__ >= 12 && defined(__SANITIZE_ADDRESS__) && defined(__AVX512F__)
+#    warning "With ASan enabled, g++-12 and later generates an aligned store to an unaligned address with AVX512"
 #else
 #    include <experimental/simd>
 


### PR DESCRIPTION
This should fix #777.