### PR TITLE
Improvements to CUDA viewcopy

### DIFF
--- a/examples/cuda/viewcopy/viewcopy.cu
+++ b/examples/cuda/viewcopy/viewcopy.cu
@@ -223,14 +223,15 @@ try
     const auto gibs = 2.0 * prop.memoryClockRate * 1000.0 * (prop.memoryBusWidth / 8) / (1024.0 * 1024.0 * 1024.0);
     fmt::print(
         "Dataset size:  {:5.1f}{} (x2)\nGMemory size:  {:5.1f}{}\nMax bandwidth: {:5.1f}GiB/s\nSMs: {}\nMax threads "
-        "per SM: {}\n",
+        "per SM: {}\nEnv: {}\n",
         dsize,
         dunit,
         gmsize,
         gmunit,
         gibs,
         prop.multiProcessorCount,
-        prop.maxThreadsPerMultiProcessor);
+        prop.maxThreadsPerMultiProcessor,
+        common::captureEnv());
     // const Size maxThreads = prop.multiProcessorCount * prop.maxThreadsPerMultiProcessor;
 
     fmt::print("{:10} -> {:10} {:11} {:>10} {:>10} {:4}\n", "src", "dst", "alg", "ms", "GiB/s", "hash");

--- a/examples/cuda/viewcopy/viewcopy.cu
+++ b/examples/cuda/viewcopy/viewcopy.cu
@@ -231,7 +231,7 @@ try
         gibs,
         prop.multiProcessorCount,
         prop.maxThreadsPerMultiProcessor);
-    const Size maxThreads = prop.multiProcessorCount * prop.maxThreadsPerMultiProcessor;
+    // const Size maxThreads = prop.multiProcessorCount * prop.maxThreadsPerMultiProcessor;
 
     fmt::print("{:10} -> {:10} {:11} {:>10} {:>10} {:4}\n", "src", "dst", "alg", "ms", "GiB/s", "hash");
 
@@ -294,13 +294,16 @@ try
         };
 
         benchmarkCopy("naive 1D", [](const auto& srcView, auto& dstView) { ::fieldWiseCopy1D(srcView, dstView); });
-        benchmarkCopy("naive 3D", [](const auto& srcView, auto& dstView) { ::fieldWiseCopy3D(srcView, dstView); });
-        benchmarkCopy(
-            "naive GS 1D",
-            [&](const auto& srcView, auto& dstView) { ::fieldWiseCopyGridStrided1D(srcView, dstView, maxThreads); });
-        benchmarkCopy(
-            "naive GS 3D",
-            [&](const auto& srcView, auto& dstView) { ::fieldWiseCopyGridStrided3D(srcView, dstView, maxThreads); });
+        // These are slower on Nvidia V100 and A100:
+        // benchmarkCopy("naive 3D", [](const auto& srcView, auto& dstView) { ::fieldWiseCopy3D(srcView, dstView); });
+        // benchmarkCopy(
+        //     "naive GS 1D",
+        //     [&](const auto& srcView, auto& dstView) { ::fieldWiseCopyGridStrided1D(srcView, dstView, maxThreads);
+        //     });
+        // benchmarkCopy(
+        //     "naive GS 3D",
+        //     [&](const auto& srcView, auto& dstView) { ::fieldWiseCopyGridStrided3D(srcView, dstView, maxThreads);
+        //     });
     };
 
     using ArrayExtents = std::remove_const_t<decltype(extents)>;

--- a/examples/cuda/viewcopy/viewcopy.cu
+++ b/examples/cuda/viewcopy/viewcopy.cu
@@ -45,8 +45,8 @@ static_assert(extents.back() % threadsPerBlock == 0);
 >;
 // clang-format on
 
-using RecordDim = Particle;
-// using RecordDim = boost::mp11::mp_take_c<Event, 20>;
+// using RecordDim = Particle;
+using RecordDim = boost::mp11::mp_take_c<Event, 20>;
 // using RecordDim = Event; // WARN: expect long compilation time
 
 static_assert(


### PR DESCRIPTION
* Use 20 repetitions with a warmup for CUDA viewcopy
* Use Event as record dimension by default
* Disable all copy algs except naive 1D
* Capture and print environment