### PR TITLE
Refactor AoSoA<->SoA copy implementations

### DIFF
--- a/include/llama/Copy.hpp
+++ b/include/llama/Copy.hpp
@@ -346,40 +346,19 @@ namespace llama
         typename RecordDim,
         typename LinearizeArrayIndex,
         std::size_t LanesSrc,
-        std::size_t LanesDst>
+        std::size_t LanesDst,
+        template<typename>
+        typename PermuteFields>
     struct Copy<
-        mapping::AoSoA<ArrayExtents, RecordDim, LanesSrc, LinearizeArrayIndex>,
-        mapping::AoSoA<ArrayExtents, RecordDim, LanesDst, LinearizeArrayIndex>,
+        mapping::AoSoA<ArrayExtents, RecordDim, LanesSrc, LinearizeArrayIndex, PermuteFields>,
+        mapping::AoSoA<ArrayExtents, RecordDim, LanesDst, LinearizeArrayIndex, PermuteFields>,
         std::enable_if_t<LanesSrc != LanesDst>>
     {
         template<typename SrcBlob, typename DstBlob>
         void operator()(
-            const View<mapping::AoSoA<ArrayExtents, RecordDim, LanesSrc, LinearizeArrayIndex>, SrcBlob>& srcView,
-            View<mapping::AoSoA<ArrayExtents, RecordDim, LanesDst, LinearizeArrayIndex>, DstBlob>& dstView,
-            std::size_t threadId,
-            std::size_t threadCount)
-        {
-            constexpr auto readOpt = true; // TODO(bgruber): how to choose?
-            aosoaCommonBlockCopy(srcView, dstView, readOpt, threadId, threadCount);
-        }
-    };
-
-    LLAMA_EXPORT
-    template<
-        typename ArrayExtents,
-        typename RecordDim,
-        typename LinearizeArrayIndex,
-        std::size_t LanesSrc,
-        mapping::Blobs DstBlobs,
-        mapping::SubArrayAlignment DstSubArrayAlignment>
-    struct Copy<
-        mapping::AoSoA<ArrayExtents, RecordDim, LanesSrc, LinearizeArrayIndex>,
-        mapping::SoA<ArrayExtents, RecordDim, DstBlobs, DstSubArrayAlignment, LinearizeArrayIndex>>
-    {
-        template<typename SrcBlob, typename DstBlob>
-        void operator()(
-            const View<mapping::AoSoA<ArrayExtents, RecordDim, LanesSrc, LinearizeArrayIndex>, SrcBlob>& srcView,
-            View<mapping::SoA<ArrayExtents, RecordDim, DstBlobs, DstSubArrayAlignment, LinearizeArrayIndex>, DstBlob>&
+            const View<mapping::AoSoA<ArrayExtents, RecordDim, LanesSrc, LinearizeArrayIndex, PermuteFields>, SrcBlob>&
+                srcView,
+            View<mapping::AoSoA<ArrayExtents, RecordDim, LanesDst, LinearizeArrayIndex, PermuteFields>, DstBlob>&
                 dstView,
             std::size_t threadId,
             std::size_t threadCount)
@@ -394,19 +373,53 @@ namespace llama
         typename ArrayExtents,
         typename RecordDim,
         typename LinearizeArrayIndex,
+        template<typename>
+        typename PermuteFields,
+        std::size_t LanesSrc,
+        mapping::Blobs DstBlobs,
+        mapping::SubArrayAlignment DstSubArrayAlignment>
+    struct Copy<
+        mapping::AoSoA<ArrayExtents, RecordDim, LanesSrc, LinearizeArrayIndex, PermuteFields>,
+        mapping::SoA<ArrayExtents, RecordDim, DstBlobs, DstSubArrayAlignment, LinearizeArrayIndex, PermuteFields>>
+    {
+        template<typename SrcBlob, typename DstBlob>
+        void operator()(
+            const View<mapping::AoSoA<ArrayExtents, RecordDim, LanesSrc, LinearizeArrayIndex, PermuteFields>, SrcBlob>&
+                srcView,
+            View<
+                mapping::
+                    SoA<ArrayExtents, RecordDim, DstBlobs, DstSubArrayAlignment, LinearizeArrayIndex, PermuteFields>,
+                DstBlob>& dstView,
+            std::size_t threadId,
+            std::size_t threadCount)
+        {
+            constexpr auto readOpt = true; // TODO(bgruber): how to choose?
+            aosoaCommonBlockCopy(srcView, dstView, readOpt, threadId, threadCount);
+        }
+    };
+
+    LLAMA_EXPORT
+    template<
+        typename ArrayExtents,
+        typename RecordDim,
+        typename LinearizeArrayIndex,
+        template<typename>
+        typename PermuteFields,
         std::size_t LanesDst,
         mapping::Blobs SrcBlobs,
         mapping::SubArrayAlignment SrcSubArrayAlignment>
     struct Copy<
-        mapping::SoA<ArrayExtents, RecordDim, SrcBlobs, SrcSubArrayAlignment, LinearizeArrayIndex>,
-        mapping::AoSoA<ArrayExtents, RecordDim, LanesDst, LinearizeArrayIndex>>
+        mapping::SoA<ArrayExtents, RecordDim, SrcBlobs, SrcSubArrayAlignment, LinearizeArrayIndex, PermuteFields>,
+        mapping::AoSoA<ArrayExtents, RecordDim, LanesDst, LinearizeArrayIndex, PermuteFields>>
     {
         template<typename SrcBlob, typename DstBlob>
         void operator()(
             const View<
-                mapping::SoA<ArrayExtents, RecordDim, SrcBlobs, SrcSubArrayAlignment, LinearizeArrayIndex>,
+                mapping::
+                    SoA<ArrayExtents, RecordDim, SrcBlobs, SrcSubArrayAlignment, LinearizeArrayIndex, PermuteFields>,
                 SrcBlob>& srcView,
-            View<mapping::AoSoA<ArrayExtents, RecordDim, LanesDst, LinearizeArrayIndex>, DstBlob>& dstView,
+            View<mapping::AoSoA<ArrayExtents, RecordDim, LanesDst, LinearizeArrayIndex, PermuteFields>, DstBlob>&
+                dstView,
             std::size_t threadId,
             std::size_t threadCount)
         {

--- a/include/llama/mapping/AoS.hpp
+++ b/include/llama/mapping/AoS.hpp
@@ -8,8 +8,8 @@
 namespace llama::mapping
 {
     /// Array of struct mapping. Used to create a \ref View via \ref allocView.
-    /// \tparam Alignment If Align, padding bytes are inserted to guarantee that struct members are properly aligned.
-    /// If Pack, struct members are tightly packed.
+    /// \tparam TFieldAlignment If Align, padding bytes are inserted to guarantee that struct members are properly
+    /// aligned. If Pack, struct members are tightly packed.
     /// \tparam TLinearizeArrayIndexFunctor Defines how the array dimensions should be mapped into linear numbers and
     /// how big the linear domain gets.
     /// \tparam PermuteFields Defines how the record dimension's fields should be permuted. See \ref

--- a/include/llama/mapping/AoSoA.hpp
+++ b/include/llama/mapping/AoSoA.hpp
@@ -88,11 +88,14 @@ namespace llama::mapping
     /// Binds parameters to an \ref AoSoA mapping except for array and record dimension, producing a quoted meta
     /// function accepting the latter two. Useful to to prepare this mapping for a meta mapping.
     LLAMA_EXPORT
-    template<std::size_t Lanes, typename LinearizeArrayIndexFunctor = LinearizeArrayIndexRight>
+    template<
+        std::size_t Lanes,
+        typename LinearizeArrayIndexFunctor = LinearizeArrayIndexRight,
+        template<typename> typename PermuteFields = PermuteFieldsInOrder>
     struct BindAoSoA
     {
         template<typename ArrayExtents, typename RecordDim>
-        using fn = AoSoA<ArrayExtents, RecordDim, Lanes, LinearizeArrayIndexFunctor>;
+        using fn = AoSoA<ArrayExtents, RecordDim, Lanes, LinearizeArrayIndexFunctor, PermuteFields>;
     };
 
     LLAMA_EXPORT
@@ -100,6 +103,6 @@ namespace llama::mapping
     inline constexpr bool isAoSoA = false;
 
     LLAMA_EXPORT
-    template<typename AD, typename RD, typename AD::value_type L>
-    inline constexpr bool isAoSoA<AoSoA<AD, RD, L>> = true;
+    template<typename AD, typename RD, typename AD::value_type L, typename Lin, template<typename> typename Perm>
+    inline constexpr bool isAoSoA<AoSoA<AD, RD, L, Lin, Perm>> = true;
 } // namespace llama::mapping

--- a/include/llama/mapping/AoSoA.hpp
+++ b/include/llama/mapping/AoSoA.hpp
@@ -68,6 +68,15 @@ namespace llama::mapping
         template<std::size_t... RecordCoords>
         LLAMA_FN_HOST_ACC_INLINE constexpr auto blobNrAndOffset(
             typename Base::ArrayIndex ai,
+            RecordCoord<RecordCoords...> rc = {}) const -> NrAndOffset<size_type>
+        {
+            return blobNrAndOffset(LinearizeArrayIndexFunctor{}(ai, Base::extents()), rc);
+        }
+
+        // Exposed for aosoaCommonBlockCopy. Should be private ...
+        template<std::size_t... RecordCoords>
+        LLAMA_FN_HOST_ACC_INLINE constexpr auto blobNrAndOffset(
+            size_type flatArrayIndex,
             RecordCoord<RecordCoords...> = {}) const -> NrAndOffset<size_type>
         {
             constexpr std::size_t flatFieldIndex =
@@ -75,7 +84,6 @@ namespace llama::mapping
                 *& // mess with nvcc compiler state to workaround bug
 #endif
                  Permuter::template permute<flatRecordCoord<TRecordDim, RecordCoord<RecordCoords...>>>;
-            const auto flatArrayIndex = LinearizeArrayIndexFunctor{}(ai, Base::extents());
             const auto blockIndex = flatArrayIndex / Lanes;
             const auto laneIndex = flatArrayIndex % Lanes;
             const auto offset = static_cast<size_type>(sizeOf<TRecordDim> * Lanes) * blockIndex

--- a/include/llama/mapping/SoA.hpp
+++ b/include/llama/mapping/SoA.hpp
@@ -126,10 +126,19 @@ namespace llama::mapping
         template<std::size_t... RecordCoords>
         LLAMA_FN_HOST_ACC_INLINE constexpr auto blobNrAndOffset(
             typename Base::ArrayIndex ai,
+            RecordCoord<RecordCoords...> rc = {}) const -> NrAndOffset<size_type>
+        {
+            return blobNrAndOffset(LinearizeArrayIndexFunctor{}(ai, Base::extents()), rc);
+        }
+
+        // Exposed for aosoaCommonBlockCopy. Should be private ...
+        template<std::size_t... RecordCoords>
+        LLAMA_FN_HOST_ACC_INLINE constexpr auto blobNrAndOffset(
+            size_type flatArrayIndex,
             RecordCoord<RecordCoords...> = {}) const -> NrAndOffset<size_type>
         {
-            const size_type elementOffset = LinearizeArrayIndexFunctor{}(ai, Base::extents())
-                * static_cast<size_type>(sizeof(GetType<TRecordDim, RecordCoord<RecordCoords...>>));
+            const size_type elementOffset
+                = flatArrayIndex * static_cast<size_type>(sizeof(GetType<TRecordDim, RecordCoord<RecordCoords...>>));
             if constexpr(blobs == Blobs::OnePerField)
             {
                 constexpr auto blob = flatRecordCoord<TRecordDim, RecordCoord<RecordCoords...>>;


### PR DESCRIPTION
Reuse the existing implementations inside the  mappings instead of duplicating functionality.

- [x] Measure if there is a performance difference: none