### PR TITLE
Require C++20 for alpaka-nbody with MSVC

### DIFF
--- a/examples/alpaka/nbody/CMakeLists.txt
+++ b/examples/alpaka/nbody/CMakeLists.txt
@@ -20,6 +20,7 @@ target_link_libraries(${PROJECT_NAME} PRIVATE llama::llama fmt::fmt alpaka::alpa
 
 if (MSVC)
 	target_compile_options(${PROJECT_NAME} PRIVATE /arch:AVX2) # /fp:fast
+	target_compile_features(${PROJECT_NAME} PRIVATE cxx_std_20) # MSVC fails some constexpr evaluation in C++17
 else()
 	target_compile_options(${PROJECT_NAME} PRIVATE -march=native -fno-math-errno) # -ffast-math
 endif()


### PR DESCRIPTION
This is a workaround for an MSVC failure when constexpr-evaluating the tag stringification during mapping visualization dumping.