### PR TITLE
Allow SubView to default construct inner view

### DIFF
--- a/include/llama/View.hpp
+++ b/include/llama/View.hpp
@@ -741,6 +741,11 @@ namespace llama
         using size_type = typename ArrayExtents::value_type;
 
     public:
+        /// Creates a SubView given an offset. The parent view is default constructed.
+        LLAMA_FN_HOST_ACC_INLINE explicit SubView(ArrayIndex offset) : offset(offset)
+        {
+        }
+
         /// Creates a SubView given a parent \ref View and offset.
         template<typename StoredParentViewFwd>
         LLAMA_FN_HOST_ACC_INLINE SubView(StoredParentViewFwd&& parentView, ArrayIndex offset)


### PR DESCRIPTION
This covers a use case in the (non-public) SPEC CPU lbm.