### PR TITLE
Drop support for g++-9

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -148,8 +148,6 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - name: build-ubuntu-gcc9
-            cxx: g++-9
           - name: build-ubuntu-gcc10
             cxx: g++-10
           - name: build-ubuntu-gcc10-nvcc11.6

--- a/README.md
+++ b/README.md
@@ -36,9 +36,9 @@ LLAMA tries to stay close to recent developments in C++ and so requires fairly u
 The following compilers are supported by LLAMA and tested as part of our CI:
 
 
-| Linux                                                                                        | Windows                                             | MacOS                            |
-|----------------------------------------------------------------------------------------------|-----------------------------------------------------|----------------------------------|
-| g++ 9 - 13 </br> clang++ 12 - 17 </br> icpx (latest) </br> nvc++ 23.5 </br> nvcc 11.6 - 12.3 | Visual Studio 2022 </br> (latest on GitHub actions) | clang++ </br> (latest from brew) |
+| Linux                                                                                         | Windows                                             | MacOS                            |
+|-----------------------------------------------------------------------------------------------|-----------------------------------------------------|----------------------------------|
+| g++ 10 - 13 </br> clang++ 12 - 17 </br> icpx (latest) </br> nvc++ 23.5 </br> nvcc 11.6 - 12.3 | Visual Studio 2022 </br> (latest on GitHub actions) | clang++ </br> (latest from brew) |
 
 
 Single header


### PR DESCRIPTION
To enable use of C++20 library features such as `std::span`.