### PR TITLE
Rename linearizers towards mdspan jargon

### DIFF
--- a/docs/pages/api.rst
+++ b/docs/pages/api.rst
@@ -191,11 +191,11 @@ RecordDim field permuters
 Common utilities
 ^^^^^^^^^^^^^^^^
 
-.. doxygenstruct:: llama::mapping::LinearizeArrayDimsCpp
+.. doxygenstruct:: llama::mapping::LinearizeArrayIndexRight
    :members:
-.. doxygenstruct:: llama::mapping::LinearizeArrayDimsFortran
+.. doxygenstruct:: llama::mapping::LinearizeArrayIndexLeft
    :members:
-.. doxygenstruct:: llama::mapping::LinearizeArrayDimsMorton
+.. doxygenstruct:: llama::mapping::LinearizeArrayIndexMorton
    :members:
 
 Tree mapping (deprecated)

--- a/docs/pages/copying.rst
+++ b/docs/pages/copying.rst
@@ -53,15 +53,15 @@ Users can add specializations of :cpp:`llama::Copy` to provide additional copy s
 .. code-block:: C++
 
     // provide special copy from AoS -> UserDefinedMapping
-    template <typename ArrayExtents, typename RecordDim, bool Aligned, typename LinearizeArrayDims>
+    template <typename ArrayExtents, typename RecordDim, bool Aligned, typename LinearizeArrayIndex>
     struct Copy<
-        llama::mapping::AoS<ArrayExtents, RecordDim, Aligned, LinearizeArrayDims>,
+        llama::mapping::AoS<ArrayExtents, RecordDim, Aligned, LinearizeArrayIndex>,
         UserDefinedMapping<ArrayExtents, RecordDim>>
     {
         template <typename SrcBlob, typename DstBlob>
         void operator()(
-            const View<mapping::AoS<ArrayExtents, RecordDim, Aligned, LinearizeArrayDims>, SrcBlob>& srcView,
-            View<mapping::SoA<ArrayExtents, RecordDim, DstSeparateBuffers, LinearizeArrayDims>, DstBlob>& dstView,
+            const View<mapping::AoS<ArrayExtents, RecordDim, Aligned, LinearizeArrayIndex>, SrcBlob>& srcView,
+            View<mapping::SoA<ArrayExtents, RecordDim, DstSeparateBuffers, LinearizeArrayIndex>, DstBlob>& dstView,
             std::size_t threadId, std::size_t threadCount) {
             ...
         }

--- a/docs/pages/mappings.rst
+++ b/docs/pages/mappings.rst
@@ -114,9 +114,9 @@ However, they do not vectorize well in practice.
     llama::mapping::AoS<ArrayExtents, RecordDim> mapping{extents}; 
     llama::mapping::AoS<ArrayExtents, RecordDim, false> mapping{extents}; // pack fields (violates alignment)
     llama::mapping::AoS<ArrayExtents, RecordDim, false
-        llama::mapping::LinearizeArrayDimsFortran> mapping{extents}; // pack fields, column major
+        llama::mapping::LinearizeArrayIndexLeft> mapping{extents}; // pack fields, column major
 
-By default, the array dimensions spanned by :cpp:`ArrayExtents` are linearized using :cpp:`llama::mapping::LinearizeArrayDimsCpp`.
+By default, the array dimensions spanned by :cpp:`ArrayExtents` are linearized using :cpp:`llama::mapping::LinearizeArrayIndexRight`.
 LLAMA provides the aliases :cpp:`llama::mapping::AlignedAoS` and :cpp:`llama::mapping::PackedAoS` for convenience.
 
 
@@ -132,9 +132,9 @@ This layout auto-vectorizes well in practice.
     llama::mapping::SoA<ArrayExtents, RecordDim> mapping{extents};
     llama::mapping::SoA<ArrayExtents, RecordDim, true> mapping{extents}; // separate blob for each attribute
     llama::mapping::SoA<ArrayExtents, RecordDim, true,
-        llama::mapping::LinearizeArrayDimsFortran> mapping{extents}; // separate blob for each attribute, column major
+        llama::mapping::LinearizeArrayIndexLeft> mapping{extents}; // separate blob for each attribute, column major
 
-By default, the array dimensions spanned by :cpp:`ArrayExtents` are linearized using :cpp:`llama::mapping::LinearizeArrayDimsCpp` and the layout is mapped into a single blob.
+By default, the array dimensions spanned by :cpp:`ArrayExtents` are linearized using :cpp:`llama::mapping::LinearizeArrayIndexRight` and the layout is mapped into a single blob.
 LLAMA provides the aliases :cpp:`llama::mapping::SingleBlobSoA` and :cpp:`llama::mapping::MultiBlobSoA` for convenience.
 
 
@@ -150,9 +150,9 @@ The AoSoA mapping has a mandatory additional parameter specifying the number of 
 
     llama::mapping::AoSoA<ArrayExtents, RecordDim, 8> mapping{extents}; // inner array has 8 values
     llama::mapping::AoSoA<ArrayExtents, RecordDim, 8,
-        llama::mapping::LinearizeArrayDimsFortran> mapping{extents}; // inner array has 8 values, column major
+        llama::mapping::LinearizeArrayIndexLeft> mapping{extents}; // inner array has 8 values, column major
 
-By default, the array dimensions spanned by :cpp:`ArrayExtents` are linearized using :cpp:`llama::mapping::LinearizeArrayDimsCpp`.
+By default, the array dimensions spanned by :cpp:`ArrayExtents` are linearized using :cpp:`llama::mapping::LinearizeArrayIndexRight`.
 
 LLAMA also provides a helper :cpp:`llama::mapping::maxLanes` which can be used to determine the maximum vector lanes which can be used for a given record dimension and vector register size.
 In this example, the inner array a size of N so even the largest type in the record dimension can fit N times into a vector register of 256bits size (e.g. AVX2).

--- a/examples/alpaka/pic/pic.cpp
+++ b/examples/alpaka/pic/pic.cpp
@@ -269,13 +269,13 @@ auto setup(Queue& queue, const Dev& dev, const DevHost& /*devHost*/)
                 ArrayExtents,
                 V3Real,
                 llama::mapping::FieldAlignment::Align,
-                llama::mapping::LinearizeArrayDimsFortran>(fieldExtents);
+                llama::mapping::LinearizeArrayIndexLeft>(fieldExtents);
         if constexpr(FieldMapping == 2)
             return llama::mapping::AoS<
                 ArrayExtents,
                 V3Real,
                 llama::mapping::FieldAlignment::Align,
-                llama::mapping::LinearizeArrayDimsMorton>(fieldExtents);
+                llama::mapping::LinearizeArrayIndexMorton>(fieldExtents);
         if constexpr(FieldMapping == 3)
             return llama::mapping::SoA<ArrayExtents, V3Real, llama::mapping::Blobs::Single>(fieldExtents);
         if constexpr(FieldMapping == 4)
@@ -284,14 +284,14 @@ auto setup(Queue& queue, const Dev& dev, const DevHost& /*devHost*/)
                 V3Real,
                 llama::mapping::Blobs::Single,
                 llama::mapping::SubArrayAlignment::Pack,
-                llama::mapping::LinearizeArrayDimsFortran>(fieldExtents);
+                llama::mapping::LinearizeArrayIndexLeft>(fieldExtents);
         if constexpr(FieldMapping == 5)
             return llama::mapping::SoA<
                 ArrayExtents,
                 V3Real,
                 llama::mapping::Blobs::Single,
                 llama::mapping::SubArrayAlignment::Pack,
-                llama::mapping::LinearizeArrayDimsMorton>(fieldExtents);
+                llama::mapping::LinearizeArrayIndexMorton>(fieldExtents);
         if constexpr(FieldMapping == 6)
             return llama::mapping::SoA<ArrayExtents, V3Real, llama::mapping::Blobs::OnePerField>(fieldExtents);
         if constexpr(FieldMapping == 7)
@@ -300,14 +300,14 @@ auto setup(Queue& queue, const Dev& dev, const DevHost& /*devHost*/)
                 V3Real,
                 llama::mapping::Blobs::OnePerField,
                 llama::mapping::SubArrayAlignment::Pack,
-                llama::mapping::LinearizeArrayDimsFortran>(fieldExtents);
+                llama::mapping::LinearizeArrayIndexLeft>(fieldExtents);
         if constexpr(FieldMapping == 8)
             return llama::mapping::SoA<
                 ArrayExtents,
                 V3Real,
                 llama::mapping::Blobs::OnePerField,
                 llama::mapping::SubArrayAlignment::Pack,
-                llama::mapping::LinearizeArrayDimsMorton>(fieldExtents);
+                llama::mapping::LinearizeArrayIndexMorton>(fieldExtents);
         if constexpr(FieldMapping == 9)
             return llama::mapping::AoSoA<ArrayExtents, V3Real, aosoaLanes>{fieldExtents};
     }();

--- a/examples/memmap/memmap.cpp
+++ b/examples/memmap/memmap.cpp
@@ -63,7 +63,7 @@ auto main(int argc, const char* argv[]) -> int
         llama::ArrayExtents<uint32_t, llama::dyn>,
         Triangle,
         llama::mapping::FieldAlignment::Pack,
-        llama::mapping::LinearizeArrayDimsCpp,
+        llama::mapping::LinearizeArrayIndexRight,
         llama::mapping::PermuteFieldsInOrder>{{n}};
     if(size != 80u + 4u + mapping.blobSize(0))
     {

--- a/include/llama/Copy.hpp
+++ b/include/llama/Copy.hpp
@@ -119,14 +119,14 @@ namespace llama
             typename RecordDim,
             mapping::Blobs Blobs,
             mapping::SubArrayAlignment SubArrayAlignment,
-            typename LinearizeArrayDimsFunctor>
+            typename LinearizeArrayIndexFunctor>
         inline constexpr std::size_t
-            aosoaLanes<mapping::SoA<ArrayExtents, RecordDim, Blobs, SubArrayAlignment, LinearizeArrayDimsFunctor>>
+            aosoaLanes<mapping::SoA<ArrayExtents, RecordDim, Blobs, SubArrayAlignment, LinearizeArrayIndexFunctor>>
             = std::numeric_limits<std::size_t>::max();
 
-        template<typename ArrayExtents, typename RecordDim, std::size_t Lanes, typename LinearizeArrayDimsFunctor>
+        template<typename ArrayExtents, typename RecordDim, std::size_t Lanes, typename LinearizeArrayIndexFunctor>
         inline constexpr std::size_t
-            aosoaLanes<mapping::AoSoA<ArrayExtents, RecordDim, Lanes, LinearizeArrayDimsFunctor>>
+            aosoaLanes<mapping::AoSoA<ArrayExtents, RecordDim, Lanes, LinearizeArrayIndexFunctor>>
             = Lanes;
     } // namespace internal
 
@@ -148,8 +148,8 @@ namespace llama
             "The source and destination record dimensions must be the same");
         static_assert(
             std::is_same_v<
-                typename SrcMapping::LinearizeArrayDimsFunctor,
-                typename DstMapping::LinearizeArrayDimsFunctor>,
+                typename SrcMapping::LinearizeArrayIndexFunctor,
+                typename DstMapping::LinearizeArrayIndexFunctor>,
             "Source and destination mapping need to use the same array dimensions linearizer");
         using RecordDim = typename SrcMapping::RecordDim;
         internal::assertTrivialCopyable<RecordDim>();
@@ -329,18 +329,18 @@ namespace llama
     template<
         typename ArrayExtents,
         typename RecordDim,
-        typename LinearizeArrayDims,
+        typename LinearizeArrayIndex,
         std::size_t LanesSrc,
         std::size_t LanesDst>
     struct Copy<
-        mapping::AoSoA<ArrayExtents, RecordDim, LanesSrc, LinearizeArrayDims>,
-        mapping::AoSoA<ArrayExtents, RecordDim, LanesDst, LinearizeArrayDims>,
+        mapping::AoSoA<ArrayExtents, RecordDim, LanesSrc, LinearizeArrayIndex>,
+        mapping::AoSoA<ArrayExtents, RecordDim, LanesDst, LinearizeArrayIndex>,
         std::enable_if_t<LanesSrc != LanesDst>>
     {
         template<typename SrcBlob, typename DstBlob>
         void operator()(
-            const View<mapping::AoSoA<ArrayExtents, RecordDim, LanesSrc, LinearizeArrayDims>, SrcBlob>& srcView,
-            View<mapping::AoSoA<ArrayExtents, RecordDim, LanesDst, LinearizeArrayDims>, DstBlob>& dstView,
+            const View<mapping::AoSoA<ArrayExtents, RecordDim, LanesSrc, LinearizeArrayIndex>, SrcBlob>& srcView,
+            View<mapping::AoSoA<ArrayExtents, RecordDim, LanesDst, LinearizeArrayIndex>, DstBlob>& dstView,
             std::size_t threadId,
             std::size_t threadCount)
         {
@@ -352,18 +352,18 @@ namespace llama
     template<
         typename ArrayExtents,
         typename RecordDim,
-        typename LinearizeArrayDims,
+        typename LinearizeArrayIndex,
         std::size_t LanesSrc,
         mapping::Blobs DstBlobs,
         mapping::SubArrayAlignment DstSubArrayAlignment>
     struct Copy<
-        mapping::AoSoA<ArrayExtents, RecordDim, LanesSrc, LinearizeArrayDims>,
-        mapping::SoA<ArrayExtents, RecordDim, DstBlobs, DstSubArrayAlignment, LinearizeArrayDims>>
+        mapping::AoSoA<ArrayExtents, RecordDim, LanesSrc, LinearizeArrayIndex>,
+        mapping::SoA<ArrayExtents, RecordDim, DstBlobs, DstSubArrayAlignment, LinearizeArrayIndex>>
     {
         template<typename SrcBlob, typename DstBlob>
         void operator()(
-            const View<mapping::AoSoA<ArrayExtents, RecordDim, LanesSrc, LinearizeArrayDims>, SrcBlob>& srcView,
-            View<mapping::SoA<ArrayExtents, RecordDim, DstBlobs, DstSubArrayAlignment, LinearizeArrayDims>, DstBlob>&
+            const View<mapping::AoSoA<ArrayExtents, RecordDim, LanesSrc, LinearizeArrayIndex>, SrcBlob>& srcView,
+            View<mapping::SoA<ArrayExtents, RecordDim, DstBlobs, DstSubArrayAlignment, LinearizeArrayIndex>, DstBlob>&
                 dstView,
             std::size_t threadId,
             std::size_t threadCount)
@@ -376,20 +376,20 @@ namespace llama
     template<
         typename ArrayExtents,
         typename RecordDim,
-        typename LinearizeArrayDims,
+        typename LinearizeArrayIndex,
         std::size_t LanesDst,
         mapping::Blobs SrcBlobs,
         mapping::SubArrayAlignment SrcSubArrayAlignment>
     struct Copy<
-        mapping::SoA<ArrayExtents, RecordDim, SrcBlobs, SrcSubArrayAlignment, LinearizeArrayDims>,
-        mapping::AoSoA<ArrayExtents, RecordDim, LanesDst, LinearizeArrayDims>>
+        mapping::SoA<ArrayExtents, RecordDim, SrcBlobs, SrcSubArrayAlignment, LinearizeArrayIndex>,
+        mapping::AoSoA<ArrayExtents, RecordDim, LanesDst, LinearizeArrayIndex>>
     {
         template<typename SrcBlob, typename DstBlob>
         void operator()(
             const View<
-                mapping::SoA<ArrayExtents, RecordDim, SrcBlobs, SrcSubArrayAlignment, LinearizeArrayDims>,
+                mapping::SoA<ArrayExtents, RecordDim, SrcBlobs, SrcSubArrayAlignment, LinearizeArrayIndex>,
                 SrcBlob>& srcView,
-            View<mapping::AoSoA<ArrayExtents, RecordDim, LanesDst, LinearizeArrayDims>, DstBlob>& dstView,
+            View<mapping::AoSoA<ArrayExtents, RecordDim, LanesDst, LinearizeArrayIndex>, DstBlob>& dstView,
             std::size_t threadId,
             std::size_t threadCount)
         {

--- a/include/llama/mapping/Common.hpp
+++ b/include/llama/mapping/Common.hpp
@@ -37,10 +37,10 @@ namespace llama::mapping
         }
     };
 
-    /// Functor that maps an \ref ArrayIndex into linear numbers the way C++ arrays work. The fast moving index of the
-    /// ArrayIndex object should be the last one. E.g. ArrayIndex<3> a; stores 3 indices where a[2] should be
-    /// incremented in the innermost loop.
-    struct LinearizeArrayDimsCpp
+    /// Functor that maps an \ref ArrayIndex into linear numbers, where the fast moving index should be the rightmost
+    /// one, which models how C++ arrays work and is analogous to mdspan's layout_right. E.g. ArrayIndex<3> a; stores 3
+    /// indices where a[2] should be incremented in the innermost loop.
+    struct LinearizeArrayIndexRight
     {
         template<typename ArrayExtents>
         LLAMA_FN_HOST_ACC_INLINE constexpr auto size(const ArrayExtents& extents) -> typename ArrayExtents::value_type
@@ -71,10 +71,12 @@ namespace llama::mapping
         }
     };
 
+    using LinearizeArrayIndexCpp = LinearizeArrayIndexRight;
+
     /// Functor that maps a \ref ArrayIndex into linear numbers the way Fortran arrays work. The fast moving index of
-    /// the ArrayIndex object should be the last one. E.g. ArrayIndex<3> a; stores 3 indices where a[2] should be
+    /// the ArrayIndex object should be the last one. E.g. ArrayIndex<3> a; stores 3 indices where a[0] should be
     /// incremented in the innermost loop.
-    struct LinearizeArrayDimsFortran
+    struct LinearizeArrayIndexLeft
     {
         template<typename ArrayExtents>
         LLAMA_FN_HOST_ACC_INLINE constexpr auto size(const ArrayExtents& extents) -> typename ArrayExtents::value_type
@@ -105,8 +107,10 @@ namespace llama::mapping
         }
     };
 
+    using LinearizeArrayIndexFortran = LinearizeArrayIndexLeft;
+
     /// Functor that maps an \ref ArrayIndex into linear numbers using the Z-order space filling curve (Morton codes).
-    struct LinearizeArrayDimsMorton
+    struct LinearizeArrayIndexMorton
     {
         template<typename ArrayExtents>
         LLAMA_FN_HOST_ACC_INLINE constexpr auto size(const ArrayExtents& extents) const ->

--- a/tests/common.hpp
+++ b/tests/common.hpp
@@ -220,7 +220,7 @@ struct ModulusMapping : TArrayExtents
         -> llama::NrAndOffset<std::size_t>
     {
         const auto blob = llama::flatRecordCoord<RecordDim, llama::RecordCoord<RecordCoords...>>;
-        const auto offset = (llama::mapping::LinearizeArrayDimsCpp{}(ai, extents()) % Modulus)
+        const auto offset = (llama::mapping::LinearizeArrayIndexRight{}(ai, extents()) % Modulus)
             * sizeof(llama::GetType<RecordDim, llama::RecordCoord<RecordCoords...>>);
         return {blob, offset};
     }

--- a/tests/computedprop.cpp
+++ b/tests/computedprop.cpp
@@ -87,7 +87,7 @@ namespace
     template<
         typename TArrayExtents,
         typename TRecordDim,
-        typename LinearizeArrayDimsFunctor = llama::mapping::LinearizeArrayDimsCpp>
+        typename LinearizeArrayIndexFunctor = llama::mapping::LinearizeArrayIndexRight>
     struct CompressedBoolMapping : TArrayExtents
     {
         using ArrayExtents = TArrayExtents;
@@ -131,7 +131,7 @@ namespace
                 [](auto rc) constexpr
                 { static_assert(std::is_same_v<llama::GetType<RecordDim, decltype(rc)>, bool>); });
             constexpr std::size_t wordBytes = sizeof(Word);
-            return (LinearizeArrayDimsFunctor{}.size(extents()) + wordBytes - 1) / wordBytes;
+            return (LinearizeArrayIndexFunctor{}.size(extents()) + wordBytes - 1) / wordBytes;
         }
 
         template<std::size_t... RecordCoords>
@@ -146,7 +146,7 @@ namespace
             llama::RecordCoord<RecordCoords...>,
             llama::Array<Blob, blobCount>& blobs) const -> BoolRef
         {
-            const auto bitOffset = LinearizeArrayDimsFunctor{}(ai, extents());
+            const auto bitOffset = LinearizeArrayIndexFunctor{}(ai, extents());
             const auto blob = llama::flatRecordCoord<RecordDim, llama::RecordCoord<RecordCoords...>>;
 
             constexpr std::size_t wordBits = sizeof(Word) * CHAR_BIT;

--- a/tests/copy.cpp
+++ b/tests/copy.cpp
@@ -24,16 +24,19 @@ namespace
 
     // Do not test all combinations as this exlodes the unit test compile and runtime.
     using AoSMappings = mp_list<
-        llama::mapping::
-            AoS<ArrayExtents, RecordDim, llama::mapping::FieldAlignment::Pack, llama::mapping::LinearizeArrayDimsCpp>,
+        llama::mapping::AoS<
+            ArrayExtents,
+            RecordDim,
+            llama::mapping::FieldAlignment::Pack,
+            llama::mapping::LinearizeArrayIndexRight>,
         // llama::mapping::AoS<ArrayExtents, RecordDim, llama::mapping::FieldAlignment::Pack,
-        // llama::mapping::LinearizeArrayDimsFortran>, llama::mapping::AoS<ArrayExtents, RecordDim,
-        // llama::mapping::FieldAlignment::Align, llama::mapping::LinearizeArrayDimsCpp>,
+        // llama::mapping::LinearizeArrayIndexLeft>, llama::mapping::AoS<ArrayExtents, RecordDim,
+        // llama::mapping::FieldAlignment::Align, llama::mapping::LinearizeArrayIndexRight>,
         llama::mapping::AoS<
             ArrayExtents,
             RecordDim,
             llama::mapping::FieldAlignment::Align,
-            llama::mapping::LinearizeArrayDimsFortran>>;
+            llama::mapping::LinearizeArrayIndexLeft>>;
 
     using OtherMappings = mp_list<
         llama::mapping::SoA<
@@ -41,29 +44,29 @@ namespace
             RecordDim,
             llama::mapping::Blobs::Single,
             llama::mapping::SubArrayAlignment::Pack,
-            llama::mapping::LinearizeArrayDimsCpp>,
+            llama::mapping::LinearizeArrayIndexRight>,
         // llama::mapping::SoA<ArrayExtents, RecordDim, llama::mapping::Blobs::Single,
-        // llama::mapping::SubArrayAlignment::Pack, llama::mapping::LinearizeArrayDimsFortran>,
+        // llama::mapping::SubArrayAlignment::Pack, llama::mapping::LinearizeArrayIndexLeft>,
         // llama::mapping::SoA<ArrayExtents, RecordDim, llama::mapping::Blobs::OnePerField,
-        // llama::mapping::SubArrayAlignment::Pack, llama::mapping::LinearizeArrayDimsCpp>,
+        // llama::mapping::SubArrayAlignment::Pack, llama::mapping::LinearizeArrayIndexRight>,
         llama::mapping::SoA<
             ArrayExtents,
             RecordDim,
             llama::mapping::Blobs::OnePerField,
             llama::mapping::SubArrayAlignment::Pack,
-            llama::mapping::LinearizeArrayDimsFortran>,
+            llama::mapping::LinearizeArrayIndexLeft>,
         llama::mapping::SoA<
             ArrayExtents,
             RecordDim,
             llama::mapping::Blobs::Single,
             llama::mapping::SubArrayAlignment::Align,
-            llama::mapping::LinearizeArrayDimsCpp>,
+            llama::mapping::LinearizeArrayIndexRight>,
         // llama::mapping::SoA<ArrayExtents, RecordDim, llama::mapping::Blobs::Single,
-        // llama::mapping::SubArrayAlignment::Align, llama::mapping::LinearizeArrayDimsFortran>,
-        llama::mapping::AoSoA<ArrayExtents, RecordDim, 4, llama::mapping::LinearizeArrayDimsCpp>,
-        // llama::mapping::AoSoA<ArrayExtents, RecordDim, 4, llama::mapping::LinearizeArrayDimsFortran>,
-        // llama::mapping::AoSoA<ArrayExtents, RecordDim, 8, llama::mapping::LinearizeArrayDimsCpp>,
-        llama::mapping::AoSoA<ArrayExtents, RecordDim, 8, llama::mapping::LinearizeArrayDimsFortran>>;
+        // llama::mapping::SubArrayAlignment::Align, llama::mapping::LinearizeArrayIndexLeft>,
+        llama::mapping::AoSoA<ArrayExtents, RecordDim, 4, llama::mapping::LinearizeArrayIndexRight>,
+        // llama::mapping::AoSoA<ArrayExtents, RecordDim, 4, llama::mapping::LinearizeArrayIndexLeft>,
+        // llama::mapping::AoSoA<ArrayExtents, RecordDim, 8, llama::mapping::LinearizeArrayIndexRight>,
+        llama::mapping::AoSoA<ArrayExtents, RecordDim, 8, llama::mapping::LinearizeArrayIndexLeft>>;
 
     using AllMappings = mp_append<AoSMappings, OtherMappings>;
 
@@ -73,8 +76,8 @@ namespace
     using BothAreSoAOrHaveDifferentLinearizer = std::bool_constant<
         (llama::mapping::isSoA<mp_first<List>> && llama::mapping::isSoA<mp_second<List>>)
         || !std::is_same_v<
-            typename mp_first<List>::LinearizeArrayDimsFunctor,
-            typename mp_second<List>::LinearizeArrayDimsFunctor>>;
+            typename mp_first<List>::LinearizeArrayIndexFunctor,
+            typename mp_second<List>::LinearizeArrayIndexFunctor>>;
 
     using AoSoAMappingsProduct
         = mp_remove_if<mp_product<mp_list, OtherMappings, OtherMappings>, BothAreSoAOrHaveDifferentLinearizer>;

--- a/tests/mapping.AoS.cpp
+++ b/tests/mapping.AoS.cpp
@@ -70,7 +70,7 @@ TEST_CASE("mapping.AoS.Packed.fortran.address")
     auto test = [](auto arrayExtents)
     {
         using Mapping
-            = llama::mapping::PackedAoS<decltype(arrayExtents), Particle, llama::mapping::LinearizeArrayDimsFortran>;
+            = llama::mapping::PackedAoS<decltype(arrayExtents), Particle, llama::mapping::LinearizeArrayIndexLeft>;
         auto mapping = Mapping{arrayExtents};
         using ArrayIndex = typename Mapping::ArrayExtents::Index;
 
@@ -133,7 +133,7 @@ TEST_CASE("mapping.AoS.Packed.morton.address")
     auto test = [](auto arrayExtents)
     {
         using Mapping
-            = llama::mapping::PackedAoS<decltype(arrayExtents), Particle, llama::mapping::LinearizeArrayDimsMorton>;
+            = llama::mapping::PackedAoS<decltype(arrayExtents), Particle, llama::mapping::LinearizeArrayIndexMorton>;
         auto mapping = Mapping{arrayExtents};
         using ArrayIndex = typename Mapping::ArrayExtents::Index;
 

--- a/tests/mapping.BitPackedInt.cpp
+++ b/tests/mapping.BitPackedInt.cpp
@@ -318,14 +318,14 @@ TEMPLATE_TEST_CASE(
         std::uint32_t,
         unsigned,
         llama::mapping::SignBit::Keep,
-        llama::mapping::LinearizeArrayDimsCpp,
+        llama::mapping::LinearizeArrayIndexRight,
         std::uint32_t>),
     (llama::mapping::BitPackedIntAoS<
         llama::ArrayExtents<std::size_t, 16>,
         std::uint32_t,
         unsigned,
         llama::mapping::SignBit::Keep,
-        llama::mapping::LinearizeArrayDimsCpp,
+        llama::mapping::LinearizeArrayIndexRight,
         llama::mapping::PermuteFieldsInOrder,
         std::uint32_t>) )
 {

--- a/tests/mapping.SoA.cpp
+++ b/tests/mapping.SoA.cpp
@@ -74,7 +74,7 @@ TEST_CASE("mapping.SoA.SingleBlob.Packed.fortran.address")
         CAPTURE(arrayExtents);
 
         using Mapping = llama::mapping::
-            PackedSingleBlobSoA<decltype(arrayExtents), Particle, llama::mapping::LinearizeArrayDimsFortran>;
+            PackedSingleBlobSoA<decltype(arrayExtents), Particle, llama::mapping::LinearizeArrayIndexLeft>;
         auto mapping = Mapping{arrayExtents};
         using ArrayIndex = typename Mapping::ArrayExtents::Index;
 
@@ -139,7 +139,7 @@ TEST_CASE("mapping.SoA.SingleBlob.Packed.morton.address")
         CAPTURE(arrayExtents);
 
         using Mapping = llama::mapping::
-            PackedSingleBlobSoA<decltype(arrayExtents), Particle, llama::mapping::LinearizeArrayDimsMorton>;
+            PackedSingleBlobSoA<decltype(arrayExtents), Particle, llama::mapping::LinearizeArrayIndexMorton>;
         auto mapping = Mapping{arrayExtents};
         using ArrayIndex = typename Mapping::ArrayExtents::Index;
 
@@ -271,7 +271,7 @@ TEST_CASE("mapping.SoA.SingleBlob.Aligned.fortran.address")
         CAPTURE(arrayExtents);
 
         using Mapping = llama::mapping::
-            AlignedSingleBlobSoA<decltype(arrayExtents), Particle, llama::mapping::LinearizeArrayDimsFortran>;
+            AlignedSingleBlobSoA<decltype(arrayExtents), Particle, llama::mapping::LinearizeArrayIndexLeft>;
         auto mapping = Mapping{arrayExtents};
         using ArrayIndex = typename Mapping::ArrayExtents::Index;
 
@@ -339,7 +339,7 @@ TEST_CASE("mapping.SoA.SingleBlob.Aligned.morton.address")
         CAPTURE(arrayExtents);
 
         using Mapping = llama::mapping::
-            AlignedSingleBlobSoA<decltype(arrayExtents), Particle, llama::mapping::LinearizeArrayDimsMorton>;
+            AlignedSingleBlobSoA<decltype(arrayExtents), Particle, llama::mapping::LinearizeArrayIndexMorton>;
         auto mapping = Mapping{arrayExtents};
         using ArrayIndex = typename Mapping::ArrayExtents::Index;
 

--- a/tests/mapping.cpp
+++ b/tests/mapping.cpp
@@ -256,18 +256,18 @@ TEMPLATE_LIST_TEST_CASE("mapping.traits", "", SizeTypes)
     STATIC_REQUIRE(llama::hasAnyComputedField<FAC>);
 }
 
-TEST_CASE("mapping.LinearizeArrayDimsCpp.size")
+TEST_CASE("mapping.LinearizeArrayIndexRight.size")
 {
-    llama::mapping::LinearizeArrayDimsCpp lin;
+    llama::mapping::LinearizeArrayIndexRight lin;
     CHECK(lin.size(llama::ArrayExtents{2, 3}) == 2 * 3);
     CHECK(lin.size(llama::ArrayExtents{2, 4}) == 2 * 4);
     CHECK(lin.size(llama::ArrayExtents{2, 5}) == 2 * 5);
     CHECK(lin.size(llama::ArrayExtents{8, 8}) == 8 * 8);
 }
 
-TEST_CASE("mapping.LinearizeArrayDimsCpp")
+TEST_CASE("mapping.LinearizeArrayIndexRight")
 {
-    const llama::mapping::LinearizeArrayDimsCpp lin;
+    const llama::mapping::LinearizeArrayIndexRight lin;
     const auto extents = llama::ArrayExtents<int, 4, 4>{};
     CHECK(lin(llama::ArrayIndex{0, 0}, extents) == 0);
     CHECK(lin(llama::ArrayIndex{0, 1}, extents) == 1);
@@ -287,18 +287,18 @@ TEST_CASE("mapping.LinearizeArrayDimsCpp")
     CHECK(lin(llama::ArrayIndex{3, 3}, extents) == 15);
 }
 
-TEST_CASE("mapping.LinearizeArrayDimsFortran.size")
+TEST_CASE("mapping.LinearizeArrayIndexLeft.size")
 {
-    llama::mapping::LinearizeArrayDimsFortran lin;
+    llama::mapping::LinearizeArrayIndexLeft lin;
     CHECK(lin.size(llama::ArrayExtents{2, 3}) == 2 * 3);
     CHECK(lin.size(llama::ArrayExtents{2, 4}) == 2 * 4);
     CHECK(lin.size(llama::ArrayExtents{2, 5}) == 2 * 5);
     CHECK(lin.size(llama::ArrayExtents{8, 8}) == 8 * 8);
 }
 
-TEST_CASE("mapping.LinearizeArrayDimsFortran")
+TEST_CASE("mapping.LinearizeArrayIndexLeft")
 {
-    const llama::mapping::LinearizeArrayDimsFortran lin;
+    const llama::mapping::LinearizeArrayIndexLeft lin;
     const auto extents = llama::ArrayExtents<int, 4, 4>{};
     CHECK(lin(llama::ArrayIndex{0, 0}, extents) == 0);
     CHECK(lin(llama::ArrayIndex{0, 1}, extents) == 4);
@@ -318,18 +318,18 @@ TEST_CASE("mapping.LinearizeArrayDimsFortran")
     CHECK(lin(llama::ArrayIndex{3, 3}, extents) == 15);
 }
 
-TEST_CASE("mapping.LinearizeArrayDimsMorton.size")
+TEST_CASE("mapping.LinearizeArrayIndexMorton.size")
 {
-    const llama::mapping::LinearizeArrayDimsMorton lin;
+    const llama::mapping::LinearizeArrayIndexMorton lin;
     CHECK(lin.size(llama::ArrayExtents{2, 3}) == 4 * 4);
     CHECK(lin.size(llama::ArrayExtents{2, 4}) == 4 * 4);
     CHECK(lin.size(llama::ArrayExtents{2, 5}) == 8 * 8);
     CHECK(lin.size(llama::ArrayExtents{8, 8}) == 8 * 8);
 }
 
-TEST_CASE("mapping.LinearizeArrayDimsMorton")
+TEST_CASE("mapping.LinearizeArrayIndexMorton")
 {
-    const llama::mapping::LinearizeArrayDimsMorton lin;
+    const llama::mapping::LinearizeArrayIndexMorton lin;
     const auto extents = llama::ArrayExtents<int, 4, 4>{};
     CHECK(lin(llama::ArrayIndex{0, 0}, extents) == 0);
     CHECK(lin(llama::ArrayIndex{0, 1}, extents) == 1);


### PR DESCRIPTION
* Rename all linearizers from `LinearizeArrayDims...` to `LinearizeArrayIndex...`
* Rename `...Cpp` to `...Right`, but leave alias for compatibility with legacy. This increases compatibility with mdspan.
* Rename `...Fortran` to `...Left`, but leave alias for compatibility with legacy. This increases compatibility with mdspan.