### PR TITLE
Improve viewcopy benchmark

### DIFF
--- a/examples/viewcopy/viewcopy.cpp
+++ b/examples/viewcopy/viewcopy.cpp
@@ -397,11 +397,11 @@ $data << EOD
     using Mappings = mp_list<
         // llama::mapping::PackedAoS<ArrayExtents, RecordDim>,
         llama::mapping::AlignedAoS<ArrayExtents, RecordDim>,
-        llama::mapping::AlignedSingleBlobSoA<ArrayExtents, RecordDim>,
+        // llama::mapping::AlignedSingleBlobSoA<ArrayExtents, RecordDim>,
         llama::mapping::MultiBlobSoA<ArrayExtents, RecordDim>,
         llama::mapping::AoSoA<ArrayExtents, RecordDim, 8>,
         llama::mapping::AoSoA<ArrayExtents, RecordDim, 32>>;
-    std::string_view mappingNames[] = {/*"AoS P",*/ "AoS A", "SoA SB", "SoA MB", "AoSoA8", "AoSoA32"};
+    std::string_view mappingNames[] = {/*"AoS P",*/ "AoS A", /*"SoA SB",*/ "SoA MB", "AoSoA8", "AoSoA32"};
     mp_for_each<mp_iota<mp_size<Mappings>>>(
         [&]<typename I>(I)
         {

--- a/examples/viewcopy/viewcopy.cpp
+++ b/examples/viewcopy/viewcopy.cpp
@@ -278,10 +278,9 @@ set ylabel "Throughput [GiB/s]"
 
     plotFile << R"plot(
 $data << EOD
-"src layout"	"dst layout"	"naive copy"	"naive copy_sem"	"std::copy"	"std::copy_sem"	"aosoa copy(r)"	"aosoa copy(r)_sem"	"aosoa copy(w)"	"aosoa copy(w)_sem"	"LLAMA copy"	"LLAMA copy_sem")plot";
+"src layout"	"dst layout"	"naive copy"	"naive copy_sem"	"std::copy"	"std::copy_sem"	"LLAMA copy"	"LLAMA copy_sem")plot";
     if constexpr(runParallelVersions)
-        plotFile
-            << R"plot(	"naive copy(p)"	"naive copy(p)_sem"	"aosoa copy(r,p)"	"aosoa copy(r,p)_sem"	"aosoa copy(w,p)"	"aosoa copy(w,p)_sem"	"LLAMA copy(p)"	"LLAMA copy_sem(p)")plot";
+        plotFile << R"plot(	"naive copy(p)"	"naive copy(p)_sem"	"LLAMA copy(p)"	"LLAMA copy_sem(p)")plot";
     plotFile << '\n';
 
     auto benchmarkAllCopies = [&](std::string_view srcName, std::string_view dstName, auto srcMapping, auto dstMapping)
@@ -317,23 +316,6 @@ $data << EOD
             [](const auto& srcView, auto& dstView) { llama::fieldWiseCopy(srcView, dstView); });
         benchmarkCopy("std::copy", [](const auto& srcView, auto& dstView) { stdCopy(srcView, dstView); });
         using namespace llama::mapping;
-        constexpr auto hasCommonBlockCopy = (isAoSoA<decltype(srcMapping)> && isAoSoA<decltype(dstMapping)>)
-            || (isAoSoA<decltype(srcMapping)> && isSoA<decltype(dstMapping)>)
-            || (isSoA<decltype(srcMapping)> && isAoSoA<decltype(dstMapping)>);
-        if constexpr(hasCommonBlockCopy)
-        {
-            benchmarkCopy(
-                "aosoa copy(r)",
-                [](const auto& srcView, auto& dstView) { llama::aosoaCommonBlockCopy(srcView, dstView, true); });
-            benchmarkCopy(
-                "aosoa copy(w)",
-                [](const auto& srcView, auto& dstView) { llama::aosoaCommonBlockCopy(srcView, dstView, false); });
-        }
-        else
-        {
-            for(int i = 0; i < 2 * 2; i++)
-                plotFile << "0\t";
-        }
         benchmarkCopy("llama", [&](const auto& srcView, auto& dstView) { llama::copy(srcView, dstView); });
 
         if constexpr(runParallelVersions)
@@ -346,40 +328,6 @@ $data << EOD
                     // NOLINTNEXTLINE(openmp-exception-escape)
                     llama::fieldWiseCopy(srcView, dstView, omp_get_thread_num(), omp_get_num_threads());
                 });
-            if constexpr(hasCommonBlockCopy)
-            {
-                benchmarkCopy(
-                    "aosoa_copy(r,p)",
-                    [&](const auto& srcView, auto& dstView)
-                    {
-#pragma omp parallel
-                        // NOLINTNEXTLINE(openmp-exception-escape)
-                        llama::aosoaCommonBlockCopy(
-                            srcView,
-                            dstView,
-                            true,
-                            omp_get_thread_num(),
-                            omp_get_num_threads());
-                    });
-                benchmarkCopy(
-                    "aosoa_copy(w,p)",
-                    [&](const auto& srcView, auto& dstView)
-                    {
-#pragma omp parallel
-                        // NOLINTNEXTLINE(openmp-exception-escape)
-                        llama::aosoaCommonBlockCopy(
-                            srcView,
-                            dstView,
-                            false,
-                            omp_get_thread_num(),
-                            omp_get_num_threads());
-                    });
-            }
-            else
-            {
-                for(int i = 0; i < 2 * 2; i++)
-                    plotFile << "0\t";
-            }
             benchmarkCopy(
                 "llama(p)",
                 [&](const auto& srcView, auto& dstView)
@@ -419,15 +367,11 @@ $data << EOD
     plotFile << R"(EOD
 plot $data using  3: 4:xtic(sprintf("%s -> %s", stringcolumn(1), stringcolumn(2))) ti col, \
         "" using  5: 6         ti col, \
-        "" using  7: 8         ti col, \
-        "" using  9:10         ti col, \
-        "" using 11:12         ti col)";
+        "" using  7: 8         ti col)";
     if constexpr(runParallelVersions)
         plotFile << R"(, \
-        "" using 13:14         ti col, \
-        "" using 15:16         ti col, \
-        "" using 17:18         ti col, \
-        "" using 19:20         ti col)";
+        "" using  9:10         ti col, \
+        "" using 11:12         ti col)";
     plotFile << '\n';
     fmt::print("Plot with: ./viewcopy.sh\n");
 }

--- a/include/llama/Core.hpp
+++ b/include/llama/Core.hpp
@@ -436,8 +436,7 @@ namespace llama
     LLAMA_FN_HOST_ACC_INLINE constexpr void forEachLeafCoord(Functor&& functor, RecordCoord<Coords...> baseCoord)
     {
         LLAMA_BEGIN_SUPPRESS_HOST_DEVICE_WARNING
-        internal::mpForEachInlined(
-            LeafRecordCoords<GetType<RecordDim, RecordCoord<Coords...>>>{},
+        mp_for_each_inline<LeafRecordCoords<GetType<RecordDim, RecordCoord<Coords...>>>>(
             [&](auto innerCoord) LLAMA_LAMBDA_INLINE_WITH_SPECIFIERS(constexpr)
             { std::forward<Functor>(functor)(cat(baseCoord, innerCoord)); });
         LLAMA_END_SUPPRESS_HOST_DEVICE_WARNING

--- a/include/llama/Core.hpp
+++ b/include/llama/Core.hpp
@@ -536,7 +536,7 @@ namespace llama
         constexpr auto flatAlignOfImpl()
         {
             std::size_t maxAlign = 0;
-            mp_for_each<mp_transform<mp_identity, TypeList>>(
+            mp_for_each_inline<mp_transform<mp_identity, TypeList>>(
                 [&](auto e) constexpr
                 {
                     using T = typename decltype(e)::type;
@@ -586,7 +586,7 @@ namespace llama
         {
             std::size_t size = 0;
             std::size_t maxAlign = 0; // NOLINT(misc-const-correctness)
-            mp_for_each<mp_transform<mp_identity, TypeList>>(
+            mp_for_each_inline<mp_transform<mp_identity, TypeList>>(
                 [&](auto e) constexpr
                 {
                     using T = typename decltype(e)::type;

--- a/include/llama/Meta.hpp
+++ b/include/llama/Meta.hpp
@@ -16,7 +16,8 @@ namespace llama
     {
         // adapted from boost::mp11, but with LLAMA_FN_HOST_ACC_INLINE
         template<template<typename...> typename L, typename... T, typename F>
-        LLAMA_FN_HOST_ACC_INLINE constexpr void mpForEachInlined(L<T...>, F&& f)
+        // NOLINTNEXTLINE(readability-identifier-naming)
+        LLAMA_FN_HOST_ACC_INLINE constexpr void mp_for_each_inline_impl(L<T...>, F&& f)
         {
             using A = int[sizeof...(T)];
             (void) A{((void) f(T{}), 0)...};
@@ -51,6 +52,14 @@ namespace llama
             using type = E<typename ReplacePlaceholdersImpl<Ts, Args...>::type...>;
         };
     } // namespace internal
+
+    /// Like boost::mp11::mp_for_each, but marked with LLAMA_FN_HOST_ACC_INLINE
+    template<typename L, typename F>
+    // NOLINTNEXTLINE(readability-identifier-naming)
+    LLAMA_FN_HOST_ACC_INLINE constexpr void mp_for_each_inline(F&& f)
+    {
+        internal::mp_for_each_inline_impl(mp_rename<L, mp_list>{}, std::forward<F>(f));
+    }
 
     LLAMA_EXPORT
     template<typename Expression, typename... Args>

--- a/include/llama/RecordRef.hpp
+++ b/include/llama/RecordRef.hpp
@@ -803,7 +803,7 @@ namespace llama
         os << "{";
         if constexpr(std::is_array_v<RecordDim>)
         {
-            mp_for_each<mp_iota_c<std::extent_v<RecordDim>>>(
+            mp_for_each_inline<mp_iota_c<std::extent_v<RecordDim>>>(
                 [&](auto ic)
                 {
                     constexpr std::size_t i = decltype(ic)::value;
@@ -814,7 +814,7 @@ namespace llama
         }
         else
         {
-            mp_for_each<mp_iota<mp_size<RecordDim>>>(
+            mp_for_each_inline<mp_iota<mp_size<RecordDim>>>(
                 [&](auto ic)
                 {
                     constexpr std::size_t i = decltype(ic)::value;

--- a/include/llama/Simd.hpp
+++ b/include/llama/Simd.hpp
@@ -79,7 +79,7 @@ namespace llama
     {
         using FRD = FlatRecordDim<RecordDim>;
         std::size_t lanes = simdLanes<MakeSimd<mp_first<FRD>>>;
-        mp_for_each<mp_transform<std::add_pointer_t, mp_drop_c<FRD, 1>>>(
+        mp_for_each_inline<mp_transform<std::add_pointer_t, mp_drop_c<FRD, 1>>>(
             [&](auto* t)
             {
                 using T = std::remove_reference_t<decltype(*t)>;

--- a/include/llama/StructName.hpp
+++ b/include/llama/StructName.hpp
@@ -302,7 +302,7 @@ namespace llama
             constexpr auto size = [&]() constexpr
             {
                 std::size_t s = 0;
-                mp_for_each<Tags>(
+                mp_for_each_inline<Tags>(
                     [&](auto tag)
                     {
                         using Tag = decltype(tag);
@@ -325,7 +325,7 @@ namespace llama
             llama::Array<char, size> a{};
             auto it = a.begin();
 
-            mp_for_each<Tags>(
+            mp_for_each_inline<Tags>(
                 [&](auto tag) constexpr
                 {
                     using Tag = decltype(tag);

--- a/include/llama/mapping/BitPackedInt.hpp
+++ b/include/llama/mapping/BitPackedInt.hpp
@@ -288,7 +288,7 @@ namespace llama::mapping
                 , VHBits{bits}
             {
                 static_assert(VHBits::value() > 0);
-                mp_for_each<mp_transform<mp_identity, FlatRecordDim<TRecordDim>>>(
+                mp_for_each_inline<mp_transform<mp_identity, FlatRecordDim<TRecordDim>>>(
                     [&](auto t)
                     {
                         using FieldType = typename decltype(t)::type;
@@ -317,7 +317,7 @@ namespace llama::mapping
                 if(VHBits::value() <= 0)
                     throw std::invalid_argument("BitPackedInt* Bits must not be zero");
 #endif
-                mp_for_each<mp_transform<mp_identity, FlatRecordDim<TRecordDim>>>(
+                mp_for_each_inline<mp_transform<mp_identity, FlatRecordDim<TRecordDim>>>(
                     [&](auto t)
                     {
                         using FieldType [[maybe_unused]] = typename decltype(t)::type;

--- a/include/llama/mapping/Bytesplit.hpp
+++ b/include/llama/mapping/Bytesplit.hpp
@@ -91,7 +91,7 @@ namespace llama::mapping
 
                 value_type v;
                 auto* p = reinterpret_cast<std::byte*>(&v);
-                mp_for_each<mp_iota_c<sizeof(value_type)>>(
+                mp_for_each_inline<mp_iota_c<sizeof(value_type)>>(
                     [&](auto ic) LLAMA_LAMBDA_INLINE
                     {
                         constexpr auto i = decltype(ic)::value;
@@ -110,7 +110,7 @@ namespace llama::mapping
 #endif
 
                 auto* p = reinterpret_cast<std::byte*>(&v);
-                mp_for_each<mp_iota_c<sizeof(value_type)>>(
+                mp_for_each_inline<mp_iota_c<sizeof(value_type)>>(
                     [&](auto ic) LLAMA_LAMBDA_INLINE
                     {
                         constexpr auto i = decltype(ic)::value;

--- a/include/llama/mapping/SoA.hpp
+++ b/include/llama/mapping/SoA.hpp
@@ -86,7 +86,7 @@ namespace llama::mapping
             {
                 size_type size = 0;
                 using FRD = typename Permuter::FlatRecordDim;
-                mp_for_each<mp_transform<mp_identity, FRD>>(
+                mp_for_each_inline<mp_transform<mp_identity, FRD>>(
                     [&](auto ti) LLAMA_LAMBDA_INLINE
                     {
                         using FieldType = typename decltype(ti)::type;
@@ -109,7 +109,7 @@ namespace llama::mapping
             constexpr auto subArrays = mp_size<FRD>::value;
             Array<size_type, subArrays> r{};
             // r[0] == 0, only compute the following offsets
-            mp_for_each<mp_iota_c<subArrays - 1>>(
+            mp_for_each_inline<mp_iota_c<subArrays - 1>>(
                 [&](auto ic)
                 {
                     constexpr auto i = decltype(ic)::value;
@@ -167,7 +167,7 @@ namespace llama::mapping
                         // type's alignment. We can also precompute a table of sub array starts (and maybe store it),
                         // or rely on the compiler it out of loops.
                         size_type offset = 0;
-                        mp_for_each<mp_iota_c<flatFieldIndex>>(
+                        mp_for_each_inline<mp_iota_c<flatFieldIndex>>(
                             [&](auto ic) LLAMA_LAMBDA_INLINE
                             {
                                 constexpr auto i = decltype(ic)::value;

--- a/tests/copy.cpp
+++ b/tests/copy.cpp
@@ -153,19 +153,10 @@ TEMPLATE_LIST_TEST_CASE("fieldWiseCopy", "", AllMappingsProduct)
 }
 
 // NOLINTNEXTLINE(cert-err58-cpp)
-TEMPLATE_LIST_TEST_CASE("aosoaCommonBlockCopy.readOpt", "", AoSoAMappingsProduct)
+TEMPLATE_LIST_TEST_CASE("aosoaCommonBlockCopy", "", AoSoAMappingsProduct)
 {
     using SrcMapping = mp_first<TestType>;
     using DstMapping = mp_second<TestType>;
     testCopy<SrcMapping, DstMapping>([](const auto& srcView, auto& dstView)
-                                     { llama::aosoaCommonBlockCopy(srcView, dstView, true); });
-}
-
-// NOLINTNEXTLINE(cert-err58-cpp)
-TEMPLATE_LIST_TEST_CASE("aosoaCommonBlockCopy.writeOpt", "", AoSoAMappingsProduct)
-{
-    using SrcMapping = mp_first<TestType>;
-    using DstMapping = mp_second<TestType>;
-    testCopy<SrcMapping, DstMapping>([](const auto& srcView, auto& dstView)
-                                     { llama::aosoaCommonBlockCopy(srcView, dstView, false); });
+                                     { llama::aosoaCommonBlockCopy(srcView, dstView); });
 }


### PR DESCRIPTION
* Simplify copy implementation
* Add a fastpath copy for aligned AoSoA
* Skip single blob SoA in viewcopy
* Consistenly use mp_for_each_inline inside LLAMA
* Make mpForEachInline public and more like Mp11 version
* Parallelize init and hash in viewcopy
