### PR TITLE
Annotate all public APIs with LLAMA_EXPORT

### DIFF
--- a/include/llama/Accessors.hpp
+++ b/include/llama/Accessors.hpp
@@ -14,6 +14,7 @@
 namespace llama::accessor
 {
     /// Default accessor. Passes through the given reference.
+    LLAMA_EXPORT
     struct Default
     {
         template<typename Reference>
@@ -24,6 +25,7 @@ namespace llama::accessor
     };
 
     /// Allows only read access and returns values instead of references to memory.
+    LLAMA_EXPORT
     struct ByValue
     {
         template<typename Reference>
@@ -38,6 +40,7 @@ namespace llama::accessor
     };
 
     /// Allows only read access by qualifying the references to memory with const.
+    LLAMA_EXPORT
     struct Const
     {
         // for l-value references
@@ -93,6 +96,7 @@ namespace llama::accessor
     };
 
     /// Qualifies references to memory with __restrict. Only works on l-value references.
+    LLAMA_EXPORT
     struct Restrict
     {
         template<typename T>
@@ -104,6 +108,7 @@ namespace llama::accessor
 
 #ifdef __cpp_lib_atomic_ref
     /// Accessor wrapping a reference into a std::atomic_ref. Can only wrap l-value references.
+    LLAMA_EXPORT
     struct Atomic
     {
         template<typename T>
@@ -115,6 +120,7 @@ namespace llama::accessor
 #endif
 
     /// Locks a mutex during each access to the data structure.
+    LLAMA_EXPORT
     template<typename Mutex = std::mutex>
     struct Locked
     {
@@ -177,11 +183,13 @@ namespace llama::accessor
 
     /// Accessor combining multiple other accessors. The contained accessors are applied in left to right order to the
     /// memory location when forming the reference returned from a view.
+    LLAMA_EXPORT
     template<typename... Accessors>
     struct Stacked : internal::StackedLeave<0, Default>
     {
     };
 
+    LLAMA_EXPORT
     template<typename FirstAccessor, typename... MoreAccessors>
     struct Stacked<FirstAccessor, MoreAccessors...>
         : internal::StackedLeave<1 + sizeof...(MoreAccessors), FirstAccessor>

--- a/include/llama/Array.hpp
+++ b/include/llama/Array.hpp
@@ -13,6 +13,7 @@ namespace llama
     /// Array class like `std::array` but suitable for use with offloading devices like GPUs.
     /// \tparam T type if array elements.
     /// \tparam N rank of the array.
+    LLAMA_EXPORT
     template<typename T, std::size_t N>
     // NOLINTNEXTLINE(bugprone-reserved-identifier,cert-dcl37-c,cert-dcl51-cpp,readability-identifier-naming)
     struct Array
@@ -126,6 +127,7 @@ namespace llama
         }
     };
 
+    LLAMA_EXPORT
     template<typename T>
     struct Array<T, 0>
     {
@@ -237,9 +239,11 @@ namespace llama
         }
     };
 
+    LLAMA_EXPORT
     template<typename First, typename... Args>
     Array(First, Args... args) -> Array<First, sizeof...(Args) + 1>;
 
+    LLAMA_EXPORT
     template<typename T, std::size_t N>
     auto operator<<(std::ostream& os, const Array<T, N>& a) -> std::ostream&
     {
@@ -257,6 +261,7 @@ namespace llama
         return os;
     }
 
+    LLAMA_EXPORT
     template<typename T, std::size_t N>
     LLAMA_FN_HOST_ACC_INLINE constexpr auto pushFront([[maybe_unused]] Array<T, N> a, T v) -> Array<T, N + 1>
     {
@@ -268,6 +273,7 @@ namespace llama
         return r;
     }
 
+    LLAMA_EXPORT
     template<typename T, std::size_t N>
     LLAMA_FN_HOST_ACC_INLINE constexpr auto pushBack([[maybe_unused]] Array<T, N> a, T v) -> Array<T, N + 1>
     {
@@ -279,6 +285,7 @@ namespace llama
         return r;
     }
 
+    LLAMA_EXPORT
     template<typename T, std::size_t N>
     LLAMA_FN_HOST_ACC_INLINE constexpr auto popBack([[maybe_unused]] Array<T, N> a)
     {
@@ -290,6 +297,7 @@ namespace llama
         return r;
     }
 
+    LLAMA_EXPORT
     template<typename T, std::size_t N>
     LLAMA_FN_HOST_ACC_INLINE constexpr auto popFront([[maybe_unused]] Array<T, N> a)
     {
@@ -301,6 +309,7 @@ namespace llama
         return r;
     }
 
+    LLAMA_EXPORT
     template<typename T, std::size_t N>
     LLAMA_FN_HOST_ACC_INLINE constexpr auto product(Array<T, N> a) -> T
     {
@@ -310,6 +319,7 @@ namespace llama
         return prod;
     }
 
+    LLAMA_EXPORT
     template<typename T, std::size_t N>
     LLAMA_FN_HOST_ACC_INLINE constexpr auto dot([[maybe_unused]] Array<T, N> a, [[maybe_unused]] Array<T, N> b) -> T
     {
@@ -321,11 +331,13 @@ namespace llama
     }
 } // namespace llama
 
+LLAMA_EXPORT
 template<typename T, size_t N>
 struct std::tuple_size<llama::Array<T, N>> : std::integral_constant<size_t, N> // NOLINT(cert-dcl58-cpp)
 {
 };
 
+LLAMA_EXPORT
 template<size_t I, typename T, size_t N>
 struct std::tuple_element<I, llama::Array<T, N>> // NOLINT(cert-dcl58-cpp)
 {

--- a/include/llama/ArrayExtents.hpp
+++ b/include/llama/ArrayExtents.hpp
@@ -14,6 +14,7 @@ namespace llama
     // TODO(bgruber): make this an alias in C++20, when we have CTAD for aliases
     /// Represents a run-time index into the array dimensions.
     /// \tparam Dim Compile-time number of dimensions.
+    LLAMA_EXPORT
     template<typename T, std::size_t Dim>
     struct ArrayIndex : Array<T, Dim>
     {
@@ -21,6 +22,7 @@ namespace llama
     };
 
     // allow comparing ArrayIndex with different size types:
+    LLAMA_EXPORT
     template<std::size_t Dim, typename TA, typename TB>
     LLAMA_FN_HOST_ACC_INLINE constexpr auto operator==(ArrayIndex<TA, Dim> a, ArrayIndex<TB, Dim> b) -> bool
     {
@@ -30,6 +32,7 @@ namespace llama
         return true;
     }
 
+    LLAMA_EXPORT
     template<std::size_t Dim, typename TA, typename TB>
     LLAMA_FN_HOST_ACC_INLINE constexpr auto operator!=(ArrayIndex<TA, Dim> a, ArrayIndex<TB, Dim> b) -> bool
     {
@@ -61,16 +64,19 @@ namespace llama
         };
     } // namespace internal
 
+    LLAMA_EXPORT
     template<typename... Args>
     ArrayIndex(Args...)
         -> ArrayIndex<typename internal::IndexTypeFromArgs<std::size_t, Args...>::type, sizeof...(Args)>;
 } // namespace llama
 
+LLAMA_EXPORT
 template<typename V, size_t N>
 struct std::tuple_size<llama::ArrayIndex<V, N>> : std::integral_constant<size_t, N> // NOLINT(cert-dcl58-cpp)
 {
 };
 
+LLAMA_EXPORT
 template<size_t I, typename V, size_t N>
 struct std::tuple_element<I, llama::ArrayIndex<V, N>> // NOLINT(cert-dcl58-cpp)
 {
@@ -116,12 +122,14 @@ namespace llama
         };
     } // namespace internal
 
+    LLAMA_EXPORT
     /// Used as a template argument to \ref ArrayExtents to mark a dynamic extent.
     inline constexpr auto dyn = internal::Dyn{};
 
     /// ArrayExtents holding compile and runtime indices. This is conceptually equivalent to the std::extent of
     /// std::mdspan (@see: https://wg21.link/P0009) including the changes to make the size_type controllable (@see:
     /// https://wg21.link/P2553).
+    LLAMA_EXPORT
     template<typename T = std::size_t, T... Sizes>
     struct ArrayExtents : Array<T, ((Sizes == dyn) + ... + 0)>
     {
@@ -163,6 +171,7 @@ namespace llama
         }
     };
 
+    LLAMA_EXPORT
     template<typename T>
     struct ArrayExtents<T>
     {
@@ -179,6 +188,7 @@ namespace llama
         }
     };
 
+    LLAMA_EXPORT
     template<typename... Args>
     ArrayExtents(Args...) -> ArrayExtents<
         typename internal::IndexTypeFromArgs<std::size_t, Args...>::type,
@@ -191,6 +201,7 @@ namespace llama
     static_assert(std::is_trivially_move_assignable_v<ArrayExtents<std::size_t, 1>>);
     static_assert(std::is_empty_v<ArrayExtents<std::size_t, 1>>);
 
+    LLAMA_EXPORT
     template<typename SizeTypeA, SizeTypeA... SizesA, typename SizeTypeB, SizeTypeB... SizesB>
     LLAMA_FN_HOST_ACC_INLINE constexpr auto operator==(
         ArrayExtents<SizeTypeA, SizesA...> a,
@@ -199,6 +210,7 @@ namespace llama
         return a.toArray() == b.toArray();
     }
 
+    LLAMA_EXPORT
     template<typename SizeTypeA, SizeTypeA... SizesA, typename SizeTypeB, SizeTypeB... SizesB>
     LLAMA_FN_HOST_ACC_INLINE constexpr auto operator!=(
         ArrayExtents<SizeTypeA, SizesA...> a,
@@ -207,6 +219,7 @@ namespace llama
         return !(a == b);
     }
 
+    LLAMA_EXPORT
     template<typename SizeType, SizeType... Sizes>
     LLAMA_FN_HOST_ACC_INLINE constexpr auto product(ArrayExtents<SizeType, Sizes...> e) -> SizeType
     {
@@ -222,14 +235,17 @@ namespace llama
         }
     } // namespace internal
 
+    LLAMA_EXPORT
     /// N-dimensional ArrayExtents where all N extents are Extent.
     template<typename SizeType, std::size_t N, SizeType Extent>
     using ArrayExtentsNCube = decltype(internal::makeArrayExtents<SizeType, Extent>(std::make_index_sequence<N>{}));
 
+    LLAMA_EXPORT
     /// N-dimensional ArrayExtents where all values are dynamic.
     template<typename SizeType, std::size_t N>
     using ArrayExtentsDynamic = ArrayExtentsNCube<SizeType, N, dyn>;
 
+    LLAMA_EXPORT
     template<typename SizeType, std::size_t Dim, typename Func, typename... OuterIndices>
     LLAMA_FN_HOST_ACC_INLINE void forEachArrayIndex(
         [[maybe_unused]] const ArrayIndex<SizeType, Dim>& extents,
@@ -250,6 +266,7 @@ namespace llama
         LLAMA_END_SUPPRESS_HOST_DEVICE_WARNING
     }
 
+    LLAMA_EXPORT
     template<typename SizeType, SizeType... Sizes, typename Func>
     LLAMA_FN_HOST_ACC_INLINE void forEachArrayIndex(ArrayExtents<SizeType, Sizes...> extents, Func&& func)
     {
@@ -257,12 +274,14 @@ namespace llama
     }
 } // namespace llama
 
+LLAMA_EXPORT
 template<typename SizeType, SizeType... Sizes>
 struct std::tuple_size<llama::ArrayExtents<SizeType, Sizes...>> // NOLINT(cert-dcl58-cpp)
     : std::integral_constant<std::size_t, sizeof...(Sizes)>
 {
 };
 
+LLAMA_EXPORT
 template<typename SizeType, std::size_t I, SizeType... Sizes>
 struct std::tuple_element<I, llama::ArrayExtents<SizeType, Sizes...>> // NOLINT(cert-dcl58-cpp)
 {

--- a/include/llama/ArrayIndexRange.hpp
+++ b/include/llama/ArrayIndexRange.hpp
@@ -17,6 +17,7 @@
 namespace llama
 {
     /// Iterator supporting \ref ArrayIndexRange.
+    LLAMA_EXPORT
     template<typename ArrayExtents>
     struct ArrayIndexIterator
     {
@@ -244,6 +245,7 @@ namespace llama
     };
 
     /// Range allowing to iterate over all indices in an \ref ArrayExtents.
+    LLAMA_EXPORT
     template<typename ArrayExtents>
     struct ArrayIndexRange
         : private ArrayExtents

--- a/include/llama/BlobAllocators.hpp
+++ b/include/llama/BlobAllocators.hpp
@@ -21,6 +21,7 @@ namespace llama::bloballoc
 {
     /// Allocates statically sized memory for a \ref View, which is copied each time a \ref View is copied.
     /// \tparam BytesToReserve the amount of memory to reserve.
+    LLAMA_EXPORT
     template<std::size_t BytesToReserve>
     struct Array
     {
@@ -44,6 +45,7 @@ namespace llama::bloballoc
 
     /// Allocates heap memory managed by a `std::unique_ptr` for a \ref View. This memory can only be uniquely owned by
     /// a single \ref View.
+    LLAMA_EXPORT
     struct UniquePtr
     {
         template<std::size_t Alignment>
@@ -61,6 +63,7 @@ namespace llama::bloballoc
 
     /// Allocates heap memory managed by a `std::shared_ptr` for a \ref View. This memory is shared between all copies
     /// of a \ref View.
+    LLAMA_EXPORT
     struct SharedPtr
     {
         template<std::size_t Alignment>
@@ -78,6 +81,7 @@ namespace llama::bloballoc
 #endif
 
     /// An STL compatible allocator allowing to specify alignment.
+    LLAMA_EXPORT
     template<typename T, std::size_t Alignment>
     struct AlignedAllocator
     {
@@ -119,6 +123,7 @@ namespace llama::bloballoc
 
     /// Allocates heap memory managed by a `std::vector` for a \ref View, which is copied each time a \ref View is
     /// copied.
+    LLAMA_EXPORT
     struct Vector
     {
         template<std::size_t Alignment>
@@ -135,6 +140,7 @@ namespace llama::bloballoc
     /// Allocates GPU device memory using cudaMalloc. The memory is managed by a std::unique_ptr with a deleter that
     /// calles cudaFree. If you want to use a view created with this allocator in a CUDA kernel, call \ref shallowCopy
     /// on the view before passing it to the kernel.
+    LLAMA_EXPORT
     struct CudaMalloc
     {
         inline static const auto deleter = [](void* p)
@@ -157,6 +163,7 @@ namespace llama::bloballoc
 #endif
 
 #if __has_include(<alpaka/alpaka.hpp>)
+    LLAMA_EXPORT
     template<typename Size, typename Dev>
     struct AlpakaBuf
     {

--- a/include/llama/Concepts.hpp
+++ b/include/llama/Concepts.hpp
@@ -15,9 +15,11 @@
 namespace llama
 {
 #ifdef __cpp_lib_concepts
+    LLAMA_EXPORT
     template<auto I>
     concept isConstexpr = requires { std::integral_constant<decltype(I), I>{}; };
 
+    LLAMA_EXPORT
     template<typename M>
     concept Mapping = requires(M m) {
         typename M::ArrayExtents;
@@ -34,6 +36,7 @@ namespace llama
         } -> std::same_as<typename M::ArrayExtents::value_type>;
     };
 
+    LLAMA_EXPORT
     template<typename M, typename RC>
     concept PhysicalField = requires(M m, typename M::ArrayExtents::Index ai) {
         {
@@ -48,19 +51,24 @@ namespace llama
         using fn = mp_bool<PhysicalField<M, RC>>;
     };
 
+    LLAMA_EXPORT
     template<typename M>
     inline constexpr bool allFieldsArePhysical
         = mp_all_of<LeafRecordCoords<typename M::RecordDim>, MakeIsPhysical<M>::template fn>::value;
 
+    LLAMA_EXPORT
     template<typename M>
     concept PhysicalMapping = Mapping<M> && allFieldsArePhysical<M>;
 
+    LLAMA_EXPORT
     template<typename R>
     concept LValueReference = std::is_lvalue_reference_v<R>;
 
+    LLAMA_EXPORT
     template<typename R>
     concept AdlTwoStepSwappable = requires(R a, R b) { swap(a, b); } || requires(R a, R b) { std::swap(a, b); };
 
+    LLAMA_EXPORT
     template<typename R>
     concept ProxyReference = std::is_copy_constructible_v<R> && std::is_copy_assignable_v<R> && requires(R r) {
         typename R::value_type;
@@ -72,13 +80,16 @@ namespace llama
         } -> std::same_as<R&>;
     } && AdlTwoStepSwappable<R>;
 
+    LLAMA_EXPORT
     template<typename R>
     concept AnyReference = LValueReference<R> || ProxyReference<R>;
 
+    LLAMA_EXPORT
     template<typename R, typename T>
     concept AnyReferenceTo = (LValueReference<R> && std::is_same_v<std::remove_cvref_t<R>, T>)
         || (ProxyReference<R> && std::is_same_v<typename R::value_type, T>);
 
+    LLAMA_EXPORT
     template<typename M, typename RC>
     concept ComputedField
         = M::isComputed(RC{}) && requires(M m, typename M::ArrayExtents::Index ai, std::byte** blobs) {
@@ -94,13 +105,16 @@ namespace llama
         using fn = mp_bool<ComputedField<M, RC>>;
     };
 
+    LLAMA_EXPORT
     template<typename M>
     inline constexpr bool allFieldsAreComputed
         = mp_all_of<LeafRecordCoords<typename M::RecordDim>, MakeIsComputed<M>::template fn>::value;
 
+    LLAMA_EXPORT
     template<typename M>
     concept FullyComputedMapping = Mapping<M> && allFieldsAreComputed<M>;
 
+    LLAMA_EXPORT
     template<
         typename M,
         typename LeafCoords = LeafRecordCoords<typename M::RecordDim>,
@@ -112,10 +126,12 @@ namespace llama
                               // because we cannot check whether the call to blobNrOrOffset()
                               // or compute() is actually valid
 
+    LLAMA_EXPORT
     template<typename M>
     concept PartiallyComputedMapping = Mapping<M> && allFieldsArePhysicalOrComputed<M>;
 
     /// Additional semantic requirement: &b[i] + j == &b[i + j] for any integral i and j in range of the blob
+    LLAMA_EXPORT
     template<typename B>
     concept Blob = requires(B b, std::size_t i) {
         // according to http://eel.is/c++draft/intro.object#3 only std::byte and unsigned char can
@@ -126,6 +142,7 @@ namespace llama
             || std::same_as<std::remove_cvref_t<decltype(b[i])>, unsigned char>;
     };
 
+    LLAMA_EXPORT
     template<typename BA>
     concept BlobAllocator = requires(BA ba, std::size_t size) {
         {
@@ -133,6 +150,7 @@ namespace llama
         } -> Blob;
     };
 
+    LLAMA_EXPORT
     template<typename V>
     concept AnyView = requires(V v, const V cv) {
         typename V::Mapping;
@@ -209,6 +227,7 @@ namespace llama
         };
     } // namespace internal
 
+    LLAMA_EXPORT
     template<typename R>
 #ifdef __cpp_lib_concepts
     inline constexpr bool isProxyReference = ProxyReference<R>;

--- a/include/llama/Copy.hpp
+++ b/include/llama/Copy.hpp
@@ -47,6 +47,7 @@ namespace llama
     /// the same array dimensions.
     /// @param threadId Optional. Zero-based id of calling thread for multi-threaded invocations.
     /// @param threadCount Optional. Thread count in case of multi-threaded invocation.
+    LLAMA_EXPORT
     template<typename Mapping, typename SrcBlob, typename DstBlob>
     void blobMemcpy(
         const View<Mapping, SrcBlob>& srcView,
@@ -73,6 +74,7 @@ namespace llama
     /// Field-wise copy from source to destination view. Both views need to have the same array and record dimensions.
     /// @param threadId Optional. Thread id in case of multi-threaded copy.
     /// @param threadCount Optional. Thread count in case of multi-threaded copy.
+    LLAMA_EXPORT
     template<typename SrcMapping, typename SrcBlob, typename DstMapping, typename DstBlob>
     void fieldWiseCopy(
         const View<SrcMapping, SrcBlob>& srcView,
@@ -134,6 +136,7 @@ namespace llama
     /// argument.
     /// @param threadId Optional. Zero-based id of calling thread for multi-threaded invocations.
     /// @param threadCount Optional. Thread count in case of multi-threaded invocation.
+    LLAMA_EXPORT
     template<typename SrcMapping, typename SrcBlob, typename DstMapping, typename DstBlob>
     void aosoaCommonBlockCopy(
         const View<SrcMapping, SrcBlob>& srcView,
@@ -306,6 +309,7 @@ namespace llama
     /// specializations of this construct for specific mappings. Users are encouraged to also specialize this template
     /// with better copy algorithms for further combinations of mappings, if they can and want to provide a better
     /// implementation.
+    LLAMA_EXPORT
     template<typename SrcMapping, typename DstMapping, typename SFINAE = void>
     struct Copy
     {
@@ -316,6 +320,7 @@ namespace llama
         }
     };
 
+    LLAMA_EXPORT
     template<typename Mapping>
     struct Copy<Mapping, Mapping>
     {
@@ -326,6 +331,7 @@ namespace llama
         }
     };
 
+    LLAMA_EXPORT
     template<
         typename ArrayExtents,
         typename RecordDim,
@@ -349,6 +355,7 @@ namespace llama
         }
     };
 
+    LLAMA_EXPORT
     template<
         typename ArrayExtents,
         typename RecordDim,
@@ -373,6 +380,7 @@ namespace llama
         }
     };
 
+    LLAMA_EXPORT
     template<
         typename ArrayExtents,
         typename RecordDim,
@@ -402,6 +410,7 @@ namespace llama
     /// dimensions. Delegates to \ref Copy to choose an implementation.
     /// @param threadId Optional. Zero-based id of calling thread for multi-threaded invocations.
     /// @param threadCount Optional. Thread count in case of multi-threaded invocation.
+    LLAMA_EXPORT
     template<typename SrcMapping, typename SrcBlob, typename DstMapping, typename DstBlob>
     void copy(
         const View<SrcMapping, SrcBlob>& srcView,

--- a/include/llama/Core.hpp
+++ b/include/llama/Core.hpp
@@ -17,12 +17,14 @@
 namespace llama
 {
     /// Anonymous naming for a \ref Field.
+    LLAMA_EXPORT
     struct NoName
     {
     };
 
     /// @brief Tells whether the given type is allowed as a field type in LLAMA. Such types need to be trivially
     /// constructible and trivially destructible.
+    LLAMA_EXPORT
     template<typename T>
     inline constexpr bool isAllowedFieldType = std::is_trivially_destructible_v<T>;
 
@@ -33,19 +35,23 @@ namespace llama
     /// Record. 2. an array of static size of any type, in which case a Record with as many \ref Field as the array
     /// size is created, named \ref RecordCoord specialized on consecutive numbers I. 3. A scalar type different from
     /// \ref Record, making this node a leaf of this type.
+    LLAMA_EXPORT
     template<typename Tag, typename Type>
     struct Field
     {
         static_assert(isAllowedFieldType<Type>, "This field's type is not allowed");
     };
 
+    LLAMA_EXPORT
     template<typename T>
     inline constexpr bool isField = false;
 
+    LLAMA_EXPORT
     template<typename Tag, typename Type>
     inline constexpr bool isField<Field<Tag, Type>> = true;
 
     /// A type list of \ref Field%s which may be used to define a record dimension.
+    LLAMA_EXPORT
     template<typename... Fields>
 #if __cpp_concepts
     // Cannot use a fold expression here, because clang/nvcc/icx cannot handle more than 256 arguments.
@@ -86,6 +92,7 @@ namespace llama
     inline namespace literals
     {
         /// Literal operator for converting a string literal "abc"_Name to a StringTag<"Name">.
+        LLAMA_EXPORT
         template<internal::FixedString Name>
         auto operator"" _Name()
         {
@@ -95,6 +102,7 @@ namespace llama
 
     /// Alternative to \ref Field. Use with string literals, e.g. NamedField<"x", float>. Access at the \ref View
     /// requires to use "x"_Name then.
+    LLAMA_EXPORT
     template<internal::FixedString Tag, typename Type>
     using NamedField = Field<internal::StringTag<Tag>, Type>;
 
@@ -136,11 +144,13 @@ namespace llama
     } // namespace internal
 
     /// Reflects the given type T using Boost.Describe and creates a record dimension for it.
+    LLAMA_EXPORT
     template<typename T>
     using ReflectToRecordDim = decltype(internal::reflectToRecordDim<T>());
 #    endif
 #endif
 
+    LLAMA_EXPORT
     template<typename T>
     struct NrAndOffset
     {
@@ -153,15 +163,18 @@ namespace llama
         }
     };
 
+    LLAMA_EXPORT
     template<typename Int>
     NrAndOffset(Int, Int) -> NrAndOffset<Int>;
 
+    LLAMA_EXPORT
     template<typename TA, typename TB>
     auto operator==(const NrAndOffset<TA>& a, const NrAndOffset<TB>& b) -> bool
     {
         return a.nr == b.nr && a.offset == b.offset;
     }
 
+    LLAMA_EXPORT
     template<typename TA, typename TB>
     auto operator!=(const NrAndOffset<TA>& a, const NrAndOffset<TB>& b) -> bool
     {
@@ -169,16 +182,20 @@ namespace llama
     }
 
     /// Get the tag from a \ref Field.
+    LLAMA_EXPORT
     template<typename Field>
     using GetFieldTag = mp_first<Field>;
 
     /// Get the type from a \ref Field.
+    LLAMA_EXPORT
     template<typename Field>
     using GetFieldType = mp_second<Field>;
 
+    LLAMA_EXPORT
     template<typename T>
     inline constexpr auto isRecord = false;
 
+    LLAMA_EXPORT
     template<typename... Fields>
     inline constexpr auto isRecord<Record<Fields...>> = true;
 
@@ -212,6 +229,7 @@ namespace llama
 
     /// Get the tags of all \ref Field%s from the root of the record dimension tree until to the node identified by
     /// \ref RecordCoord.
+    LLAMA_EXPORT
     template<typename RecordDim, typename RecordCoord>
     using GetTags = typename internal::GetTagsImpl<RecordDim, RecordCoord>::type;
 
@@ -231,6 +249,7 @@ namespace llama
     } // namespace internal
 
     /// Get the tag of the \ref Field at a \ref RecordCoord inside the record dimension tree.
+    LLAMA_EXPORT
     template<typename RecordDim, typename RecordCoord>
     using GetTag = typename internal::GetTagImpl<RecordDim, RecordCoord>::type;
 
@@ -240,6 +259,7 @@ namespace llama
     /// \tparam RecordCoordA \ref RecordCoord based on RecordDimA along which the tags are compared.
     /// \tparam RecordDimB second record dimension.
     /// \tparam RecordCoordB \ref RecordCoord based on RecordDimB along which the tags are compared.
+    LLAMA_EXPORT
     template<typename RecordDimA, typename RecordCoordA, typename RecordDimB, typename RecordCoordB>
     inline constexpr auto hasSameTags = []() constexpr
     {
@@ -328,6 +348,7 @@ namespace llama
 
     /// Converts a series of tags, or a list of tags, navigating down a record dimension into a \ref RecordCoord. A
     /// RecordCoord will be passed through unmodified.
+    LLAMA_EXPORT
     template<typename RecordDim, typename... TagsOrTagList>
     using GetCoordFromTags = typename internal::GetCoordFromTagsImpl<RecordDim, RecordCoord<>, TagsOrTagList...>::type;
 
@@ -362,6 +383,7 @@ namespace llama
 
     /// Returns the type of a node in a record dimension tree identified by a given \ref RecordCoord or a series of
     /// tags.
+    LLAMA_EXPORT
     template<typename RecordDim, typename... RecordCoordOrTags>
     using GetType = typename internal::GetTypeImpl<RecordDim, RecordCoordOrTags...>::type;
 
@@ -401,6 +423,7 @@ namespace llama
     } // namespace internal
 
     /// Returns a flat type list containing all record coordinates to all leaves of the given record dimension.
+    LLAMA_EXPORT
     template<typename RecordDim>
     using LeafRecordCoords = typename internal::LeafRecordCoordsImpl<RecordDim, RecordCoord<>>::type;
 
@@ -409,6 +432,7 @@ namespace llama
     /// the \ref RecordCoord in the record dimension tree.
     /// \param baseCoord \ref RecordCoord at which the iteration should be started. The functor is called on elements
     /// beneath this coordinate.
+    LLAMA_EXPORT
     template<typename RecordDim, typename Functor, std::size_t... Coords>
     LLAMA_FN_HOST_ACC_INLINE constexpr void forEachLeafCoord(Functor&& functor, RecordCoord<Coords...> baseCoord)
     {
@@ -425,6 +449,7 @@ namespace llama
     /// the \ref RecordCoord in the record dimension tree.
     /// \param baseTags Tags used to define where the iteration should be started. The functor is called on elements
     /// beneath this coordinate.
+    LLAMA_EXPORT
     template<typename RecordDim, typename Functor, typename... Tags>
     LLAMA_FN_HOST_ACC_INLINE constexpr void forEachLeafCoord(Functor&& functor, Tags... /*baseTags*/)
     {
@@ -452,17 +477,21 @@ namespace llama
     } // namespace internal
 
     /// Returns a flat type list containing all leaf field types of the given record dimension.
+    LLAMA_EXPORT
     template<typename RecordDim>
     using FlatRecordDim = typename internal::FlattenRecordDimImpl<RecordDim>::type;
 
     /// The total number of fields in the recursively expanded record dimension.
+    LLAMA_EXPORT
     template<typename RecordDim>
     inline constexpr std::size_t flatFieldCount = 1;
 
+    LLAMA_EXPORT
     template<typename... Children>
     inline constexpr std::size_t flatFieldCount<Record<Children...>>
         = (flatFieldCount<GetFieldType<Children>> + ... + 0);
 
+    LLAMA_EXPORT
     template<typename Child, std::size_t N>
     inline constexpr std::size_t flatFieldCount<Child[N]> = flatFieldCount<Child> * N;
 
@@ -484,17 +513,21 @@ namespace llama
 
     /// The equivalent zero based index into a flat record dimension (\ref FlatRecordDim) of the given hierarchical
     /// record coordinate.
+    LLAMA_EXPORT
     template<typename RecordDim, typename RecordCoord>
     inline constexpr std::size_t flatRecordCoord = 0;
 
+    LLAMA_EXPORT
     template<typename T>
     inline constexpr std::size_t flatRecordCoord<T, RecordCoord<>> = 0;
 
+    LLAMA_EXPORT
     template<typename... Children, std::size_t I, std::size_t... Is>
     inline constexpr std::size_t flatRecordCoord<Record<Children...>, RecordCoord<I, Is...>>
         = internal::flatFieldCountBefore<I, Record<Children...>>
         + flatRecordCoord<GetFieldType<mp_at_c<Record<Children...>, I>>, RecordCoord<Is...>>;
 
+    LLAMA_EXPORT
     template<typename Child, std::size_t N, std::size_t I, std::size_t... Is>
     inline constexpr std::size_t flatRecordCoord<Child[N], RecordCoord<I, Is...>>
         = flatFieldCount<Child> * I + flatRecordCoord<Child, RecordCoord<Is...>>;
@@ -517,19 +550,23 @@ namespace llama
 
     /// The alignment of a type list if its elements would be in a normal struct. Effectively returns the maximum
     /// alignment value in the type list.
+    LLAMA_EXPORT
     template<typename TypeList>
     inline constexpr std::size_t flatAlignOf = internal::flatAlignOfImpl<TypeList>();
 
     /// The alignment of a type T.
+    LLAMA_EXPORT
     template<typename T>
     inline constexpr std::size_t alignOf = alignof(T);
 
     /// The alignment of a record dimension if its fields would be in a normal struct. Effectively returns the maximum
     /// alignment value in the type list.
+    LLAMA_EXPORT
     template<typename... Fields>
     inline constexpr std::size_t alignOf<Record<Fields...>> = flatAlignOf<FlatRecordDim<Record<Fields...>>>;
 
     /// Returns the ceiling of a / b.
+    LLAMA_EXPORT
     template<typename Integral>
     [[nodiscard]] LLAMA_FN_HOST_ACC_INLINE constexpr auto divCeil(Integral a, Integral b) -> Integral
     {
@@ -537,6 +574,7 @@ namespace llama
     }
 
     /// Returns the integral n rounded up to be a multiple of mult.
+    LLAMA_EXPORT
     template<typename Integral>
     [[nodiscard]] LLAMA_FN_HOST_ACC_INLINE constexpr auto roundUpToMultiple(Integral n, Integral mult) -> Integral
     {
@@ -575,19 +613,23 @@ namespace llama
     } // namespace internal
 
     /// The size of a type list if its elements would be in a normal struct.
+    LLAMA_EXPORT
     template<typename TypeList, bool Align, bool IncludeTailPadding = true>
     inline constexpr std::size_t flatSizeOf = internal::sizeOfImpl<TypeList, Align, IncludeTailPadding>();
 
     /// The size of a type T.
+    LLAMA_EXPORT
     template<typename T, bool Align = false, bool IncludeTailPadding = true>
     inline constexpr std::size_t sizeOf = sizeof(T);
 
     /// The size of a record dimension if its fields would be in a normal struct.
+    LLAMA_EXPORT
     template<typename... Fields, bool Align, bool IncludeTailPadding>
     inline constexpr std::size_t sizeOf<Record<Fields...>, Align, IncludeTailPadding>
         = flatSizeOf<FlatRecordDim<Record<Fields...>>, Align, IncludeTailPadding>;
 
     /// The byte offset of an element in a type list ifs elements would be in a normal struct.
+    LLAMA_EXPORT
     template<typename TypeList, std::size_t I, bool Align>
     inline constexpr std::size_t flatOffsetOf = internal::offsetOfImplWorkaround<TypeList, I, Align>();
 
@@ -614,6 +656,7 @@ namespace llama
     /// The byte offset of an element in a record dimension if it would be a normal struct.
     /// \tparam RecordDim Record dimension tree.
     /// \tparam RecordCoord Record coordinate of an element inrecord dimension tree.
+    LLAMA_EXPORT
     template<typename RecordDim, typename RecordCoord, bool Align = false>
     inline constexpr std::size_t offsetOf
         = flatOffsetOf<FlatRecordDim<RecordDim>, flatRecordCoord<RecordDim, RecordCoord>, Align>;
@@ -650,6 +693,7 @@ namespace llama
     } // namespace internal
 
     /// True if the T is a record dimension. That is, T is either a llama::Record or a bounded array.
+    LLAMA_EXPORT
     template<typename T>
     inline constexpr bool isRecordDim = isRecord<T> || internal::IsBoundedArray<T>::value;
 
@@ -701,12 +745,14 @@ namespace llama
 
     /// Creates a new record dimension where each new leaf field's type is the result of applying FieldTypeFunctor to
     /// the original leaf's \ref RecordCoord and field's type.
+    LLAMA_EXPORT
     template<typename RecordDim, template<typename, typename> typename FieldTypeFunctor>
     using TransformLeavesWithCoord =
         typename internal::TransformLeavesWithCoordImpl<RecordCoord<>, RecordDim, FieldTypeFunctor>::type;
 
     /// Creates a new record dimension where each new leaf field's type is the result of applying FieldTypeFunctor to
     /// the original leaf field's type.
+    LLAMA_EXPORT
     template<typename RecordDim, template<typename> typename FieldTypeFunctor>
     using TransformLeaves
         = TransformLeavesWithCoord<RecordDim, internal::MakePassSecond<FieldTypeFunctor>::template fn>;
@@ -767,15 +813,18 @@ namespace llama
     } // namespace internal
 
     /// Creates a merged record dimension, where duplicated, nested fields are unified.
+    LLAMA_EXPORT
     template<typename RecordDimA, typename RecordDimB>
     using MergedRecordDims =
         typename decltype(internal::mergeRecordDimsImpl(mp_identity<RecordDimA>{}, mp_identity<RecordDimB>{}))::type;
 
     /// Alias for ToT, adding `const` if FromT is const qualified.
+    LLAMA_EXPORT
     template<typename FromT, typename ToT>
     using CopyConst = std::conditional_t<std::is_const_v<FromT>, const ToT, ToT>;
 
     /// Used as template argument to specify a constant/compile-time value.
+    LLAMA_EXPORT
     template<auto V>
     using Constant = std::integral_constant<decltype(V), V>;
 
@@ -792,6 +841,7 @@ namespace llama
         };
     } // namespace internal
 
+    LLAMA_EXPORT
     template<typename T>
     inline constexpr bool isConstant = internal::IsConstant<T>::value;
 
@@ -838,6 +888,7 @@ namespace llama
         };
     } // namespace internal
 
+    LLAMA_EXPORT
     struct PrettySize
     {
         double size;
@@ -846,6 +897,7 @@ namespace llama
 
     /// Repeatedly divides the given size (in bytes) until it fits below 1000. Returns the new size and a string
     /// literal with the corresponding unit.
+    LLAMA_EXPORT
     inline auto prettySize(double size) -> PrettySize
     {
         static const char* unit[] = {"B ", "KB", "MB", "GB", "TB", "PB", "EB"};

--- a/include/llama/DumpMapping.hpp
+++ b/include/llama/DumpMapping.hpp
@@ -234,6 +234,7 @@ namespace llama
 
     /// Returns an SVG image visualizing the memory layout created by the given mapping. The created memory blocks are
     /// wrapped after wrapByteCount bytes.
+    LLAMA_EXPORT
     template<typename Mapping>
     auto toSvg(const Mapping& mapping, std::size_t wrapByteCount = 64, bool breakBoxes = true) -> std::string
     {
@@ -384,6 +385,7 @@ namespace llama
 
     /// Returns an HTML document visualizing the memory layout created by the given mapping. The visualization is
     /// resizeable.
+    LLAMA_EXPORT
     template<typename Mapping>
     auto toHtml(const Mapping& mapping) -> std::string
     {

--- a/include/llama/Meta.hpp
+++ b/include/llama/Meta.hpp
@@ -52,6 +52,7 @@ namespace llama
         };
     } // namespace internal
 
+    LLAMA_EXPORT
     template<typename Expression, typename... Args>
     using ReplacePlaceholders = typename internal::ReplacePlaceholdersImpl<Expression, Args...>::type;
 } // namespace llama

--- a/include/llama/Proofs.hpp
+++ b/include/llama/Proofs.hpp
@@ -45,6 +45,7 @@ namespace llama
     /// Proofs by exhaustion of the array and record dimensions, that all values mapped to memory do not overlap.
     // Unfortunately, this only works for smallish array dimensions, because of compiler limits on constexpr evaluation
     // depth.
+    LLAMA_EXPORT
     template<typename Mapping>
     constexpr auto mapsNonOverlappingly(const Mapping& m) -> bool
     {
@@ -87,6 +88,7 @@ namespace llama
     /// contiguously.
     // Unfortunately, this only works for smallish array dimensions, because of compiler limits on constexpr evaluation
     // depth.
+    LLAMA_EXPORT
     template<std::size_t PieceLength, typename Mapping>
     constexpr auto mapsPiecewiseContiguous(const Mapping& m) -> bool
     {

--- a/include/llama/ProxyRefOpMixin.hpp
+++ b/include/llama/ProxyRefOpMixin.hpp
@@ -8,6 +8,7 @@
 namespace llama
 {
     /// CRTP mixin for proxy reference types to support all compound assignment and increment/decrement operators.
+    LLAMA_EXPORT
     template<typename Derived, typename ValueType>
     struct ProxyRefOpMixin
     {

--- a/include/llama/RecordCoord.hpp
+++ b/include/llama/RecordCoord.hpp
@@ -14,6 +14,7 @@ namespace llama
 {
     /// Represents a coordinate for a record inside the record dimension tree.
     /// \tparam Coords... the compile time coordinate.
+    LLAMA_EXPORT
     template<std::size_t... Coords>
     struct RecordCoord
     {
@@ -25,6 +26,7 @@ namespace llama
         static constexpr std::size_t size = sizeof...(Coords);
     };
 
+    LLAMA_EXPORT
     template<>
     struct RecordCoord<>
     {
@@ -33,30 +35,36 @@ namespace llama
         static constexpr std::size_t size = 0;
     };
 
+    LLAMA_EXPORT
     template<std::size_t... CoordsA, std::size_t... CoordsB>
     LLAMA_FN_HOST_ACC_INLINE constexpr auto operator==(RecordCoord<CoordsA...>, RecordCoord<CoordsB...>)
     {
         return false;
     }
 
+    LLAMA_EXPORT
     template<std::size_t... Coords>
     LLAMA_FN_HOST_ACC_INLINE constexpr auto operator==(RecordCoord<Coords...>, RecordCoord<Coords...>)
     {
         return true;
     }
 
+    LLAMA_EXPORT
     template<std::size_t... CoordsA, std::size_t... CoordsB>
     LLAMA_FN_HOST_ACC_INLINE constexpr auto operator!=(RecordCoord<CoordsA...> a, RecordCoord<CoordsB...> b)
     {
         return !(a == b);
     }
 
+    LLAMA_EXPORT
     template<typename T>
     inline constexpr bool isRecordCoord = false;
 
+    LLAMA_EXPORT
     template<std::size_t... Coords>
     inline constexpr bool isRecordCoord<RecordCoord<Coords...>> = true;
 
+    LLAMA_EXPORT
     template<std::size_t... RCs>
     auto operator<<(std::ostream& os, RecordCoord<RCs...>) -> std::ostream&
     {
@@ -77,6 +85,7 @@ namespace llama
     inline namespace literals
     {
         /// Literal operator for converting a numeric literal into a \ref RecordCoord.
+        LLAMA_EXPORT
         template<char... Digits>
         constexpr auto operator"" _RC()
         {
@@ -97,14 +106,17 @@ namespace llama
     } // namespace literals
 
     /// Converts a type list of integral constants into a \ref RecordCoord.
+    LLAMA_EXPORT
     template<typename L>
     using RecordCoordFromList = internal::mp_unwrap_values_into<L, RecordCoord>;
 
     /// Concatenate a set of \ref RecordCoord%s.
+    LLAMA_EXPORT
     template<typename... RecordCoords>
     using Cat = RecordCoordFromList<mp_append<typename RecordCoords::List...>>;
 
     /// Concatenate a set of \ref RecordCoord%s instances.
+    LLAMA_EXPORT
     template<typename... RecordCoords>
     LLAMA_FN_HOST_ACC_INLINE constexpr auto cat(RecordCoords...)
     {
@@ -112,6 +124,7 @@ namespace llama
     }
 
     /// RecordCoord without first coordinate component.
+    LLAMA_EXPORT
     template<typename RecordCoord>
     using PopFront = RecordCoordFromList<mp_pop_front<typename RecordCoord::List>>;
 
@@ -135,6 +148,7 @@ namespace llama
     } // namespace internal
 
     /// Checks wether the first RecordCoord is bigger than the second.
+    LLAMA_EXPORT
     template<typename First, typename Second>
     inline constexpr auto recordCoordCommonPrefixIsBigger
         = internal::recordCoordCommonPrefixIsBiggerImpl(First{}, Second{});
@@ -155,6 +169,7 @@ namespace llama
     } // namespace internal
 
     /// Checks whether two \ref RecordCoord%s are the same or one is the prefix of the other.
+    LLAMA_EXPORT
     template<typename First, typename Second>
     inline constexpr auto recordCoordCommonPrefixIsSame
         = internal::recordCoordCommonPrefixIsSameImpl(First{}, Second{});

--- a/include/llama/RecordRef.hpp
+++ b/include/llama/RecordRef.hpp
@@ -15,16 +15,20 @@
 
 namespace llama
 {
+    LLAMA_EXPORT
     template<typename View, typename BoundRecordCoord, bool OwnView>
     struct RecordRef;
 
+    LLAMA_EXPORT
     template<typename View>
     inline constexpr auto isRecordRef = false;
 
+    LLAMA_EXPORT
     template<typename View, typename BoundRecordCoord, bool OwnView>
     inline constexpr auto isRecordRef<RecordRef<View, BoundRecordCoord, OwnView>> = true;
 
     /// Returns a \ref One with the same record dimension as the given record ref, with values copyied from rr.
+    LLAMA_EXPORT
     template<typename View, typename BoundRecordCoord, bool OwnView>
     LLAMA_FN_HOST_ACC_INLINE auto copyRecord(const RecordRef<View, BoundRecordCoord, OwnView>& rr)
     {
@@ -336,6 +340,7 @@ namespace llama
     /// (array dimensions coord and partial record coord) to retrieve it later from a \ref View. Records references
     /// should not be created by the user. They are returned from various access functions in \ref View and RecordRef
     /// itself.
+    LLAMA_EXPORT
     template<typename TView, typename TBoundRecordCoord, bool OwnView>
     struct RecordRef : private TView::Mapping::ArrayExtents::Index
     {
@@ -761,6 +766,7 @@ namespace llama
     };
 
     // swap for heterogeneous RecordRef
+    LLAMA_EXPORT
     template<
         typename ViewA,
         typename BoundRecordDimA,
@@ -784,6 +790,7 @@ namespace llama
             });
     }
 
+    LLAMA_EXPORT
     template<typename View, typename BoundRecordCoord, bool OwnView>
     auto operator<<(std::ostream& os, const RecordRef<View, BoundRecordCoord, OwnView>& vr) -> std::ostream&
     {
@@ -816,6 +823,7 @@ namespace llama
         return os;
     }
 
+    LLAMA_EXPORT
     template<typename RecordRefFwd, typename Functor>
     LLAMA_FN_HOST_ACC_INLINE constexpr void forEachLeaf(RecordRefFwd&& vr, Functor&& functor)
     {
@@ -859,6 +867,7 @@ namespace llama
     } // namespace internal
 
     /// Pulls a copy of the given value or reference. Proxy references are resolved to their value types.
+    LLAMA_EXPORT
     template<typename T>
     auto decayCopy(T&& valueOrRef) -> typename internal::ValueOf<T>::type
     {
@@ -869,6 +878,7 @@ namespace llama
     /// construction. The stored value is written back when ScopedUpdate is destroyed. ScopedUpdate tries to act like
     /// the stored value as much as possible, exposing member functions of the stored value and acting like a proxy
     /// reference if the stored value is a primitive type.
+    LLAMA_EXPORT
     template<typename Reference, typename = void>
     struct ScopedUpdate : internal::ValueOf<Reference>::type
     {
@@ -909,6 +919,7 @@ namespace llama
         Reference ref;
     };
 
+    LLAMA_EXPORT
     template<typename Reference>
     struct ScopedUpdate<
         Reference,
@@ -990,28 +1001,33 @@ namespace llama
         };
     } // namespace internal
 
+    LLAMA_EXPORT
     template<typename T>
     ScopedUpdate(T) -> ScopedUpdate<typename internal::ReferenceTo<std::remove_reference_t<T>>::type>;
 } // namespace llama
 
+LLAMA_EXPORT
 template<typename View, typename BoundRecordCoord, bool OwnView>
 struct std::tuple_size<llama::RecordRef<View, BoundRecordCoord, OwnView>> // NOLINT(cert-dcl58-cpp)
     : boost::mp11::mp_size<typename llama::RecordRef<View, BoundRecordCoord, OwnView>::AccessibleRecordDim>
 {
 };
 
+LLAMA_EXPORT
 template<std::size_t I, typename View, typename BoundRecordCoord, bool OwnView>
 struct std::tuple_element<I, llama::RecordRef<View, BoundRecordCoord, OwnView>> // NOLINT(cert-dcl58-cpp)
 {
     using type = decltype(std::declval<llama::RecordRef<View, BoundRecordCoord, OwnView>>().template get<I>());
 };
 
+LLAMA_EXPORT
 template<std::size_t I, typename View, typename BoundRecordCoord, bool OwnView>
 struct std::tuple_element<I, const llama::RecordRef<View, BoundRecordCoord, OwnView>> // NOLINT(cert-dcl58-cpp)
 {
     using type = decltype(std::declval<const llama::RecordRef<View, BoundRecordCoord, OwnView>>().template get<I>());
 };
 
+LLAMA_EXPORT
 template<typename View, typename BoundRecordCoord, bool OwnView>
 struct std::hash<llama::RecordRef<View, BoundRecordCoord, OwnView>> // NOLINT(cert-dcl58-cpp)
 {
@@ -1027,6 +1043,7 @@ struct std::hash<llama::RecordRef<View, BoundRecordCoord, OwnView>> // NOLINT(ce
 };
 
 #if CAN_USE_RANGES
+LLAMA_EXPORT
 template<
     typename ViewA,
     typename BoundA,

--- a/include/llama/Simd.hpp
+++ b/include/llama/Simd.hpp
@@ -22,12 +22,14 @@ namespace llama
     /// address.
     /// * a `static void storeUnaligned(Simd simd, value_type* mem)` function, storing the given Simd to a given
     /// memory address.
+    LLAMA_EXPORT
     template<typename Simd, typename SFINAE = void>
     struct SimdTraits
     {
         static_assert(sizeof(Simd) == 0, "Please specialize SimdTraits for the type Simd");
     };
 
+    LLAMA_EXPORT
     template<typename T>
     struct SimdTraits<T, std::enable_if_t<std::is_arithmetic_v<T>>>
     {
@@ -48,6 +50,7 @@ namespace llama
 
     /// The number of SIMD simdLanes the given SIMD vector or \ref Simd<T> has. If Simd is not a structural \ref Simd
     /// or \ref SimdN, this is a shortcut for SimdTraits<Simd>::lanes.
+    LLAMA_EXPORT
     template<typename Simd, typename SFINAE = void>
     inline constexpr auto simdLanes = SimdTraits<Simd>::lanes;
 
@@ -55,6 +58,7 @@ namespace llama
     /// then reducing their sizes.
     /// @tparam MakeSimd Type function creating a SIMD type given a field type from the record dimension.
     /// @param reduce Binary reduction function to reduce the SIMD lanes.
+    LLAMA_EXPORT
     template<typename RecordDim, template<typename> typename MakeSimd, typename BinaryReductionFunction>
     LLAMA_CONSTEVAL auto chooseSimdLanes(BinaryReductionFunction reduce) -> std::size_t
     {
@@ -75,6 +79,7 @@ namespace llama
     /// multiple SIMD vectors for some field types.
     /// @tparam RecordDim The record dimension to simdize
     /// @tparam MakeSimd Type function creating a SIMD type given a field type from the record dimension.
+    LLAMA_EXPORT
     template<typename RecordDim, template<typename> typename MakeSimd>
     inline constexpr std::size_t simdLanesWithFullVectorsFor
         = chooseSimdLanes<RecordDim, MakeSimd>([](auto a, auto b) { return std::max(a, b); });
@@ -84,6 +89,7 @@ namespace llama
     /// registers for some data types.
     /// @tparam RecordDim The record dimension to simdize
     /// @tparam MakeSimd Type function creating a SIMD type given a field type from the record dimension.
+    LLAMA_EXPORT
     template<typename RecordDim, template<typename> typename MakeSimd>
     inline constexpr std::size_t simdLanesWithLeastRegistersFor
         = chooseSimdLanes<RecordDim, MakeSimd>([](auto a, auto b) { return std::min(a, b); });
@@ -117,11 +123,13 @@ namespace llama
     /// Transforms the given record dimension into a SIMD version of it. Each leaf field type will be replaced by a
     /// sized SIMD vector with length N, as determined by MakeSizedSimd. If N is 1, SimdizeN<T, 1, ...> is an alias for
     /// T.
+    LLAMA_EXPORT
     template<typename RecordDim, std::size_t N, template<typename, /* std::integral */ auto> typename MakeSizedSimd>
     using SimdizeN = typename internal::SimdizeNImpl<RecordDim, N, MakeSizedSimd>::type;
 
     /// Transforms the given record dimension into a SIMD version of it. Each leaf field type will be replaced by a
     /// SIMD vector, as determined by MakeSimd.
+    LLAMA_EXPORT
     template<typename RecordDim, template<typename> typename MakeSimd>
     using Simdize = TransformLeaves<RecordDim, MakeSimd>;
 
@@ -129,6 +137,7 @@ namespace llama
     /// SIMD type of the original field type. The SIMD vectors have length N. If N is 1, an ordinary \ref One of the
     /// record dimension T is created. If T is not a record dimension, a SIMD vector with value T and length N is
     /// created. If N is 1 (and T is not a record dimension), then T is produced.
+    LLAMA_EXPORT
     template<typename T, std::size_t N, template<typename, /* std::integral */ auto> typename MakeSizedSimd>
     using SimdN = typename std::conditional_t<
         isRecordDim<T>,
@@ -137,6 +146,7 @@ namespace llama
 
     /// Creates a SIMD version of the given type. Of T is a record dimension, creates a \ref One where each field is a
     /// SIMD type of the original field type.
+    LLAMA_EXPORT
     template<typename T, template<typename> typename MakeSimd>
     using Simd = typename std::
         conditional_t<isRecordDim<T>, mp_identity<One<Simdize<T, MakeSimd>>>, mp_identity<Simdize<T, MakeSimd>>>::type;
@@ -153,6 +163,7 @@ namespace llama
 
     /// Specialization for Simd<RecordDim>. Only works if all SIMD types in the fields of the record dimension have the
     /// same size.
+    LLAMA_EXPORT
     template<typename Simd>
     inline constexpr std::size_t simdLanes<Simd, std::enable_if_t<isRecordRef<Simd>>> = []
     {
@@ -260,6 +271,7 @@ namespace llama
     /// RecordRef are loaded. If Simd contains multiple fields of SIMD types, a SIMD vector will be fetched for each of
     /// the fields. The number of elements fetched per SIMD vector depends on the SIMD width of the vector. Simd is
     /// allowed to have different vector lengths per element.
+    LLAMA_EXPORT
     template<typename T, typename Simd>
     LLAMA_FN_HOST_ACC_INLINE void loadSimd(const T& srcRef, Simd& dstSimd)
     {
@@ -287,6 +299,7 @@ namespace llama
     /// reference. Only field tags occurring in RecordRef are stored. If Simd contains multiple fields of SIMD types, a
     /// SIMD vector will be stored for each of the fields. The number of elements stored per SIMD vector depends on the
     /// SIMD width of the vector. Simd is allowed to have different vector lengths per element.
+    LLAMA_EXPORT
     template<typename Simd, typename T>
     LLAMA_FN_HOST_ACC_INLINE void storeSimd(const Simd& srcSimd, T&& dstRef)
     {
@@ -310,6 +323,7 @@ namespace llama
         }
     }
 
+    LLAMA_EXPORT
     template<
         std::size_t N,
         template<typename, /* std::integral */ auto>
@@ -347,6 +361,7 @@ namespace llama
         }
     }
 
+    LLAMA_EXPORT
     template<
         template<typename>
         typename MakeSimd,

--- a/include/llama/StructName.hpp
+++ b/include/llama/StructName.hpp
@@ -194,6 +194,7 @@ namespace llama
         inline constexpr auto typeNameStorage = typeNameAsArray<T>();
     } // namespace internal
 
+    LLAMA_EXPORT
     template<typename T>
     inline constexpr auto qualifiedTypeName = []
     {
@@ -272,6 +273,7 @@ namespace llama
         }();
     } // namespace internal
 
+    LLAMA_EXPORT
     template<typename T>
     constexpr auto structName(T = {}) -> std::string_view
     {
@@ -366,6 +368,7 @@ namespace llama
 
     /// Returns a pretty representation of the record coordinate inside the given record dimension. Tags are
     /// interspersed by '.' and arrays are represented using subscript notation ("[123]").
+    LLAMA_EXPORT
     template<typename RecordDim, std::size_t... Coords>
     constexpr auto prettyRecordCoord(RecordCoord<Coords...> = {}) -> std::string_view
     {
@@ -373,6 +376,7 @@ namespace llama
         return std::string_view{value.data(), value.size()};
     }
 
+    LLAMA_EXPORT
     template<typename RecordDim>
     constexpr auto prettyRecordCoord(RecordCoord<>) -> std::string_view
     {

--- a/include/llama/Tuple.hpp
+++ b/include/llama/Tuple.hpp
@@ -42,12 +42,14 @@ namespace llama
         };
     } // namespace internal
 
+    LLAMA_EXPORT
     template<typename... Elements>
     struct LLAMA_DECLSPEC_EMPTY_BASES Tuple
     {
     };
 
     /// Tuple class like `std::tuple` but suitable for use with offloading devices like GPUs.
+    LLAMA_EXPORT
     template<typename TFirstElement, typename... RestElements>
     struct LLAMA_DECLSPEC_EMPTY_BASES Tuple<TFirstElement, RestElements...>
         : internal::TupleLeaf<1 + sizeof...(RestElements), TFirstElement>
@@ -110,9 +112,11 @@ namespace llama
         }
     };
 
+    LLAMA_EXPORT
     template<typename... Elements>
     LLAMA_HOST_ACC Tuple(Elements...) -> Tuple<std::remove_cv_t<std::remove_reference_t<Elements>>...>;
 
+    LLAMA_EXPORT
     template<std::size_t I, typename... Elements>
     LLAMA_FN_HOST_ACC_INLINE constexpr auto get(Tuple<Elements...>& tuple) -> auto&
     {
@@ -121,6 +125,7 @@ namespace llama
         return tuple.Base::value();
     }
 
+    LLAMA_EXPORT
     template<std::size_t I, typename... Elements>
     LLAMA_FN_HOST_ACC_INLINE constexpr auto get(const Tuple<Elements...>& tuple) -> const auto&
     {
@@ -130,12 +135,14 @@ namespace llama
     }
 } // namespace llama
 
+LLAMA_EXPORT
 template<typename... Elements>
 struct std::tuple_size<llama::Tuple<Elements...>> // NOLINT(cert-dcl58-cpp)
 {
     static constexpr auto value = sizeof...(Elements);
 };
 
+LLAMA_EXPORT
 template<std::size_t I, typename... Elements>
 struct std::tuple_element<I, llama::Tuple<Elements...>> // NOLINT(cert-dcl58-cpp)
 {
@@ -156,6 +163,7 @@ namespace llama
         }
     } // namespace internal
 
+    LLAMA_EXPORT
     template<typename... ElementsA, typename... ElementsB>
     LLAMA_FN_HOST_ACC_INLINE constexpr auto operator==(const Tuple<ElementsA...>& a, const Tuple<ElementsB...>& b)
         -> bool
@@ -167,6 +175,7 @@ namespace llama
         return false;
     }
 
+    LLAMA_EXPORT
     template<typename... ElementsA, typename... ElementsB>
     LLAMA_FN_HOST_ACC_INLINE constexpr auto operator!=(const Tuple<ElementsA...>& a, const Tuple<ElementsB...>& b)
         -> bool
@@ -187,6 +196,7 @@ namespace llama
         }
     } // namespace internal
 
+    LLAMA_EXPORT
     template<typename Tuple1, typename Tuple2>
     LLAMA_FN_HOST_ACC_INLINE constexpr auto tupleCat(const Tuple1& t1, const Tuple2& t2)
     {
@@ -219,6 +229,7 @@ namespace llama
     } // namespace internal
 
     /// Creates a copy of a tuple with the element at position Pos replaced by replacement.
+    LLAMA_EXPORT
     template<std::size_t Pos, typename Tuple, typename Replacement>
     LLAMA_FN_HOST_ACC_INLINE constexpr auto tupleReplace(Tuple&& tuple, Replacement&& replacement)
     {
@@ -245,6 +256,7 @@ namespace llama
 
     /// Applies a functor to every element of a tuple, creating a new tuple with the result of the element
     /// transformations. The functor needs to implement a template `operator()` to which all tuple elements are passed.
+    LLAMA_EXPORT
     template<typename... Elements, typename Functor>
     LLAMA_FN_HOST_ACC_INLINE constexpr auto tupleTransform(const Tuple<Elements...>& tuple, const Functor& functor)
     {
@@ -253,6 +265,7 @@ namespace llama
     }
 
     /// Returns a copy of the tuple without the first element.
+    LLAMA_EXPORT
     template<typename... Elements>
     LLAMA_FN_HOST_ACC_INLINE constexpr auto popFront(const Tuple<Elements...>& tuple)
     {

--- a/include/llama/Vector.hpp
+++ b/include/llama/Vector.hpp
@@ -17,6 +17,7 @@ namespace llama
     /// exception guarantee.
     /// WARNING: This class is experimental.
     /// @tparam Mapping The mapping to be used for the underlying view. Needs to have 1 array dimension.
+    LLAMA_EXPORT
     template<typename Mapping>
     struct Vector
     {
@@ -307,6 +308,4 @@ namespace llama
         ViewType m_view = {};
         size_type m_size = 0;
     };
-
-
 } // namespace llama

--- a/include/llama/View.hpp
+++ b/include/llama/View.hpp
@@ -16,6 +16,7 @@
 
 namespace llama
 {
+    LLAMA_EXPORT
 #ifdef __cpp_lib_concepts
     template<typename TMapping, Blob BlobType, typename TAccessor>
 #else
@@ -45,6 +46,7 @@ namespace llama
     } // namespace internal
 
     /// Same as \ref allocView but does not run field constructors.
+    LLAMA_EXPORT
 #ifdef __cpp_lib_concepts
     template<typename Mapping, BlobAllocator Allocator = bloballoc::Vector, typename Accessor = accessor::Default>
 #else
@@ -77,16 +79,19 @@ namespace llama
     } // namespace internal
 
     /// Returns true if the field accessed via the given mapping and record coordinate is a computed value.
+    LLAMA_EXPORT
     template<typename Mapping, typename RecordCoord>
     inline constexpr bool isComputed = internal::IsComputed<Mapping, RecordCoord>::value;
 
     /// Returns true if any field accessed via the given mapping is a computed value.
     // TODO(bgruber): harmonize this with LLAMA's concepts from Concepts.hpp
+    LLAMA_EXPORT
     template<typename Mapping>
     inline constexpr bool hasAnyComputedField = mp_any_of<
         LeafRecordCoords<typename Mapping::RecordDim>,
         mp_bind_front<internal::IsComputed, Mapping>::template fn>::value;
 
+    LLAMA_EXPORT
     template<typename Mapping, typename BlobType, typename Accessor, std::size_t... RCs>
     LLAMA_FN_HOST_ACC_INLINE void constructField(
         View<Mapping, BlobType, Accessor>& view,
@@ -127,6 +132,7 @@ namespace llama
     /// Value-initializes all fields reachable through the given view. That is, constructors are run and fundamental
     /// types are zero-initialized. Computed fields are constructed if they return l-value references and assigned a
     /// default constructed value if they return a proxy reference.
+    LLAMA_EXPORT
     template<typename Mapping, typename BlobType, typename Accessor>
     LLAMA_FN_HOST_ACC_INLINE void constructFields(View<Mapping, BlobType, Accessor>& view)
     {
@@ -143,6 +149,7 @@ namespace llama
     /// allocator callable is called with the alignment and size of bytes to allocate for each blob of the mapping.
     /// Value-initialization is performed for all fields by calling \ref constructFields. This function is the
     /// preferred way to create a \ref View. See also \ref allocViewUninitialized.
+    LLAMA_EXPORT
 #ifdef __cpp_lib_concepts
     template<typename Mapping, BlobAllocator Allocator = bloballoc::Vector, typename Accessor = accessor::Default>
 #else
@@ -157,6 +164,7 @@ namespace llama
     }
 
     /// Same as \ref allocViewStack but does not run field constructors.
+    LLAMA_EXPORT
     template<std::size_t Dim, typename RecordDim>
     LLAMA_FN_HOST_ACC_INLINE auto allocViewStackUninitialized() -> decltype(auto)
     {
@@ -166,6 +174,7 @@ namespace llama
 
     /// Allocates a \ref View holding a single record backed by stack memory (\ref bloballoc::Array).
     /// \tparam Dim Dimension of the \ref ArrayExtents of the \ref View.
+    LLAMA_EXPORT
     template<std::size_t Dim, typename RecordDim>
     LLAMA_FN_HOST_ACC_INLINE auto allocViewStack() -> decltype(auto)
     {
@@ -174,17 +183,21 @@ namespace llama
         return view;
     }
 
+    LLAMA_EXPORT
     template<typename View, typename BoundRecordCoord = RecordCoord<>, bool OwnView = false>
     struct RecordRef;
 
     /// A \ref RecordRef that owns and holds a single value.
+    LLAMA_EXPORT
     template<typename RecordDim>
     using One = RecordRef<decltype(allocViewStack<0, RecordDim>()), RecordCoord<>, true>;
 
     /// Is true, if T is an instance of \ref One.
+    LLAMA_EXPORT
     template<typename T>
     inline constexpr bool isOne = false;
 
+    LLAMA_EXPORT
     template<typename View, typename BoundRecordCoord>
     inline constexpr bool isOne<RecordRef<View, BoundRecordCoord, true>> = true;
 
@@ -192,6 +205,7 @@ namespace llama
     // superior to a single iterator over multiple dimensions. At least compilers are able to produce better code.
     // std::mdspan also discovered similar difficulties and there was a discussion in WG21 in Oulu 2016 to
     // remove/postpone iterators from the design. In std::mdspan's design, the iterator iterated over the co-domain.
+    LLAMA_EXPORT
     template<typename View>
     struct Iterator
     {
@@ -345,6 +359,7 @@ namespace llama
     /// Using a mapping, maps the given array index and record coordinate to a memory reference onto the given blobs.
     /// \return Either an l-value reference if the record coord maps to a physical field or a proxy reference if mapped
     /// to a computed field.
+    LLAMA_EXPORT
     template<typename Mapping, typename RecordCoord, typename Blobs>
     LLAMA_FN_HOST_ACC_INLINE auto mapToMemory(
         Mapping& mapping,
@@ -369,6 +384,7 @@ namespace llama
     /// mapping. A view should be created using \ref allocView. \tparam TMapping The mapping used by the view to
     /// map accesses into memory. \tparam TBlobType The storage type used by the view holding memory. \tparam
     /// TAccessor The accessor to use when an access is made through this view.
+    LLAMA_EXPORT
 #ifdef __cpp_lib_concepts
     template<typename TMapping, Blob TBlobType, typename TAccessor = accessor::Default>
 #else
@@ -580,6 +596,7 @@ namespace llama
         Array<BlobType, Mapping::blobCount> m_blobs;
     };
 
+    LLAMA_EXPORT
 #ifdef __cpp_lib_concepts
     template<typename View>
     inline constexpr auto isView = AnyView<View>;
@@ -630,6 +647,7 @@ namespace llama
 
     /// Applies the given transformation to the blobs of a view and creates a new view with the transformed blobs
     /// and the same mapping and accessor as the old view.
+    LLAMA_EXPORT
     template<typename ViewFwd, typename TransformBlobFunc, typename = std::enable_if_t<isView<std::decay_t<ViewFwd>>>>
     LLAMA_FN_HOST_ACC_INLINE auto transformBlobs(ViewFwd&& view, const TransformBlobFunc& transformBlob)
     {
@@ -649,6 +667,7 @@ namespace llama
     /// Creates a shallow copy of a view. This copy must not outlive the view, since it references its blob array.
     /// \tparam NewBlobType The blob type of the shallow copy. Must be a non owning pointer like type.
     /// \return A new view with the same mapping as view, where each blob refers to the blob in view.
+    LLAMA_EXPORT
     template<
         typename View,
         typename NewBlobType = CopyConst<std::remove_reference_t<View>, std::byte>*,
@@ -670,6 +689,7 @@ namespace llama
 
     // Creates a new view from an existing view with the given accessor.
     // \param view A view which's mapping and blobs are forwarded into a new view with the different accessor.
+    LLAMA_EXPORT
     template<typename NewAccessor, typename ViewFwd, typename = std::enable_if_t<isView<std::decay_t<ViewFwd>>>>
     LLAMA_FN_HOST_ACC_INLINE auto withAccessor(ViewFwd&& view, NewAccessor newAccessor = {})
     {
@@ -682,6 +702,7 @@ namespace llama
 
     // Creates a new view from an existing view with the given mapping.
     // \param view A view which's accessor and blobs are forwarded into a new view with the different mapping.
+    LLAMA_EXPORT
     template<typename NewMapping, typename ViewFwd, typename = std::enable_if_t<isView<std::decay_t<ViewFwd>>>>
     LLAMA_FN_HOST_ACC_INLINE auto withMapping(ViewFwd&& view, NewMapping newMapping = {})
     {
@@ -700,6 +721,7 @@ namespace llama
 
     /// Like a \ref View, but array indices are shifted.
     /// @tparam TStoredParentView Type of the underlying view. May be cv qualified and/or a reference type.
+    LLAMA_EXPORT
     template<typename TStoredParentView>
     struct SubView
     {
@@ -822,6 +844,7 @@ namespace llama
 
     /// SubView vview(view); will store a reference to view.
     /// SubView vview(std::move(view)); will store the view.
+    LLAMA_EXPORT
     template<typename TStoredParentView>
     SubView(TStoredParentView&&, typename std::remove_reference_t<TStoredParentView>::Mapping::ArrayExtents::Index)
         -> SubView<TStoredParentView>;

--- a/include/llama/macros.hpp
+++ b/include/llama/macros.hpp
@@ -186,6 +186,12 @@
 #    define LLAMA_CONSTEVAL constexpr
 #endif
 
+#ifndef LLAMA_EXPORT
+/// Annotation of all LLAMA public APIs. Expands to nothing by default. Can be defined to 'export' when building LLAMA
+/// as a C++20 module.
+#    define LLAMA_EXPORT
+#endif
+
 // TODO(bgruber): clang 10-15 (libstdc++ from gcc 11.2 or gcc 12.1) fail to compile this currently with the issue
 // described here:
 // https://stackoverflow.com/questions/64300832/why-does-clang-think-gccs-subrange-does-not-satisfy-gccs-ranges-begin-functi

--- a/include/llama/mapping/AoS.hpp
+++ b/include/llama/mapping/AoS.hpp
@@ -15,6 +15,7 @@ namespace llama::mapping
     /// \tparam PermuteFields Defines how the record dimension's fields should be permuted. See \ref
     /// PermuteFieldsInOrder, \ref PermuteFieldsIncreasingAlignment, \ref PermuteFieldsDecreasingAlignment and
     /// \ref PermuteFieldsMinimizePadding.
+    LLAMA_EXPORT
     template<
         typename TArrayExtents,
         typename TRecordDim,
@@ -64,16 +65,19 @@ namespace llama::mapping
     };
 
     // we can drop this when inherited ctors also inherit deduction guides
+    LLAMA_EXPORT
     template<typename TArrayExtents, typename TRecordDim>
     AoS(TArrayExtents, TRecordDim) -> AoS<TArrayExtents, TRecordDim>;
 
     /// Array of struct mapping preserving the alignment of the field types by inserting padding.
     /// \see AoS
+    LLAMA_EXPORT
     template<typename ArrayExtents, typename RecordDim, typename LinearizeArrayIndexFunctor = LinearizeArrayIndexRight>
     using AlignedAoS = AoS<ArrayExtents, RecordDim, FieldAlignment::Align, LinearizeArrayIndexFunctor>;
 
     /// Array of struct mapping preserving the alignment of the field types by inserting padding and permuting the
     /// field order to minimize this padding. \see AoS
+    LLAMA_EXPORT
     template<typename ArrayExtents, typename RecordDim, typename LinearizeArrayIndexFunctor = LinearizeArrayIndexRight>
     using MinAlignedAoS = AoS<
         ArrayExtents,
@@ -84,11 +88,13 @@ namespace llama::mapping
 
     /// Array of struct mapping packing the field types tightly, violating the type's alignment requirements.
     /// \see AoS
+    LLAMA_EXPORT
     template<typename ArrayExtents, typename RecordDim, typename LinearizeArrayIndexFunctor = LinearizeArrayIndexRight>
     using PackedAoS = AoS<ArrayExtents, RecordDim, FieldAlignment::Pack, LinearizeArrayIndexFunctor>;
 
     /// Binds parameters to an \ref AoS mapping except for array and record dimension, producing a quoted meta
     /// function accepting the latter two. Useful to to prepare this mapping for a meta mapping.
+    LLAMA_EXPORT
     template<
         FieldAlignment Alignment = FieldAlignment::Align,
         typename LinearizeArrayIndexFunctor = LinearizeArrayIndexRight>
@@ -98,9 +104,11 @@ namespace llama::mapping
         using fn = AoS<ArrayExtents, RecordDim, Alignment, LinearizeArrayIndexFunctor>;
     };
 
+    LLAMA_EXPORT
     template<typename Mapping>
     inline constexpr bool isAoS = false;
 
+    LLAMA_EXPORT
     template<
         typename ArrayExtents,
         typename RecordDim,

--- a/include/llama/mapping/AoSoA.hpp
+++ b/include/llama/mapping/AoSoA.hpp
@@ -11,6 +11,7 @@ namespace llama::mapping
 {
     /// The maximum number of vector lanes that can be used to fetch each leaf type in the record dimension into a
     /// vector register of the given size in bits.
+    LLAMA_EXPORT
     template<typename RecordDim, std::size_t VectorRegisterBits>
     inline constexpr std::size_t maxLanes = []() constexpr
     {
@@ -29,6 +30,7 @@ namespace llama::mapping
     /// \tparam PermuteFields Defines how the record dimension's fields should be permuted. See \ref
     /// PermuteFieldsInOrder, \ref PermuteFieldsIncreasingAlignment, \ref PermuteFieldsDecreasingAlignment and
     /// \ref PermuteFieldsMinimizePadding.
+    LLAMA_EXPORT
     template<
         typename TArrayExtents,
         typename TRecordDim,
@@ -85,6 +87,7 @@ namespace llama::mapping
 
     /// Binds parameters to an \ref AoSoA mapping except for array and record dimension, producing a quoted meta
     /// function accepting the latter two. Useful to to prepare this mapping for a meta mapping.
+    LLAMA_EXPORT
     template<std::size_t Lanes, typename LinearizeArrayIndexFunctor = LinearizeArrayIndexRight>
     struct BindAoSoA
     {
@@ -92,10 +95,11 @@ namespace llama::mapping
         using fn = AoSoA<ArrayExtents, RecordDim, Lanes, LinearizeArrayIndexFunctor>;
     };
 
+    LLAMA_EXPORT
     template<typename Mapping>
     inline constexpr bool isAoSoA = false;
 
+    LLAMA_EXPORT
     template<typename AD, typename RD, typename AD::value_type L>
     inline constexpr bool isAoSoA<AoSoA<AD, RD, L>> = true;
-
 } // namespace llama::mapping

--- a/include/llama/mapping/BitPackedFloat.hpp
+++ b/include/llama/mapping/BitPackedFloat.hpp
@@ -196,6 +196,7 @@ namespace llama::mapping
     /// \tparam TLinearizeArrayIndexFunctor Defines how the array dimensions should be mapped into linear numbers and
     /// how big the linear domain gets.
     /// \tparam TStoredIntegral Integral type used as storage of reduced precision floating-point values.
+    LLAMA_EXPORT
     template<
         typename TArrayExtents,
         typename TRecordDim,
@@ -283,6 +284,7 @@ namespace llama::mapping
 
     /// Binds parameters to a \ref BitPackedFloatSoA mapping except for array and record dimension, producing a quoted
     /// meta function accepting the latter two. Useful to to prepare this mapping for a meta mapping.
+    LLAMA_EXPORT
     template<
         typename ExponentBits = unsigned,
         typename MantissaBits = ExponentBits,
@@ -303,12 +305,15 @@ namespace llama::mapping
                 internal::StoredIntegralFor<RecordDim>>>;
     };
 
+    LLAMA_EXPORT
     template<typename Mapping>
     inline constexpr bool isBitPackedFloatSoA = false;
 
+    LLAMA_EXPORT
     template<typename... Ts>
     inline constexpr bool isBitPackedFloatSoA<BitPackedFloatSoA<Ts...>> = true;
 
+    LLAMA_EXPORT
     template<
         typename TArrayExtents,
         typename TRecordDim,
@@ -401,6 +406,7 @@ namespace llama::mapping
         }
     };
 
+    LLAMA_EXPORT
     template<
         typename ExponentBits = unsigned,
         typename MantissaBits = ExponentBits,
@@ -423,9 +429,11 @@ namespace llama::mapping
                 internal::StoredIntegralFor<RecordDim>>>;
     };
 
+    LLAMA_EXPORT
     template<typename Mapping>
     inline constexpr bool isBitPackedFloatAoS = false;
 
+    LLAMA_EXPORT
     template<
         typename ArrayExtents,
         typename RecordDim,

--- a/include/llama/mapping/BitPackedInt.hpp
+++ b/include/llama/mapping/BitPackedInt.hpp
@@ -12,6 +12,7 @@
 
 namespace llama::mapping
 {
+    LLAMA_EXPORT
     enum class SignBit
     {
         Keep,
@@ -354,6 +355,7 @@ namespace llama::mapping
     /// how big the linear domain gets.
     /// \tparam TStoredIntegral Integral type used as storage of reduced precision integers. Must be std::uint32_t or
     /// std::uint64_t.
+    LLAMA_EXPORT
     template<
         typename TArrayExtents,
         typename TRecordDim,
@@ -411,6 +413,7 @@ namespace llama::mapping
 
     /// Binds parameters to a \ref BitPackedIntSoA mapping except for array and record dimension, producing a quoted
     /// meta function accepting the latter two. Useful to to prepare this mapping for a meta mapping.
+    LLAMA_EXPORT
     template<
         typename Bits = void,
         SignBit SignBit = SignBit::Keep,
@@ -431,9 +434,11 @@ namespace llama::mapping
                 internal::StoredUnsignedFor<RecordDim>>>;
     };
 
+    LLAMA_EXPORT
     template<typename Mapping>
     inline constexpr bool isBitPackedIntSoA = false;
 
+    LLAMA_EXPORT
     template<
         typename ArrayExtents,
         typename RecordDim,
@@ -459,6 +464,7 @@ namespace llama::mapping
     //  \ref PermuteFieldsMinimizePadding.
     /// \tparam TStoredIntegral Integral type used as storage of reduced precision integers. Must be std::uint32_t or
     /// std::uint64_t.
+    LLAMA_EXPORT
     template<
         typename TArrayExtents,
         typename TRecordDim,
@@ -523,6 +529,7 @@ namespace llama::mapping
 
     /// Binds parameters to a \ref BitPackedIntAoS mapping except for array and record dimension, producing a quoted
     /// meta function accepting the latter two. Useful to to prepare this mapping for a meta mapping.
+    LLAMA_EXPORT
     template<
         typename Bits = void,
         SignBit SignBit = SignBit::Keep,
@@ -545,6 +552,7 @@ namespace llama::mapping
                 internal::StoredUnsignedFor<RecordDim>>>;
     };
 
+    LLAMA_EXPORT
     template<typename Mapping>
     inline constexpr bool isBitPackedIntAoS = false;
 

--- a/include/llama/mapping/Bytesplit.hpp
+++ b/include/llama/mapping/Bytesplit.hpp
@@ -19,6 +19,7 @@ namespace llama::mapping
 
     /// Meta mapping splitting each field in the record dimension into an array of bytes and mapping the resulting
     /// record dimension using a further mapping.
+    LLAMA_EXPORT
     template<typename TArrayExtents, typename TRecordDim, template<typename, typename> typename InnerMapping>
     struct Bytesplit : private InnerMapping<TArrayExtents, internal::SplitBytes<TRecordDim>>
     {
@@ -131,6 +132,7 @@ namespace llama::mapping
 
     /// Binds parameters to a \ref Bytesplit mapping except for array and record dimension, producing a quoted
     /// meta function accepting the latter two. Useful to to prepare this mapping for a meta mapping.
+    LLAMA_EXPORT
     template<template<typename, typename> typename InnerMapping>
     struct BindBytesplit
     {
@@ -138,9 +140,11 @@ namespace llama::mapping
         using fn = Bytesplit<ArrayExtents, RecordDim, InnerMapping>;
     };
 
+    LLAMA_EXPORT
     template<typename Mapping>
     inline constexpr bool isBytesplit = false;
 
+    LLAMA_EXPORT
     template<typename TArrayExtents, typename TRecordDim, template<typename, typename> typename InnerMapping>
     inline constexpr bool isBytesplit<Bytesplit<TArrayExtents, TRecordDim, InnerMapping>> = true;
 } // namespace llama::mapping

--- a/include/llama/mapping/Byteswap.hpp
+++ b/include/llama/mapping/Byteswap.hpp
@@ -59,6 +59,7 @@ namespace llama::mapping
     } // namespace internal
 
     /// Mapping that swaps the byte order of all values when loading/storing.
+    LLAMA_EXPORT
     template<typename ArrayExtents, typename RecordDim, template<typename, typename> typename InnerMapping>
     struct Byteswap : Projection<ArrayExtents, RecordDim, InnerMapping, internal::MakeByteswapProjectionMap<RecordDim>>
     {
@@ -71,6 +72,7 @@ namespace llama::mapping
 
     /// Binds parameters to a \ref ChangeType mapping except for array and record dimension, producing a quoted
     /// meta function accepting the latter two. Useful to to prepare this mapping for a meta mapping.
+    LLAMA_EXPORT
     template<template<typename, typename> typename InnerMapping>
     struct BindByteswap
     {
@@ -78,9 +80,11 @@ namespace llama::mapping
         using fn = Byteswap<ArrayExtents, RecordDim, InnerMapping>;
     };
 
+    LLAMA_EXPORT
     template<typename Mapping>
     inline constexpr bool isByteswap = false;
 
+    LLAMA_EXPORT
     template<typename TArrayExtents, typename TRecordDim, template<typename, typename> typename InnerMapping>
     inline constexpr bool isByteswap<Byteswap<TArrayExtents, TRecordDim, InnerMapping>> = true;
 } // namespace llama::mapping

--- a/include/llama/mapping/ChangeType.hpp
+++ b/include/llama/mapping/ChangeType.hpp
@@ -49,6 +49,7 @@ namespace llama::mapping
     /// load and store.
     /// @tparam ReplacementMap A type list of binary type lists (a map) specifiying which type or the type at a \ref
     /// RecordCoord (map key) to replace by which other type (mapped value).
+    LLAMA_EXPORT
     template<
         typename ArrayExtents,
         typename RecordDim,
@@ -71,6 +72,7 @@ namespace llama::mapping
 
     /// Binds parameters to a \ref ChangeType mapping except for array and record dimension, producing a quoted
     /// meta function accepting the latter two. Useful to to prepare this mapping for a meta mapping.
+    LLAMA_EXPORT
     template<template<typename, typename> typename InnerMapping, typename ReplacementMap>
     struct BindChangeType
     {
@@ -78,9 +80,11 @@ namespace llama::mapping
         using fn = ChangeType<ArrayExtents, RecordDim, InnerMapping, ReplacementMap>;
     };
 
+    LLAMA_EXPORT
     template<typename Mapping>
     inline constexpr bool isChangeType = false;
 
+    LLAMA_EXPORT
     template<
         typename TArrayExtents,
         typename TRecordDim,

--- a/include/llama/mapping/Common.hpp
+++ b/include/llama/mapping/Common.hpp
@@ -13,6 +13,7 @@
 
 namespace llama::mapping
 {
+    LLAMA_EXPORT
     template<typename TArrayExtents, typename TRecordDim>
     struct MappingBase : protected TArrayExtents
     {
@@ -40,6 +41,7 @@ namespace llama::mapping
     /// Functor that maps an \ref ArrayIndex into linear numbers, where the fast moving index should be the rightmost
     /// one, which models how C++ arrays work and is analogous to mdspan's layout_right. E.g. ArrayIndex<3> a; stores 3
     /// indices where a[2] should be incremented in the innermost loop.
+    LLAMA_EXPORT
     struct LinearizeArrayIndexRight
     {
         template<typename ArrayExtents>
@@ -71,11 +73,13 @@ namespace llama::mapping
         }
     };
 
+    LLAMA_EXPORT
     using LinearizeArrayIndexCpp = LinearizeArrayIndexRight;
 
     /// Functor that maps a \ref ArrayIndex into linear numbers the way Fortran arrays work. The fast moving index of
     /// the ArrayIndex object should be the last one. E.g. ArrayIndex<3> a; stores 3 indices where a[0] should be
     /// incremented in the innermost loop.
+    LLAMA_EXPORT
     struct LinearizeArrayIndexLeft
     {
         template<typename ArrayExtents>
@@ -107,9 +111,11 @@ namespace llama::mapping
         }
     };
 
+    LLAMA_EXPORT
     using LinearizeArrayIndexFortran = LinearizeArrayIndexLeft;
 
     /// Functor that maps an \ref ArrayIndex into linear numbers using the Z-order space filling curve (Morton codes).
+    LLAMA_EXPORT
     struct LinearizeArrayIndexMorton
     {
         template<typename ArrayExtents>
@@ -170,6 +176,7 @@ namespace llama::mapping
     };
 
     /// Retains the order of the record dimension's fields.
+    LLAMA_EXPORT
     template<typename TFlatRecordDim>
     struct PermuteFieldsInOrder
     {
@@ -182,6 +189,7 @@ namespace llama::mapping
     /// Sorts the record dimension's the fields according to a given predicate on the field types.
     /// @tparam Less A binary predicate accepting two field types, which exposes a member value. Value must be true if
     /// the first field type is less than the second one, otherwise false.
+    LLAMA_EXPORT
     template<typename FlatOrigRecordDim, template<typename, typename> typename Less>
     struct PermuteFieldsSorted
     {
@@ -218,14 +226,17 @@ namespace llama::mapping
     } // namespace internal
 
     /// Sorts the record dimension fields by increasing alignment of its fields.
+    LLAMA_EXPORT
     template<typename FlatRecordDim>
     using PermuteFieldsIncreasingAlignment = PermuteFieldsSorted<FlatRecordDim, internal::LessAlignment>;
 
     /// Sorts the record dimension fields by decreasing alignment of its fields.
+    LLAMA_EXPORT
     template<typename FlatRecordDim>
     using PermuteFieldsDecreasingAlignment = PermuteFieldsSorted<FlatRecordDim, internal::MoreAlignment>;
 
     /// Sorts the record dimension fields by the alignment of its fields to minimize padding.
+    LLAMA_EXPORT
     template<typename FlatRecordDim>
     using PermuteFieldsMinimizePadding = PermuteFieldsIncreasingAlignment<FlatRecordDim>;
 
@@ -256,7 +267,7 @@ namespace llama::mapping
         }
     } // namespace internal
 
-
+    LLAMA_EXPORT
     enum class FieldAlignment
     {
         Pack,

--- a/include/llama/mapping/FieldAccessCount.hpp
+++ b/include/llama/mapping/FieldAccessCount.hpp
@@ -12,6 +12,7 @@
 
 namespace llama::mapping
 {
+    LLAMA_EXPORT
     template<typename CountType>
     struct AccessCounts
     {
@@ -79,6 +80,7 @@ namespace llama::mapping
     /// @tparam TCountType The type used for counting the number of accesses.
     /// @tparam MyCodeHandlesProxyReferences If false, FieldAccessCount will avoid proxy references but can then only
     /// count the number of address computations
+    LLAMA_EXPORT
     template<typename Mapping, typename TCountType = std::size_t, bool MyCodeHandlesProxyReferences = true>
     struct FieldAccessCount : Mapping
     {
@@ -363,9 +365,11 @@ namespace llama::mapping
         }
     };
 
+    LLAMA_EXPORT
     template<typename Mapping>
     inline constexpr bool isFieldAccessCount = false;
 
+    LLAMA_EXPORT
     template<typename Mapping, typename CountType, bool MyCodeHandlesProxyReferences>
     inline constexpr bool isFieldAccessCount<FieldAccessCount<Mapping, CountType, MyCodeHandlesProxyReferences>>
         = true;

--- a/include/llama/mapping/Heatmap.hpp
+++ b/include/llama/mapping/Heatmap.hpp
@@ -23,6 +23,7 @@ namespace llama::mapping
     /// individually. A value of e.g. 64, counts accesses per 64 byte block.
     /// @tparam TCountType Data type used to count the number of accesses. Atomic increments must be supported for this
     /// type.
+    LLAMA_EXPORT
     template<
         typename Mapping,
         typename Mapping::ArrayExtents::value_type Granularity = 1,
@@ -222,9 +223,11 @@ EOF
 )";
     };
 
+    LLAMA_EXPORT
     template<typename Mapping>
     inline constexpr bool isHeatmap = false;
 
+    LLAMA_EXPORT
     template<typename Mapping, typename Mapping::ArrayExtents::value_type Granularity, typename CountType>
     inline constexpr bool isHeatmap<Heatmap<Mapping, Granularity, CountType>> = true;
 } // namespace llama::mapping

--- a/include/llama/mapping/Null.hpp
+++ b/include/llama/mapping/Null.hpp
@@ -29,6 +29,7 @@ namespace llama::mapping
 
     /// The Null mappings maps all elements to nothing. Writing data through a reference obtained from the Null mapping
     /// discards the value. Reading through such a reference returns a default constructed object.
+    LLAMA_EXPORT
     template<typename TArrayExtents, typename TRecordDim>
     struct Null : MappingBase<TArrayExtents, TRecordDim>
     {
@@ -64,9 +65,11 @@ namespace llama::mapping
         }
     };
 
+    LLAMA_EXPORT
     template<typename Mapping>
     inline constexpr bool isNull = false;
 
+    LLAMA_EXPORT
     template<typename ArrayExtents, typename RecordDim>
     inline constexpr bool isNull<Null<ArrayExtents, RecordDim>> = true;
 } // namespace llama::mapping

--- a/include/llama/mapping/One.hpp
+++ b/include/llama/mapping/One.hpp
@@ -15,6 +15,7 @@ namespace llama::mapping
     /// \tparam PermuteFields Defines how the record dimension's fields should be permuted. See \ref
     /// PermuteFieldsInOrder, \ref PermuteFieldsIncreasingAlignment, \ref PermuteFieldsDecreasingAlignment and
     /// \ref PermuteFieldsMinimizePadding.
+    LLAMA_EXPORT
     template<
         typename TArrayExtents,
         typename TRecordDim,
@@ -69,22 +70,26 @@ namespace llama::mapping
 
     /// One mapping preserving the alignment of the field types by inserting padding.
     /// \see One
+    LLAMA_EXPORT
     template<typename ArrayExtents, typename RecordDim>
     using AlignedOne = One<ArrayExtents, RecordDim, FieldAlignment::Align, PermuteFieldsInOrder>;
 
     /// One mapping preserving the alignment of the field types by inserting padding and permuting the field order to
     /// minimize this padding.
     /// \see One
+    LLAMA_EXPORT
     template<typename ArrayExtents, typename RecordDim>
     using MinAlignedOne = One<ArrayExtents, RecordDim, FieldAlignment::Align, PermuteFieldsMinimizePadding>;
 
     /// One mapping packing the field types tightly, violating the types' alignment requirements.
     /// \see One
+    LLAMA_EXPORT
     template<typename ArrayExtents, typename RecordDim>
     using PackedOne = One<ArrayExtents, RecordDim, FieldAlignment::Pack, PermuteFieldsInOrder>;
 
     /// Binds parameters to a \ref One mapping except for array and record dimension, producing a quoted
     /// meta function accepting the latter two. Useful to to prepare this mapping for a meta mapping.
+    LLAMA_EXPORT
     template<
         FieldAlignment FieldAlignment = FieldAlignment::Align,
         template<typename> typename PermuteFields = PermuteFieldsMinimizePadding>
@@ -94,9 +99,11 @@ namespace llama::mapping
         using fn = One<ArrayExtents, RecordDim, FieldAlignment, PermuteFields>;
     };
 
+    LLAMA_EXPORT
     template<typename Mapping>
     inline constexpr bool isOne = false;
 
+    LLAMA_EXPORT
     template<
         typename ArrayExtents,
         typename RecordDim,

--- a/include/llama/mapping/PermuteArrayIndex.hpp
+++ b/include/llama/mapping/PermuteArrayIndex.hpp
@@ -11,6 +11,7 @@ namespace llama::mapping
     /// changed.
     /// @tparam Permutation The pack of integrals describing the permutation of the array indices. The inner mapping
     /// will be called with an ArrayIndex{ai[Permutation]...}.
+    LLAMA_EXPORT
     template<typename Mapping, std::size_t... Permutation>
     struct PermuteArrayIndex : Mapping
     {
@@ -53,12 +54,15 @@ namespace llama::mapping
         }
     };
 
+    LLAMA_EXPORT
     template<typename Mapping>
     PermuteArrayIndex(Mapping) -> PermuteArrayIndex<Mapping>;
 
+    LLAMA_EXPORT
     template<typename Mapping>
     inline constexpr bool isPermuteArrayIndex = false;
 
+    LLAMA_EXPORT
     template<typename Mapping, std::size_t... Permutation>
     inline constexpr bool isPermuteArrayIndex<PermuteArrayIndex<Mapping, Permutation...>> = true;
 } // namespace llama::mapping

--- a/include/llama/mapping/Projection.hpp
+++ b/include/llama/mapping/Projection.hpp
@@ -121,6 +121,7 @@ namespace llama::mapping
     ///   static auto load(auto&& fromMem);
     ///   static auto store(auto&& toMem);
     /// };
+    LLAMA_EXPORT
     template<
         typename TArrayExtents,
         typename TRecordDim,
@@ -180,6 +181,7 @@ namespace llama::mapping
 
     /// Binds parameters to a \ref Projection mapping except for array and record dimension, producing a quoted
     /// meta function accepting the latter two. Useful to to prepare this mapping for a meta mapping.
+    LLAMA_EXPORT
     template<template<typename, typename> typename InnerMapping, typename ProjectionMap>
     struct BindProjection
     {
@@ -187,9 +189,11 @@ namespace llama::mapping
         using fn = Projection<ArrayExtents, RecordDim, InnerMapping, ProjectionMap>;
     };
 
+    LLAMA_EXPORT
     template<typename Mapping>
     inline constexpr bool isProjection = false;
 
+    LLAMA_EXPORT
     template<
         typename TArrayExtents,
         typename TRecordDim,

--- a/include/llama/mapping/SoA.hpp
+++ b/include/llama/mapping/SoA.hpp
@@ -9,12 +9,14 @@
 
 namespace llama::mapping
 {
+    LLAMA_EXPORT
     enum class Blobs
     {
         Single,
         OnePerField
     };
 
+    LLAMA_EXPORT
     enum class SubArrayAlignment
     {
         Pack,
@@ -32,6 +34,7 @@ namespace llama::mapping
     /// \tparam PermuteFieldsSingleBlob Defines how the record dimension's fields should be permuted if Blobs is
     /// Single. See \ref PermuteFieldsInOrder, \ref PermuteFieldsIncreasingAlignment, \ref
     /// PermuteFieldsDecreasingAlignment and \ref PermuteFieldsMinimizePadding.
+    LLAMA_EXPORT
     template<
         typename TArrayExtents,
         typename TRecordDim,
@@ -179,29 +182,34 @@ namespace llama::mapping
     };
 
     // we can drop this when inherited ctors also inherit deduction guides
+    LLAMA_EXPORT
     template<typename TArrayExtents, typename TRecordDim>
     SoA(TArrayExtents, TRecordDim) -> SoA<TArrayExtents, TRecordDim>;
 
     /// Struct of array mapping storing the entire layout in a single blob. The starts of the sub arrays are aligned by
     /// inserting padding. \see SoA
+    LLAMA_EXPORT
     template<typename ArrayExtents, typename RecordDim, typename LinearizeArrayIndexFunctor = LinearizeArrayIndexRight>
     using AlignedSingleBlobSoA
         = SoA<ArrayExtents, RecordDim, Blobs::Single, SubArrayAlignment::Align, LinearizeArrayIndexFunctor>;
 
     /// Struct of array mapping storing the entire layout in a single blob. The sub arrays are tightly packed,
     /// violating the type's alignment requirements. \see SoA
+    LLAMA_EXPORT
     template<typename ArrayExtents, typename RecordDim, typename LinearizeArrayIndexFunctor = LinearizeArrayIndexRight>
     using PackedSingleBlobSoA
         = SoA<ArrayExtents, RecordDim, Blobs::Single, SubArrayAlignment::Pack, LinearizeArrayIndexFunctor>;
 
     /// Struct of array mapping storing each attribute of the record dimension in a separate blob.
     /// \see SoA
+    LLAMA_EXPORT
     template<typename ArrayExtents, typename RecordDim, typename LinearizeArrayIndexFunctor = LinearizeArrayIndexRight>
     using MultiBlobSoA
         = SoA<ArrayExtents, RecordDim, Blobs::OnePerField, SubArrayAlignment::Pack, LinearizeArrayIndexFunctor>;
 
     /// Binds parameters to an \ref SoA mapping except for array and record dimension, producing a quoted
     /// meta function accepting the latter two. Useful to to prepare this mapping for a meta mapping.
+    LLAMA_EXPORT
     template<
         Blobs Blobs = Blobs::OnePerField,
         SubArrayAlignment SubArrayAlignment = SubArrayAlignment::Pack,
@@ -212,9 +220,11 @@ namespace llama::mapping
         using fn = SoA<ArrayExtents, RecordDim, Blobs, SubArrayAlignment, LinearizeArrayIndexFunctor>;
     };
 
+    LLAMA_EXPORT
     template<typename Mapping>
     inline constexpr bool isSoA = false;
 
+    LLAMA_EXPORT
     template<
         typename ArrayExtents,
         typename RecordDim,

--- a/include/llama/mapping/Split.hpp
+++ b/include/llama/mapping/Split.hpp
@@ -94,6 +94,7 @@ namespace llama::mapping
     /// \tparam MappingTemplate1 The mapping used for the selected part of the record dimension.
     /// \tparam MappingTemplate2 The mapping used for the not selected part of the record dimension.
     /// \tparam SeparateBlobs If true, both pieces of the record dimension are mapped to separate blobs.
+    LLAMA_EXPORT
     template<
         typename TArrayExtents,
         typename TRecordDim,
@@ -222,6 +223,7 @@ namespace llama::mapping
 
     /// Binds parameters to a \ref Split mapping except for array and record dimension, producing a quoted
     /// meta function accepting the latter two. Useful to to prepare this mapping for a meta mapping.
+    LLAMA_EXPORT
     template<
         typename SelectorForMapping1,
         template<typename...>
@@ -236,9 +238,11 @@ namespace llama::mapping
             = Split<ArrayExtents, RecordDim, SelectorForMapping1, MappingTemplate1, MappingTemplate2, SeparateBlobs>;
     };
 
+    LLAMA_EXPORT
     template<typename Mapping>
     inline constexpr bool isSplit = false;
 
+    LLAMA_EXPORT
     template<
         typename ArrayExtents,
         typename RecordDim,


### PR DESCRIPTION
This prepares LLAMA to be built as a C++20 module.