### PR TITLE
Exclude parallel memcpy when measuring only serial copies

### DIFF
--- a/examples/viewcopy/viewcopy.cpp
+++ b/examples/viewcopy/viewcopy.cpp
@@ -18,7 +18,7 @@
 
 constexpr auto repetitions = 20; // excluding 1 warmup run
 constexpr auto extents = llama::ArrayExtentsDynamic<std::size_t, 3>{512, 512, 16};
-constexpr auto measureMemcpy = false;
+constexpr auto measureMemcpy = true;
 constexpr auto runParallelVersions = true;
 constexpr auto maxMismatchesPrintedPerFailedCopy = 10;
 

--- a/examples/viewcopy/viewcopy.cpp
+++ b/examples/viewcopy/viewcopy.cpp
@@ -221,20 +221,35 @@ void benchmarkMemcopy(std::size_t dataSize, std::ostream& plotFile)
 #ifdef __AVX2__
     run("memcpy_avx2", memcpyAVX2);
 #endif
-    run("memcpy(p)",
-        [&](auto* dst, auto* src, auto size)
-        {
+    if constexpr(runParallelVersions)
+    {
+        run("memcpy(p)",
+            [&](auto* dst, auto* src, auto size)
+            {
 #pragma omp parallel
-            llama::internal::parallelMemcpy(dst, src, size, omp_get_thread_num(), omp_get_num_threads(), std::memcpy);
-        });
+                llama::internal::parallelMemcpy(
+                    dst,
+                    src,
+                    size,
+                    omp_get_thread_num(),
+                    omp_get_num_threads(),
+                    std::memcpy);
+            });
 #ifdef __AVX2__
-    run("memcpy_avx2(p)",
-        [&](auto* dst, auto* src, auto size)
-        {
+        run("memcpy_avx2(p)",
+            [&](auto* dst, auto* src, auto size)
+            {
 #    pragma omp parallel
-            llama::internal::parallelMemcpy(dst, src, size, omp_get_thread_num(), omp_get_num_threads(), memcpyAVX2);
-        });
+                llama::internal::parallelMemcpy(
+                    dst,
+                    src,
+                    size,
+                    omp_get_thread_num(),
+                    omp_get_num_threads(),
+                    memcpyAVX2);
+            });
 #endif
+    }
 }
 
 auto main() -> int


### PR DESCRIPTION
Also measure memcpy by default.