### PR TITLE
Fix a few issues in copy implementation

### DIFF
--- a/examples/viewcopy/viewcopy.cpp
+++ b/examples/viewcopy/viewcopy.cpp
@@ -17,7 +17,7 @@
 #include <string_view>
 
 constexpr auto repetitions = 20; // excluding 1 warmup run
-constexpr auto extents = llama::ArrayExtents{512, 512, 16};
+constexpr auto extents = llama::ArrayExtentsDynamic<std::size_t, 3>{512, 512, 16};
 constexpr auto measureMemcpy = false;
 constexpr auto runParallelVersions = true;
 constexpr auto maxMismatchesPrintedPerFailedCopy = 10;

--- a/examples/viewcopy/viewcopy.cpp
+++ b/examples/viewcopy/viewcopy.cpp
@@ -212,7 +212,8 @@ try
     plotFile << fmt::format(
         R"plot(#!/usr/bin/gnuplot -p
 # {}
-set title "viewcopy CPU {}MiB particles"
+# ArrayExtents: {}
+set title "viewcopy CPU {}Mi {} ({}MiB)"
 set style data histograms
 set style histogram errorbars
 set style fill solid border -1
@@ -222,6 +223,11 @@ set ylabel "Throughput [GiB/s]"
 
 )plot",
         env,
+        fmt::streamed(extents),
+        dataSize / 1024 / 1024,
+        std::is_same_v<RecordDim, Particle>
+            ? "particles"
+            : "events of " + std::to_string(boost::mp11::mp_size<RecordDim>::value) + " fields",
         dataSize / 1024 / 1024);
 
     // measure memcpy to have a baseline for comparison

--- a/include/llama/StructName.hpp
+++ b/include/llama/StructName.hpp
@@ -352,7 +352,7 @@ namespace llama
                             *it = '.';
                             it++;
                         }
-                        constexpr auto sn = structName(tag);
+                        constexpr auto sn = structName(Tag{});
                         constexprCopy(sn.begin(), sn.end(), it);
                         it += sn.size();
                     }

--- a/tests/copy.cpp
+++ b/tests/copy.cpp
@@ -13,7 +13,7 @@ namespace
     template<typename SrcMapping, typename DstMapping, typename CopyFunc>
     void testCopy(CopyFunc copy)
     {
-        const auto viewExtents = ArrayExtents{4, 8};
+        const auto viewExtents = ArrayExtents{8, 6};
         const auto srcMapping = SrcMapping(viewExtents);
         auto srcView = llama::allocViewUninitialized(srcMapping);
         iotaFillView(srcView);
@@ -68,7 +68,7 @@ namespace
         llama::mapping::AoSoA<
             ArrayExtents,
             RecordDim,
-            4,
+            6,
             llama::mapping::FieldAlignment::Align,
             llama::mapping::LinearizeArrayIndexRight>,
         // llama::mapping::AoSoA<ArrayExtents, RecordDim, 4, llama::mapping::LinearizeArrayIndexLeft>,

--- a/tests/copy.cpp
+++ b/tests/copy.cpp
@@ -8,7 +8,7 @@
 namespace
 {
     using ArrayExtents = llama::ArrayExtentsDynamic<std::size_t, 2>;
-    using RecordDim = Vec3I;
+    using RecordDim = llama::Record<llama::Field<int, int>, llama::Field<char, char>, llama::Field<double, double>>;
 
     template<typename SrcMapping, typename DstMapping, typename CopyFunc>
     void testCopy(CopyFunc copy)


### PR DESCRIPTION
This PR fixes a couple of issues in the LLAMA copy implementation, adds a few tests for it, and adds more information to the output of the viewcopy benchmark.