### PR TITLE
Alpaka n-body changes

### DIFF
--- a/examples/alpaka/nbody/nbody.cpp
+++ b/examples/alpaka/nbody/nbody.cpp
@@ -418,11 +418,11 @@ $data << EOD
         run<Acc, AoS, SoA_SB>(plotFile);
     if constexpr(hasSharedMem<Acc>)
         run<Acc, AoS, AoSoA>(plotFile);
-    run<Acc, SoA_SB, AoS>(plotFile);
+    run<Acc, SoA_MB, AoS>(plotFile);
     if constexpr(hasSharedMem<Acc>)
-        run<Acc, SoA_SB, SoA_SB>(plotFile);
+        run<Acc, SoA_MB, SoA_SB>(plotFile);
     if constexpr(hasSharedMem<Acc>)
-        run<Acc, SoA_SB, AoSoA>(plotFile);
+        run<Acc, SoA_MB, AoSoA>(plotFile);
     run<Acc, AoSoA, AoS>(plotFile);
     if constexpr(hasSharedMem<Acc>)
         run<Acc, AoSoA, SoA_SB>(plotFile);

--- a/examples/alpaka/nbody/nbody.cpp
+++ b/examples/alpaka/nbody/nbody.cpp
@@ -412,20 +412,22 @@ $data << EOD
         problemSize / 1024,
         alpaka::getAccName<Acc>());
 
+    constexpr auto runSMVariations = hasSharedMem<Acc> && runUpdate;
+
     run<Acc, AoS, AoS>(plotFile);
-    if constexpr(hasSharedMem<Acc>)
+    if constexpr(runSMVariations)
         run<Acc, AoS, SoA_SB>(plotFile);
-    if constexpr(hasSharedMem<Acc>)
+    if constexpr(runSMVariations)
         run<Acc, AoS, AoSoA>(plotFile);
     run<Acc, SoA_MB, AoS>(plotFile);
-    if constexpr(hasSharedMem<Acc>)
+    if constexpr(runSMVariations)
         run<Acc, SoA_MB, SoA_SB>(plotFile);
-    if constexpr(hasSharedMem<Acc>)
+    if constexpr(runSMVariations)
         run<Acc, SoA_MB, AoSoA>(plotFile);
     run<Acc, AoSoA, AoS>(plotFile);
-    if constexpr(hasSharedMem<Acc>)
+    if constexpr(runSMVariations)
         run<Acc, AoSoA, SoA_SB>(plotFile);
-    if constexpr(hasSharedMem<Acc>)
+    if constexpr(runSMVariations)
         run<Acc, AoSoA, AoSoA>(plotFile);
     run<Acc, SplitGpuGems, AoS>(plotFile);
 

--- a/examples/common/env.hpp
+++ b/examples/common/env.hpp
@@ -98,9 +98,10 @@ namespace common
             const auto devName = trim(getName(dev)); // TODO(bgruber): drop trim after fix lands in alpaka
             const auto devProps = alpaka::getAccDevProps<Acc>(dev);
             env += fmt::format(
-                "; alpaka acc: {}, dev[0]: {}, SMem: {}KiB",
+                "; alpaka acc: {}, dev[0]: {}, {}MiB GM, {}KiB SM",
                 accName,
                 devName,
+                alpaka::getMemBytes(dev) / 1024 / 1024,
                 devProps.m_sharedMemSizeBytes / 1024);
         }
 #endif


### PR DESCRIPTION
* Use SoA MB for global memory
* Optimize alpaka n-body for slides/thesis

This PR is the non-C++20 part of #821 