### PR TITLE
Rewrite aligning new to please MSVC

### DIFF
--- a/examples/nbody_code_comp/nbody-SoA.cpp
+++ b/examples/nbody_code_comp/nbody-SoA.cpp
@@ -58,7 +58,7 @@ struct AlignedAllocator {
     using value_type = T;
 
     auto allocate(std::size_t n) const -> T* {
-        return new(std::align_val_t{64}) T[n];
+        return static_cast<T*>(::operator new[](n * sizeof(T), std::align_val_t{64}));
     }
 
     void deallocate(T* p, std::size_t) const {


### PR DESCRIPTION
MSVC was complaining about the previous form with: error C2956: usual deallocation function 'void operator delete[](void *,std::align_val_t) noexcept' would be chosen as placement deallocation function.